### PR TITLE
Add Verlet cloth simulation with interactive matplotlib demo

### DIFF
--- a/Practical/README.md
+++ b/Practical/README.md
@@ -68,6 +68,7 @@ Brief synopses; dive into each folder for details.
 | Seam Carving | Content-aware image resizing (CLI + GUI + progress). | OpenCV, NumPy, Pillow (GUI) |
 | ToDoList-CLI | File‑backed todo manager (undo, prioritize, search). | Dataclasses, color output |
 | Vector Product | Vector math utilities & 3D plotting. | matplotlib |
+| Verlet Cloth | Cloth simulation using Verlet integration with interactive toggles. | NumPy, matplotlib |
 | Old School cringe | Retro rotating cube + assets demo. | matplotlib.animation, NumPy |
 | Graphing Calculator | Basic expression plotting GUI. | Tkinter, eval sandboxing |
 | Paint / Clone | Simple drawing & export. | Tkinter |

--- a/Practical/Verlet Cloth/README.md
+++ b/Practical/Verlet Cloth/README.md
@@ -1,0 +1,42 @@
+# Verlet Cloth Simulation
+
+This mini-project demonstrates a two-dimensional cloth simulated with Verlet integration and distance constraints. It is designed as an educational reference: the implementation keeps the math explicit, documents the physical model, and includes an interactive visualizer with realtime toggles for gravity and wind forces.
+
+## Physical Model
+
+The cloth is represented as a rectangular grid of point masses connected by distance constraints:
+
+- **Particles** carry position, previous position, and accumulated acceleration. They have unit mass and integrate motion using the classic position-based Verlet update.
+- **Constraints** enforce a fixed rest length between neighbouring particles. The solver iteratively corrects positions to satisfy these constraints, distributing the correction based on whether particles are pinned.
+- **Forces** (gravity, wind gusts, user-applied impulses) act as accelerations. Gravity pulls every unpinned particle downward. Wind acts horizontally with a mild sinusoidal variation to create a fluttering effect.
+- **Damping** is applied implicitly through the Verlet step by scaling the preserved velocity component, preventing the cloth from gaining energy indefinitely.
+
+The default configuration pins the entire top row of particles so the fabric hangs while remaining anchored.
+
+## Controls & Usage
+
+Two entry points are provided:
+
+1. `cloth.py` exposes the simulation core. Import `Cloth` and call `step(dt)` to advance time. Helper methods expose particle positions and constraint segments for rendering.
+2. `visualize.py` renders the cloth with `matplotlib`. It animates the grid and responds to keyboard input:
+   - Press **`g`** to toggle gravity.
+   - Press **`w`** to toggle wind gusts.
+   - Press **`r`** to reset the cloth to its initial, perfectly flat state.
+   - Press **`q`** or close the window to exit.
+
+Run the demo with:
+
+```bash
+python visualize.py
+```
+
+Optional arguments let you change grid resolution or constraint iterations; run `python visualize.py --help` for details.
+
+## Tests & Further Experiments
+
+The `tests/test_cloth.py` module checks two simple invariants:
+
+- When no external forces are active the cloth remains perfectly still after a simulation step.
+- Pinned particles stay anchored even when gravity is active.
+
+Use these as a foundation for your own experiments—try different pinning patterns, add shear/bend constraints, or plug the simulation into an OpenGL renderer.

--- a/Practical/Verlet Cloth/cloth.py
+++ b/Practical/Verlet Cloth/cloth.py
@@ -1,0 +1,273 @@
+"""Core cloth simulation based on Verlet integration.
+
+The module provides a `Cloth` class that manages a grid of particles connected by
+simple distance constraints.  Each simulation step performs a Verlet update,
+optionally applies gravity and wind forces, and iteratively satisfies
+constraints to keep the fabric cohesive.
+
+Example
+-------
+>>> cloth = Cloth(width=2.0, height=1.5, num_x=15, num_y=10)
+>>> cloth.step(0.016)  # Advance ~1/60th of a second
+>>> positions = cloth.positions
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+import numpy as np
+
+ArrayLike = Sequence[float]
+
+
+@dataclass
+class Particle:
+    """A single node of the cloth mesh."""
+
+    position: np.ndarray
+    prev_position: np.ndarray
+    acceleration: np.ndarray
+    rest_position: np.ndarray
+    pinned: bool = False
+    pin_position: np.ndarray | None = None
+
+    def apply_force(self, force: np.ndarray) -> None:
+        """Accumulate a force (treated as acceleration for unit mass)."""
+
+        if self.pinned:
+            return
+        self.acceleration += force
+
+    def verlet(self, dt: float, damping: float) -> None:
+        """Advance the particle using Verlet integration."""
+
+        if self.pinned:
+            target = self.pin_position if self.pin_position is not None else self.rest_position
+            self.position[...] = target
+            self.prev_position[...] = target
+            self.acceleration[...] = 0.0
+            return
+
+        current = self.position.copy()
+        velocity = (self.position - self.prev_position) * damping
+        self.position += velocity + self.acceleration * (dt * dt)
+        self.prev_position = current
+        self.acceleration[...] = 0.0
+
+
+@dataclass
+class DistanceConstraint:
+    """Maintains a fixed distance between two particles."""
+
+    particle_a: Particle
+    particle_b: Particle
+    rest_length: float
+    stiffness: float = 1.0
+
+    def satisfy(self) -> None:
+        pos_a = self.particle_a.position
+        pos_b = self.particle_b.position
+        delta = pos_b - pos_a
+        distance = np.linalg.norm(delta)
+        if distance == 0.0:
+            return
+        difference = (distance - self.rest_length) / distance
+        correction = delta * 0.5 * self.stiffness * difference
+
+        if not self.particle_a.pinned:
+            pos_a += correction
+        if not self.particle_b.pinned:
+            pos_b -= correction
+
+
+class Cloth:
+    """Two-dimensional cloth simulation driven by Verlet integration."""
+
+    def __init__(
+        self,
+        width: float = 2.0,
+        height: float = 1.5,
+        num_x: int = 30,
+        num_y: int = 20,
+        pinned_rows: int = 1,
+        gravity: ArrayLike = (0.0, 9.81),
+        wind: ArrayLike = (3.0, 0.0),
+        damping: float = 0.995,
+        constraint_iterations: int = 5,
+    ) -> None:
+        if num_x < 2 or num_y < 2:
+            raise ValueError("Cloth requires at least a 2x2 grid of particles")
+        if not 0 <= pinned_rows <= num_y:
+            raise ValueError("pinned_rows must be between 0 and num_y inclusive")
+
+        self.width = float(width)
+        self.height = float(height)
+        self.num_x = int(num_x)
+        self.num_y = int(num_y)
+        self.damping = float(damping)
+        self.constraint_iterations = int(constraint_iterations)
+
+        self.gravity_vector = np.array(gravity, dtype=np.float64)
+        self.wind_base = np.array(wind, dtype=np.float64)
+        self.wind_variation = np.array(wind, dtype=np.float64) * 0.35
+
+        self.gravity_enabled = True
+        self.wind_enabled = False
+
+        self._time = 0.0
+
+        self._grid: List[List[Particle]] = []
+        self._constraints: List[DistanceConstraint] = []
+
+        self._init_particles(pinned_rows)
+        self._init_constraints()
+
+    # ------------------------------------------------------------------
+    # Initialization helpers
+    def _init_particles(self, pinned_rows: int) -> None:
+        spacing_x = self.width / (self.num_x - 1)
+        spacing_y = self.height / (self.num_y - 1)
+
+        for y in range(self.num_y):
+            row: List[Particle] = []
+            for x in range(self.num_x):
+                position = np.array([x * spacing_x, y * spacing_y], dtype=np.float64)
+                particle = Particle(
+                    position=position.copy(),
+                    prev_position=position.copy(),
+                    acceleration=np.zeros(2, dtype=np.float64),
+                    rest_position=position.copy(),
+                )
+                if y < pinned_rows:
+                    particle.pinned = True
+                    particle.pin_position = position.copy()
+                row.append(particle)
+            self._grid.append(row)
+
+    def _init_constraints(self) -> None:
+        rest_x = self.width / (self.num_x - 1)
+        rest_y = self.height / (self.num_y - 1)
+
+        for y in range(self.num_y):
+            for x in range(self.num_x):
+                if x < self.num_x - 1:
+                    self._constraints.append(
+                        DistanceConstraint(
+                            self._grid[y][x],
+                            self._grid[y][x + 1],
+                            rest_x,
+                        )
+                    )
+                if y < self.num_y - 1:
+                    self._constraints.append(
+                        DistanceConstraint(
+                            self._grid[y][x],
+                            self._grid[y + 1][x],
+                            rest_y,
+                        )
+                    )
+
+    # ------------------------------------------------------------------
+    # Public API
+    @property
+    def particles(self) -> Iterable[Particle]:
+        for row in self._grid:
+            for particle in row:
+                yield particle
+
+    @property
+    def constraints(self) -> Sequence[DistanceConstraint]:
+        return self._constraints
+
+    @property
+    def positions(self) -> np.ndarray:
+        return np.array([particle.position for particle in self.particles])
+
+    @property
+    def segments(self) -> np.ndarray:
+        segments = []
+        for constraint in self._constraints:
+            segments.append(
+                np.array(
+                    [constraint.particle_a.position.copy(), constraint.particle_b.position.copy()]
+                )
+            )
+        return np.array(segments)
+
+    def reset(self) -> None:
+        """Return the cloth to its initial rest configuration."""
+
+        for row in self._grid:
+            for particle in row:
+                particle.position[...] = particle.rest_position
+                particle.prev_position[...] = particle.rest_position
+                particle.acceleration[...] = 0.0
+        self._time = 0.0
+
+    def toggle_gravity(self) -> None:
+        self.gravity_enabled = not self.gravity_enabled
+
+    def toggle_wind(self) -> None:
+        self.wind_enabled = not self.wind_enabled
+
+    def set_gravity(self, enabled: bool) -> None:
+        self.gravity_enabled = bool(enabled)
+
+    def set_wind(self, enabled: bool) -> None:
+        self.wind_enabled = bool(enabled)
+
+    def step(self, dt: float) -> None:
+        """Advance the simulation by `dt` seconds."""
+
+        if dt <= 0:
+            raise ValueError("dt must be positive")
+
+        self._time += dt
+        gust = np.sin(self._time * 1.3) * self.wind_variation if self.wind_enabled else None
+
+        for particle in self.particles:
+            if self.gravity_enabled:
+                particle.apply_force(self.gravity_vector)
+            if self.wind_enabled:
+                force = self.wind_base + gust * (1.0 + 0.25 * np.sin(particle.position[1] * 2.5))
+                particle.apply_force(force)
+            particle.verlet(dt, self.damping)
+
+        for _ in range(self.constraint_iterations):
+            for constraint in self._constraints:
+                constraint.satisfy()
+
+    # ------------------------------------------------------------------
+    # Utility helpers for demos / testing
+    def displacements(self) -> np.ndarray:
+        """Return the distance each constraint deviates from rest."""
+
+        deviations = []
+        for constraint in self._constraints:
+            pa = constraint.particle_a.position
+            pb = constraint.particle_b.position
+            distance = np.linalg.norm(pb - pa)
+            deviations.append(distance - constraint.rest_length)
+        return np.array(deviations)
+
+    def pin_indices(self) -> List[Tuple[int, int]]:
+        """Return the grid indices of pinned particles."""
+
+        indices: List[Tuple[int, int]] = []
+        for y, row in enumerate(self._grid):
+            for x, particle in enumerate(row):
+                if particle.pinned:
+                    indices.append((x, y))
+        return indices
+
+    def pinned_positions(self) -> np.ndarray:
+        """Return an array of the world positions of pinned particles."""
+
+        positions = []
+        for y, row in enumerate(self._grid):
+            for x, particle in enumerate(row):
+                if particle.pinned:
+                    positions.append(particle.position.copy())
+        return np.array(positions)

--- a/Practical/Verlet Cloth/tests/test_cloth.py
+++ b/Practical/Verlet Cloth/tests/test_cloth.py
@@ -1,0 +1,25 @@
+"""Basic behavioural checks for the Verlet cloth simulation."""
+
+import numpy as np
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from cloth import Cloth
+
+
+def test_static_cloth_remains_at_rest():
+    cloth = Cloth(num_x=4, num_y=4, gravity=(0.0, 0.0), wind=(0.0, 0.0), pinned_rows=0)
+    initial = cloth.positions.copy()
+    cloth.step(0.01)
+    np.testing.assert_allclose(cloth.positions, initial)
+
+
+def test_pinned_particles_do_not_move_under_gravity():
+    cloth = Cloth(num_x=4, num_y=4, pinned_rows=1)
+    initial = cloth.pinned_positions().copy()
+    for _ in range(10):
+        cloth.step(0.016)
+    np.testing.assert_allclose(cloth.pinned_positions(), initial)

--- a/Practical/Verlet Cloth/visualize.py
+++ b/Practical/Verlet Cloth/visualize.py
@@ -1,0 +1,112 @@
+"""Interactive matplotlib visualization for the Verlet cloth simulation."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Tuple
+
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+from matplotlib.backend_bases import KeyEvent
+from matplotlib.collections import LineCollection
+
+from cloth import Cloth
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Animate a Verlet cloth simulation")
+    parser.add_argument("--width", type=float, default=2.0, help="Width of the cloth in world units")
+    parser.add_argument("--height", type=float, default=1.5, help="Height of the cloth in world units")
+    parser.add_argument("--cols", type=int, default=30, help="Number of particles along the x-axis")
+    parser.add_argument("--rows", type=int, default=20, help="Number of particles along the y-axis")
+    parser.add_argument("--iterations", type=int, default=5, help="Constraint solver iterations per frame")
+    parser.add_argument("--dt", type=float, default=0.016, help="Simulation timestep per frame in seconds")
+    return parser.parse_args()
+
+
+def configure_axes(ax: plt.Axes, width: float, height: float) -> None:
+    ax.set_xlim(0, width)
+    ax.set_ylim(height, 0)  # invert y-axis (origin at top-left)
+    ax.set_aspect("equal")
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_title("Verlet Cloth Simulation")
+
+
+def init_plot(ax: plt.Axes, cloth: Cloth) -> Tuple[LineCollection, plt.Line2D, plt.Text]:
+    segments = cloth.segments
+    collection = LineCollection(segments, colors="tab:blue", linewidths=1.0)
+    ax.add_collection(collection)
+
+    scatter = ax.scatter(cloth.positions[:, 0], cloth.positions[:, 1], s=10, c="tab:red")
+
+    info = ax.text(
+        0.02,
+        0.98,
+        "",
+        transform=ax.transAxes,
+        verticalalignment="top",
+        fontsize=9,
+        family="monospace",
+        bbox=dict(facecolor="white", alpha=0.7, edgecolor="none"),
+    )
+    return collection, scatter, info
+
+
+def update_info(info: plt.Text, cloth: Cloth) -> None:
+    status_lines = [
+        f"Gravity: {'ON ' if cloth.gravity_enabled else 'OFF'}",
+        f"Wind:    {'ON ' if cloth.wind_enabled else 'OFF'}",
+        "Keys: [g] gravity  [w] wind  [r] reset  [q] quit",
+    ]
+    info.set_text("\n".join(status_lines))
+
+
+def main() -> None:
+    args = parse_args()
+    cloth = Cloth(
+        width=args.width,
+        height=args.height,
+        num_x=args.cols,
+        num_y=args.rows,
+        constraint_iterations=args.iterations,
+    )
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    configure_axes(ax, args.width, args.height)
+    collection, scatter, info = init_plot(ax, cloth)
+    update_info(info, cloth)
+
+    paused = {"value": False}
+
+    def on_key(event: KeyEvent) -> None:
+        if event.key == "g":
+            cloth.toggle_gravity()
+            update_info(info, cloth)
+        elif event.key == "w":
+            cloth.toggle_wind()
+            update_info(info, cloth)
+        elif event.key == "r":
+            cloth.reset()
+            update_info(info, cloth)
+        elif event.key == "p":
+            paused["value"] = not paused["value"]
+        elif event.key == "q":
+            plt.close(fig)
+
+    fig.canvas.mpl_connect("key_press_event", on_key)
+
+    def animate(_frame: int) -> Tuple[LineCollection, plt.Line2D]:
+        if not paused["value"]:
+            cloth.step(args.dt)
+        segments = cloth.segments
+        collection.set_segments(segments)
+        scatter.set_offsets(cloth.positions)
+        return collection, scatter
+
+    FuncAnimation(fig, animate, interval=int(args.dt * 1000), blit=False)
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ While this is a personal project, the principles behind it are universal. If you
 | 8 | Parametric/Graphic Equalizer for .wav files (Make it real-time) | Not Yet |
 | 9 | Graphing Calculator (BONUS: Graph the Function's Derivatives) | [View Solution](./Practical/Graphing%20Calculator/) |
 | 10 | To-Do List Application (Web app or CLI) | [View Solution](./Practical/ToDoList-CLI/) |
-| 11 | Verlet Integration (Verlet Cloth) | Not Yet |
+| 11 | Verlet Integration (Verlet Cloth) | [View Solution](./Practical/Verlet%20Cloth/) |
 | 12 | TCP/UDP Chat Server + Client | Not Yet |
 | 13 | Music Streaming | Not Yet |
 | 14 | Shazam | Not Yet |


### PR DESCRIPTION
## Summary
- implement a reusable cloth simulation core with Verlet integration, gravity, wind, and constraint utilities
- add an interactive matplotlib visualizer plus documentation outlining the physical model and controls
- supply basic behavioural tests and link the new project from the repository overviews

## Testing
- pytest 'Practical/Verlet Cloth/tests'

------
https://chatgpt.com/codex/tasks/task_b_68d6c28f59548329ba73abb265f98bc5