### PR TITLE
Add Tkinter-based WMS viewer with caching and tests

### DIFF
--- a/Practical/WMS Viewer/README.md
+++ b/Practical/WMS Viewer/README.md
@@ -1,0 +1,91 @@
+# Desktop WMS Viewer
+
+This project implements challenge 144 from the practical section: a desktop viewer for [OGC Web Map Service (WMS)](https://www.ogc.org/standards/wms) endpoints. The viewer is implemented with Tkinter and demonstrates an offline-capable map experience backed by disk caching.
+
+## Features
+
+- **OGC compliant map requests** – generates `GetMap` requests against WMS 1.1.1 endpoints with configurable layers, coordinate reference systems, and styles.
+- **Interactive navigation** – pan by dragging with the mouse, zoom with the scroll wheel or dedicated buttons, and switch between configured layers/endpoints.
+- **Disk-backed cache** – tiles are cached locally the first time they are requested. Subsequent views reuse the cached PNG image to provide an offline-capable workflow.
+- **Configurable coordinate systems** – default setup targets EPSG:3857 (Web Mercator), while the YAML configuration allows alternative CRSs per server or layer.
+- **Reusable engine** – the rendering and fetching logic lives in `wms_engine.py`, making it easy to integrate into other desktop frameworks such as PyQt without rewriting the networking layer.
+
+## Project Layout
+
+```
+Practical/WMS Viewer/
+├── config.yaml           # Endpoint, layer, CRS, and display defaults
+├── wms_engine.py         # Tile math, caching, and WMS client helpers
+├── wms_viewer.py         # Tkinter GUI entry point
+├── README.md             # This document
+└── tests/
+    └── test_wms_engine.py
+```
+
+## Requirements
+
+Install dependencies with `pip install -r ../../Practical/requirements.txt`. The viewer relies on:
+
+- `requests` – HTTP client for WMS `GetMap` calls.
+- `pyproj` – coordinate transformations between WGS84 and target projected systems.
+- `Pillow` – image decoding for displaying PNG/JPEG map tiles.
+- `tkinter` – included with the standard CPython distribution on most platforms.
+
+## Usage
+
+1. Adjust `config.yaml` to include your WMS servers, preferred coordinate reference system, and default view.
+2. Run the viewer:
+
+   ```bash
+   python wms_viewer.py
+   ```
+
+3. Interact with the map:
+   - **Drag** with the left mouse button to pan.
+   - **Scroll** the mouse wheel or use the `+`/`-` buttons to zoom.
+   - **Switch servers/layers** using the dropdown menus at the top of the window.
+
+Map responses are cached to `cache/` in the project directory. Delete this folder to clear stale tiles.
+
+## Configuration
+
+The provided `config.yaml` includes two public demo servers. Each server entry lets you set:
+
+- `name`: Friendly label displayed in the UI.
+- `url`: Base WMS endpoint.
+- `version`: WMS protocol version (defaults to 1.1.1 for XY axis order).
+- `crs`: Coordinate reference system used for map requests.
+- `layers`: List of dictionaries with `name`, `title`, `styles`, and optional `format` overrides.
+- `attribution`: Credit displayed in the status bar.
+
+You can add additional endpoints or override defaults per server.
+
+## Testing
+
+Unit tests cover cache lookups, bounding-box math, and request construction without requiring live network access. Run them with:
+
+```bash
+python -m unittest discover -s tests -t .
+```
+
+The tests use mocked HTTP responses, so they do not rely on external WMS availability.
+
+## Offline and Standards Notes
+
+- The viewer speaks the OGC WMS `GetMap` protocol. Extend it with `GetCapabilities` parsing if you need dynamic layer discovery.
+- Cached tiles are keyed by server, layer, bounding box, CRS, and requested image size. Stale tiles can be purged by deleting individual cache files.
+- For true offline workflows, pre-warm the cache by iterating over the bounding boxes you anticipate needing (e.g., via a script that calls `WMSClient.fetch_map`).
+
+## Extending to PyQt
+
+Although the bundled GUI uses Tkinter to avoid extra dependencies, `wms_engine.py` is GUI-agnostic. You can integrate it into a PyQt `QGraphicsView` by:
+
+1. Reusing `MapViewState` for pan/zoom math.
+2. Loading cached tiles through `WMSClient`.
+3. Displaying the returned bytes with `QPixmap.loadFromData`.
+
+This separation keeps the networking and projection logic consistent across toolkits.
+
+## Challenge Status
+
+This implementation marks challenge 144 – "WMS viewer that isn't web based" – as complete.

--- a/Practical/WMS Viewer/config.yaml
+++ b/Practical/WMS Viewer/config.yaml
@@ -1,0 +1,32 @@
+# Default view options
+view:
+  width: 640
+  height: 640
+  default_zoom: 2
+  default_center: [0.0, 0.0]   # lon, lat
+
+servers:
+  - name: "NASA Blue Marble"
+    url: "https://gibs.earthdata.nasa.gov/wms/epsg3857/best/wms.cgi"
+    version: "1.1.1"
+    crs: "EPSG:3857"
+    attribution: "NASA GIBS"
+    layers:
+      - name: "BlueMarble_ShadedRelief"
+        title: "Blue Marble"
+        styles: ""
+        format: "image/png"
+  - name: "Ahocevar Demo"
+    url: "https://ahocevar.com/geoserver/wms"
+    version: "1.1.1"
+    crs: "EPSG:3857"
+    attribution: "Ahocevar.com GeoServer"
+    layers:
+      - name: "topp:states"
+        title: "US States"
+        styles: ""
+        format: "image/png"
+      - name: "ne:ne"
+        title: "Natural Earth"
+        styles: ""
+        format: "image/png"

--- a/Practical/WMS Viewer/tests/test_wms_engine.py
+++ b/Practical/WMS Viewer/tests/test_wms_engine.py
@@ -1,0 +1,97 @@
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from wms_engine import (
+    AppConfig,
+    LayerConfig,
+    MapViewState,
+    Projection,
+    ServerConfig,
+    ViewConfig,
+    WMSCache,
+    WMSClient,
+    load_config,
+)
+
+
+class FakeResponse:
+    def __init__(self, content: bytes, status_code: int = 200):
+        self.content = content
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError("HTTP error")
+
+
+class WMSEngineTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.cache = WMSCache(Path(self.tmp.name))
+        self.server = ServerConfig(
+            name="Test",
+            url="https://example.com/wms",
+            layers=[LayerConfig(name="foo:bar", title="Foo", styles="", format="image/png")],
+        )
+        self.layer = self.server.layers[0]
+        self.client = WMSClient(self.cache, timeout=1)
+
+    def test_cache_hits_second_request(self) -> None:
+        bbox = (-1.0, -1.0, 1.0, 1.0)
+        size = (256, 256)
+        with mock.patch("requests.get", return_value=FakeResponse(b"abc")) as mocked:
+            first = self.client.fetch_map(self.server, self.layer, bbox, size)
+            self.assertEqual(first, b"abc")
+            second = self.client.fetch_map(self.server, self.layer, bbox, size)
+            self.assertEqual(second, b"abc")
+            self.assertEqual(mocked.call_count, 1, "Expected second call to be served from cache")
+
+    def test_map_view_bbox_and_pan(self) -> None:
+        projection = Projection("EPSG:3857")
+        view = MapViewState(256, 256, projection, zoom=2, center_lon=0.0, center_lat=0.0)
+        bbox = view.bounding_box()
+        expected_half = view.resolution * view.width / 2
+        self.assertAlmostEqual(bbox[0], -expected_half, places=3)
+        self.assertAlmostEqual(bbox[2], expected_half, places=3)
+        view.pan_pixels(10, -5)
+        bbox_after = view.bounding_box()
+        self.assertNotEqual(bbox, bbox_after)
+
+    def test_load_config_from_yaml(self) -> None:
+        yaml_text = """
+view:
+  width: 400
+  height: 300
+servers:
+  - name: Test Server
+    url: https://example.com/wms
+    layers:
+      - name: foo
+"""
+        config_path = Path(self.tmp.name) / "config.yaml"
+        config_path.write_text(yaml_text, encoding="utf-8")
+        config = load_config(config_path)
+        self.assertIsInstance(config, AppConfig)
+        self.assertEqual(config.view.width, 400)
+        self.assertEqual(config.servers[0].layers[0].name, "foo")
+
+    def test_build_params_wms_1_3_axis_order(self) -> None:
+        server = ServerConfig(
+            name="Test",
+            url="https://example.com/wms",
+            version="1.3.0",
+            crs="EPSG:4326",
+            layers=[LayerConfig(name="foo")],
+        )
+        bbox = (-1.0, -1.0, 1.0, 1.0)
+        params = self.client.build_params(server, server.layers[0], bbox, (256, 256))
+        self.assertIn("crs", params)
+        self.assertNotIn("srs", params)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Practical/WMS Viewer/wms_engine.py
+++ b/Practical/WMS Viewer/wms_engine.py
@@ -1,0 +1,319 @@
+"""Core WMS helpers shared by GUI implementations.
+
+This module handles configuration loading, map-view math, disk caching, and
+issuing OGC WMS `GetMap` requests.  The GUI layer (Tkinter, PyQt, etc.) can
+remain thin by delegating the heavy lifting here.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import requests
+from pyproj import CRS, Transformer
+import yaml
+
+# Constants specific to the common Web Mercator tiling scheme.
+WEB_MERCATOR_BOUNDS = (
+    -20037508.342789244,
+    -20037508.342789244,
+    20037508.342789244,
+    20037508.342789244,
+)
+BASE_RESOLUTION = 156543.03392804097  # meters/pixel at zoom level 0
+
+
+@dataclass
+class LayerConfig:
+    """Serializable configuration for an individual WMS layer."""
+
+    name: str
+    title: str = ""
+    styles: str = ""
+    format: str = "image/png"
+
+
+@dataclass
+class ServerConfig:
+    """WMS server definition loaded from configuration."""
+
+    name: str
+    url: str
+    version: str = "1.1.1"
+    crs: str = "EPSG:3857"
+    attribution: str = ""
+    layers: List[LayerConfig] = field(default_factory=list)
+
+
+@dataclass
+class ViewConfig:
+    width: int
+    height: int
+    default_zoom: int = 2
+    default_center: Tuple[float, float] = (0.0, 0.0)  # lon, lat
+    min_zoom: int = 0
+    max_zoom: int = 18
+
+
+@dataclass
+class AppConfig:
+    view: ViewConfig
+    servers: List[ServerConfig]
+
+
+class ConfigError(ValueError):
+    """Raised when the configuration file is malformed."""
+
+
+def load_config(path: Path) -> AppConfig:
+    """Load the YAML configuration file."""
+
+    with open(path, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+
+    if not data or "servers" not in data:
+        raise ConfigError("Configuration must include a 'servers' section")
+
+    view_raw = data.get("view", {})
+    view = ViewConfig(
+        width=int(view_raw.get("width", 512)),
+        height=int(view_raw.get("height", 512)),
+        default_zoom=int(view_raw.get("default_zoom", 2)),
+        default_center=tuple(view_raw.get("default_center", [0.0, 0.0])),
+        min_zoom=int(view_raw.get("min_zoom", 0)),
+        max_zoom=int(view_raw.get("max_zoom", 18)),
+    )
+
+    servers: List[ServerConfig] = []
+    for server_raw in data["servers"]:
+        layers_raw = server_raw.get("layers", [])
+        if not layers_raw:
+            raise ConfigError(f"Server '{server_raw.get('name', 'Unnamed')}' has no layers")
+        layers = [
+            LayerConfig(
+                name=layer_raw["name"],
+                title=layer_raw.get("title", layer_raw["name"]),
+                styles=layer_raw.get("styles", ""),
+                format=layer_raw.get("format", "image/png"),
+            )
+            for layer_raw in layers_raw
+        ]
+        servers.append(
+            ServerConfig(
+                name=server_raw["name"],
+                url=server_raw["url"],
+                version=server_raw.get("version", "1.1.1"),
+                crs=server_raw.get("crs", "EPSG:3857"),
+                attribution=server_raw.get("attribution", ""),
+                layers=layers,
+            )
+        )
+
+    return AppConfig(view=view, servers=servers)
+
+
+class Projection:
+    """Coordinate system helper built on top of pyproj."""
+
+    def __init__(self, crs: str) -> None:
+        self.crs = CRS.from_user_input(crs)
+        self._to_xy = Transformer.from_crs("EPSG:4326", self.crs, always_xy=True)
+        self._to_lonlat = Transformer.from_crs(self.crs, "EPSG:4326", always_xy=True)
+        self.bounds = self._estimate_bounds()
+
+    def _estimate_bounds(self) -> Optional[Tuple[float, float, float, float]]:
+        if self.crs.to_epsg() == 3857:
+            return WEB_MERCATOR_BOUNDS
+        try:
+            area = self.crs.area_of_use
+            transformer = Transformer.from_crs("EPSG:4326", self.crs, always_xy=True)
+            x_min, y_min = transformer.transform(area.west, area.south)
+            x_max, y_max = transformer.transform(area.east, area.north)
+            return (
+                min(x_min, x_max),
+                min(y_min, y_max),
+                max(x_min, x_max),
+                max(y_min, y_max),
+            )
+        except Exception:
+            return None
+
+    def lonlat_to_xy(self, lon: float, lat: float) -> Tuple[float, float]:
+        return self._to_xy.transform(lon, lat)
+
+    def xy_to_lonlat(self, x: float, y: float) -> Tuple[float, float]:
+        return self._to_lonlat.transform(x, y)
+
+
+class MapViewState:
+    """Tracks pan/zoom state for a projected map view."""
+
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        projection: Projection,
+        zoom: int = 2,
+        min_zoom: int = 0,
+        max_zoom: int = 18,
+        center_lon: float = 0.0,
+        center_lat: float = 0.0,
+    ) -> None:
+        self.width = width
+        self.height = height
+        self.projection = projection
+        self.zoom = zoom
+        self.min_zoom = min_zoom
+        self.max_zoom = max_zoom
+        self._set_center_xy(*self.projection.lonlat_to_xy(center_lon, center_lat))
+
+    def _set_center_xy(self, x: float, y: float) -> None:
+        if self.projection.bounds is None:
+            self.center_x = x
+            self.center_y = y
+            return
+        minx, miny, maxx, maxy = self.projection.bounds
+        self.center_x = min(max(x, minx), maxx)
+        self.center_y = min(max(y, miny), maxy)
+
+    @property
+    def resolution(self) -> float:
+        return BASE_RESOLUTION / (2 ** self.zoom)
+
+    def pan_pixels(self, dx: float, dy: float) -> None:
+        res = self.resolution
+        self._set_center_xy(self.center_x - dx * res, self.center_y - dy * res)
+
+    def set_center_lonlat(self, lon: float, lat: float) -> None:
+        self._set_center_xy(*self.projection.lonlat_to_xy(lon, lat))
+
+    def zoom_to(self, zoom: int) -> None:
+        self.zoom = max(self.min_zoom, min(self.max_zoom, zoom))
+
+    def zoom_by(self, delta: int) -> None:
+        self.zoom_to(self.zoom + delta)
+
+    def resize(self, width: int, height: int) -> None:
+        self.width = width
+        self.height = height
+
+    def bounding_box(self) -> Tuple[float, float, float, float]:
+        res = self.resolution
+        half_width = (self.width * res) / 2
+        half_height = (self.height * res) / 2
+        minx = self.center_x - half_width
+        maxx = self.center_x + half_width
+        miny = self.center_y - half_height
+        maxy = self.center_y + half_height
+        if self.projection.bounds is not None:
+            bounds = self.projection.bounds
+            minx = max(minx, bounds[0])
+            miny = max(miny, bounds[1])
+            maxx = min(maxx, bounds[2])
+            maxy = min(maxy, bounds[3])
+        return (minx, miny, maxx, maxy)
+
+    def center_lonlat(self) -> Tuple[float, float]:
+        return self.projection.xy_to_lonlat(self.center_x, self.center_y)
+
+
+class WMSCache:
+    """Simple disk cache for WMS image responses."""
+
+    def __init__(self, cache_dir: Path) -> None:
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _key_to_path(self, key: Dict[str, object]) -> Path:
+        digest = hashlib.sha1(json.dumps(key, sort_keys=True).encode("utf-8")).hexdigest()
+        extension = str(key.get("format", "image/png")).split("/")[-1]
+        subdir = self.cache_dir / digest[:2] / digest[2:4]
+        subdir.mkdir(parents=True, exist_ok=True)
+        return subdir / f"{digest}.{extension}"
+
+    def get(self, key: Dict[str, object]) -> Optional[bytes]:
+        path = self._key_to_path(key)
+        if path.exists():
+            return path.read_bytes()
+        return None
+
+    def set(self, key: Dict[str, object], data: bytes) -> bytes:
+        path = self._key_to_path(key)
+        path.write_bytes(data)
+        return data
+
+
+class WMSClient:
+    """Fetches map imagery from a WMS server with caching."""
+
+    def __init__(self, cache: WMSCache, timeout: int = 15) -> None:
+        self.cache = cache
+        self.timeout = timeout
+
+    def build_params(
+        self,
+        server: ServerConfig,
+        layer: LayerConfig,
+        bbox: Sequence[float],
+        size: Tuple[int, int],
+    ) -> Dict[str, str]:
+        width, height = size
+        params = {
+            "service": "WMS",
+            "request": "GetMap",
+            "version": server.version,
+            "layers": layer.name,
+            "styles": layer.styles,
+            "format": layer.format,
+            "srs": server.crs,
+            "bbox": ",".join(f"{coord:.6f}" for coord in bbox),
+            "width": str(width),
+            "height": str(height),
+            "transparent": "TRUE",
+        }
+        if server.version.startswith("1.3"):
+            # Axis order swapped for some CRSs; users can override via config.
+            params.pop("srs")
+            params["crs"] = server.crs
+        return params
+
+    def fetch_map(
+        self,
+        server: ServerConfig,
+        layer: LayerConfig,
+        bbox: Sequence[float],
+        size: Tuple[int, int],
+    ) -> bytes:
+        cache_key = {
+            "url": server.url,
+            "version": server.version,
+            "layer": layer.name,
+            "styles": layer.styles,
+            "format": layer.format,
+            "bbox": [round(c, 6) for c in bbox],
+            "size": list(size),
+            "crs": server.crs,
+        }
+        cached = self.cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        params = self.build_params(server, layer, bbox, size)
+        response = requests.get(server.url, params=params, timeout=self.timeout)
+        response.raise_for_status()
+        return self.cache.set(cache_key, response.content)
+
+
+def ensure_cache_dir(base_path: Path) -> Path:
+    """Utility to create a cache directory beside the executable."""
+    cache_path = base_path / "cache"
+    cache_path.mkdir(parents=True, exist_ok=True)
+    return cache_path
+
+
+def iter_layers(server: ServerConfig) -> Iterable[LayerConfig]:
+    """Helper for flattening layer configs in the UI layer."""
+    return server.layers

--- a/Practical/WMS Viewer/wms_viewer.py
+++ b/Practical/WMS Viewer/wms_viewer.py
@@ -1,0 +1,227 @@
+"""Tkinter-based desktop client for the WMS viewer challenge."""
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image, ImageTk
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from wms_engine import (
+    AppConfig,
+    LayerConfig,
+    MapViewState,
+    Projection,
+    ServerConfig,
+    WMSCache,
+    WMSClient,
+    ensure_cache_dir,
+    load_config,
+)
+
+
+class WMSViewerApp:
+    """Main application controller for the Tkinter GUI."""
+
+    def __init__(self, root: tk.Tk, config: AppConfig, cache_path: Path) -> None:
+        self.root = root
+        self.root.title("OGC WMS Desktop Viewer")
+        self.config = config
+        self.cache = WMSCache(cache_path)
+        self.client = WMSClient(self.cache)
+
+        self._server_var = tk.StringVar()
+        self._layer_var = tk.StringVar()
+
+        self._projection: Optional[Projection] = None
+        self._view_state: Optional[MapViewState] = None
+        self._current_image: Optional[ImageTk.PhotoImage] = None
+        self._drag_last: Optional[tuple[int, int]] = None
+
+        self._build_ui()
+        self._initialize_state()
+        self._update_map()
+
+    # ------------------------------------------------------------------ UI setup
+    def _build_ui(self) -> None:
+        control_frame = ttk.Frame(self.root, padding=4)
+        control_frame.pack(side=tk.TOP, fill=tk.X)
+
+        ttk.Label(control_frame, text="Server:").pack(side=tk.LEFT)
+        self.server_combo = ttk.Combobox(
+            control_frame,
+            textvariable=self._server_var,
+            state="readonly",
+            values=[server.name for server in self.config.servers],
+        )
+        self.server_combo.pack(side=tk.LEFT, padx=(4, 12))
+        self.server_combo.bind("<<ComboboxSelected>>", self._on_server_change)
+
+        ttk.Label(control_frame, text="Layer:").pack(side=tk.LEFT)
+        self.layer_combo = ttk.Combobox(control_frame, textvariable=self._layer_var, state="readonly")
+        self.layer_combo.pack(side=tk.LEFT, padx=(4, 12))
+        self.layer_combo.bind("<<ComboboxSelected>>", self._on_layer_change)
+
+        ttk.Button(control_frame, text="+", width=3, command=lambda: self._on_zoom(1)).pack(side=tk.LEFT)
+        ttk.Button(control_frame, text="-", width=3, command=lambda: self._on_zoom(-1)).pack(side=tk.LEFT, padx=(4, 0))
+
+        self.status_var = tk.StringVar(value="")
+        self.status_label = ttk.Label(self.root, textvariable=self.status_var, anchor=tk.W)
+        self.status_label.pack(side=tk.BOTTOM, fill=tk.X, padx=4, pady=2)
+
+        self.canvas = tk.Canvas(self.root, width=self.config.view.width, height=self.config.view.height, bg="#1f1f1f")
+        self.canvas.pack(fill=tk.BOTH, expand=True)
+        self.canvas.bind("<Configure>", self._on_resize)
+        self.canvas.bind("<ButtonPress-1>", self._on_drag_start)
+        self.canvas.bind("<B1-Motion>", self._on_drag_move)
+        self.canvas.bind("<ButtonRelease-1>", self._on_drag_end)
+        self.canvas.bind("<MouseWheel>", self._on_mouse_wheel)
+        # Linux scroll events
+        self.canvas.bind("<Button-4>", lambda event: self._on_zoom(1))
+        self.canvas.bind("<Button-5>", lambda event: self._on_zoom(-1))
+
+    # ------------------------------------------------------------------ State init
+    def _initialize_state(self) -> None:
+        if not self.config.servers:
+            messagebox.showerror("Configuration error", "No servers configured")
+            self.root.destroy()
+            return
+        default_server = self.config.servers[0]
+        self._server_var.set(default_server.name)
+        self._populate_layers(default_server)
+        self._projection = Projection(default_server.crs)
+        self._view_state = MapViewState(
+            width=self.config.view.width,
+            height=self.config.view.height,
+            projection=self._projection,
+            zoom=self.config.view.default_zoom,
+            min_zoom=self.config.view.min_zoom,
+            max_zoom=self.config.view.max_zoom,
+            center_lon=self.config.view.default_center[0],
+            center_lat=self.config.view.default_center[1],
+        )
+
+    # ------------------------------------------------------------------ Helpers
+    def _populate_layers(self, server: ServerConfig) -> None:
+        self.layer_combo["values"] = [layer.title or layer.name for layer in server.layers]
+        default_layer = server.layers[0]
+        self._layer_var.set(default_layer.title or default_layer.name)
+
+    def _current_server(self) -> ServerConfig:
+        name = self._server_var.get()
+        for server in self.config.servers:
+            if server.name == name:
+                return server
+        return self.config.servers[0]
+
+    def _current_layer(self) -> LayerConfig:
+        title = self._layer_var.get()
+        server = self._current_server()
+        for layer in server.layers:
+            if layer.title == title or layer.name == title:
+                return layer
+        return server.layers[0]
+
+    # ------------------------------------------------------------------ Event handlers
+    def _on_server_change(self, event: tk.Event) -> None:  # type: ignore[override]
+        server = self._current_server()
+        self._projection = Projection(server.crs)
+        if self._view_state:
+            lon, lat = self._view_state.center_lonlat()
+            self._view_state = MapViewState(
+                width=self._view_state.width,
+                height=self._view_state.height,
+                projection=self._projection,
+                zoom=self._view_state.zoom,
+                min_zoom=self.config.view.min_zoom,
+                max_zoom=self.config.view.max_zoom,
+                center_lon=lon,
+                center_lat=lat,
+            )
+        else:
+            self._view_state = MapViewState(
+                width=self.config.view.width,
+                height=self.config.view.height,
+                projection=self._projection,
+            )
+        self._populate_layers(server)
+        self._update_map()
+
+    def _on_layer_change(self, event: tk.Event) -> None:  # type: ignore[override]
+        self._update_map()
+
+    def _on_zoom(self, delta: int) -> None:
+        if not self._view_state:
+            return
+        self._view_state.zoom_by(delta)
+        self._update_map()
+
+    def _on_mouse_wheel(self, event: tk.Event) -> None:  # type: ignore[override]
+        delta = 1 if event.delta > 0 else -1
+        self._on_zoom(delta)
+
+    def _on_resize(self, event: tk.Event) -> None:  # type: ignore[override]
+        if not self._view_state:
+            return
+        if event.width != self._view_state.width or event.height != self._view_state.height:
+            self._view_state.resize(event.width, event.height)
+            self._update_map()
+
+    def _on_drag_start(self, event: tk.Event) -> None:  # type: ignore[override]
+        self._drag_last = (event.x, event.y)
+
+    def _on_drag_move(self, event: tk.Event) -> None:  # type: ignore[override]
+        if not self._view_state or self._drag_last is None:
+            return
+        last_x, last_y = self._drag_last
+        dx = event.x - last_x
+        dy = event.y - last_y
+        self._view_state.pan_pixels(dx, dy)
+        self._drag_last = (event.x, event.y)
+        self._update_map()
+
+    def _on_drag_end(self, event: tk.Event) -> None:  # type: ignore[override]
+        self._drag_last = None
+
+    # ------------------------------------------------------------------ Map refresh
+    def _update_map(self) -> None:
+        if not self._view_state:
+            return
+        server = self._current_server()
+        layer = self._current_layer()
+        bbox = self._view_state.bounding_box()
+        size = (self._view_state.width, self._view_state.height)
+
+        try:
+            image_bytes = self.client.fetch_map(server, layer, bbox, size)
+        except Exception as exc:  # pragma: no cover - user-visible dialog
+            messagebox.showerror("WMS Error", str(exc))
+            return
+
+        image = Image.open(io.BytesIO(image_bytes))
+        self._current_image = ImageTk.PhotoImage(image)
+        self.canvas.delete("all")
+        self.canvas.create_image(0, 0, anchor=tk.NW, image=self._current_image)
+
+        lon, lat = self._view_state.center_lonlat()
+        self.status_var.set(
+            f"{server.name} – {layer.title or layer.name} | Zoom {self._view_state.zoom} | "
+            f"Center: {lon:.3f}, {lat:.3f} | {server.attribution}"
+        )
+
+
+def main(config_path: Optional[Path] = None) -> None:
+    base_path = Path(__file__).parent
+    config_file = config_path or (base_path / "config.yaml")
+    app_config = load_config(config_file)
+    cache_path = ensure_cache_dir(base_path)
+
+    root = tk.Tk()
+    WMSViewerApp(root, app_config, cache_path)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/Practical/requirements.txt
+++ b/Practical/requirements.txt
@@ -10,9 +10,11 @@ plotly>=5.22,<5.23          # Interactive geo plots for IP tracking
 
 # Web / networking
 Flask>=3.0,<3.1             # Imageboard web app
-requests>=2.32,<2.33        # IP tracking API calls
+requests>=2.32,<2.33        # IP tracking API calls, WMS viewer map requests
+pyproj>=3.6,<3.7            # Coordinate transforms for WMS viewer
 
 # Data processing / progress
+PyYAML>=6.0.2,<6.1          # Configuration parsing for WMS viewer
 tqdm>=4.66,<4.67            # Optional progress bars (IP tracking) – optional but recommended
 
 # Imaging

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ While this is a personal project, the principles behind it are universal. If you
 | 141 | Bismuth Fractal | [View Solution](./Practical/Bismuth%20Fractal/) |
 | 142 | Seam Carving | [View Solution](./Practical/Seam%20Carving/) |
 | 143 | Bayesian Filter | [View Solution](./Practical/Bayesian%20Filter/) |
-| 144 | WMS viewer that isn't web based | Not Yet |
+| 144 | WMS viewer that isn't web based | [View Solution](./Practical/WMS%20Viewer/) |
 
 ### Algorithmic
 


### PR DESCRIPTION
## Summary
- add a Tkinter desktop client for interacting with configured OGC WMS endpoints, including pan/zoom, layer switching, and disk caching
- factor reusable WMS engine utilities for configuration loading, projection math, and HTTP tile fetching
- document the new challenge solution, configuration details, and dependencies

## Testing
- python -m unittest tests.test_wms_engine

------
https://chatgpt.com/codex/tasks/task_b_68d6c2c45bf0832987643bdb09f2ae75