### PR TITLE
Add Tkinter Markdown editor with preview and exports

### DIFF
--- a/Practical/Markdown Editor/README.md
+++ b/Practical/Markdown Editor/README.md
@@ -1,0 +1,99 @@
+# Markdown Editor
+
+A desktop-focused Markdown editor built with Tkinter. It provides inline syntax highlighting, live HTML preview, and quick export tools so you can focus on writing content rather than wiring up tooling.
+
+![Markdown editor screenshot placeholder](../programming%20challenges.png)
+
+## Feature Overview
+
+| Area | Highlights |
+| ---- | ---------- |
+| Editing | • Familiar Ctrl+N/Ctrl+O/Ctrl+S workflow<br>• Front matter detection with live metadata display<br>• Fast rule-based syntax highlighting for headings, emphasis, code fences, and links |
+| Preview | • Side-by-side live HTML preview updates as you type<br>• Template aware (front matter `template` key selects a template automatically)<br>• Renders using [`tkhtmlview`](https://github.com/Andereoo/TkinterWeb) when installed; falls back to HTML source preview otherwise |
+| Export | • Save Markdown, HTML, or XML from the same session<br>• HTML export renders through the selected template<br>• XML export captures front matter + rendered HTML for pipeline integration |
+| Conversion utilities | • `converter.py` exposes reusable helpers for parsing front matter, rendering templates, and producing XML<br>• Tested with `unittest` for confidence |
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt  # optional global requirements
+pip install -r "Practical/Markdown Editor/requirements.txt"
+```
+
+> `tkhtmlview` is optional but recommended for a rendered preview pane. Without it, the preview shows generated HTML markup.
+
+## Usage
+
+```bash
+python "Practical/Markdown Editor/editor.py"
+```
+
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+| -------- | ------ |
+| `Ctrl+N` | New document |
+| `Ctrl+O` | Open Markdown file |
+| `Ctrl+S` | Save document |
+| `Ctrl+Shift+S` | Save As |
+| `Ctrl+E` | Export rendered HTML |
+| `Ctrl+Shift+E` | Export XML package |
+| `Ctrl+L` | Toggle between light and dark application themes |
+| `F5` | Force refresh of syntax highlighting & preview |
+
+### Theming & Templates
+
+- **Application themes**: choose _Light_ or _Dark_ from the `View → Theme` menu (or press `Ctrl+L`).
+- **Content templates**: templates live in `templates/`. The current selection is shown in the toolbar combo box. You can:
+  - Set `template: dark` (or another name) in front matter to auto-select it.
+  - Drop in new `.html` files with `$title`, `$content`, `$styles`, and `$extra_head` placeholders to extend the gallery.
+
+### Front Matter
+
+Start documents with YAML-style front matter delimited by `---` to pre-fill metadata:
+
+```markdown
+---
+title: Release Notes
+author: Jane Dev
+template: dark
+extra_head: <meta name="robots" content="noindex">
+---
+
+# Release Notes
+...
+```
+
+Fields are injected into templates and also appear in XML exports.
+
+## Export Formats
+
+- **Markdown**: standard `.md` editing, saved via `File → Save`.
+- **HTML**: generated through the currently selected template; ideal for quick publishing.
+- **XML**: structured container with `<front_matter>` and `<content_html>` nodes, so build pipelines can extract metadata or HTML safely.
+
+## Tests
+
+```bash
+python -m unittest discover "Practical/Markdown Editor/tests"
+```
+
+## Folder Layout
+
+```
+Practical/Markdown Editor/
+├── converter.py          # Front matter parsing + conversion utilities (unit tested)
+├── editor.py             # Tkinter GUI application
+├── requirements.txt      # Focused dependencies (markdown, tkhtmlview optional)
+├── templates/            # HTML templates (light + dark)
+└── tests/test_converter.py
+```
+
+## Live Preview Tips
+
+- Press `F5` if you disabled auto-refresh or want to re-run conversions manually.
+- If preview rendering looks raw, install `tkhtmlview` to enable full HTML styling.
+
+Enjoy writing!

--- a/Practical/Markdown Editor/__init__.py
+++ b/Practical/Markdown Editor/__init__.py
@@ -1,0 +1,19 @@
+"""Markdown editor toolkit (GUI + conversion utilities)."""
+
+from .converter import (
+    ConversionResult,
+    TemplateDefinition,
+    TemplateManager,
+    convert_markdown,
+    convert_to_xml,
+    parse_front_matter,
+)
+
+__all__ = [
+    "ConversionResult",
+    "TemplateDefinition",
+    "TemplateManager",
+    "convert_markdown",
+    "convert_to_xml",
+    "parse_front_matter",
+]

--- a/Practical/Markdown Editor/converter.py
+++ b/Practical/Markdown Editor/converter.py
@@ -1,0 +1,219 @@
+"""Utilities for parsing Markdown documents with YAML-style front matter,
+applying HTML templates, and producing HTML/XML outputs.
+
+The functions here are intentionally importable by the GUI and the unit tests.
+They avoid GUI dependencies so they can be reused in headless pipelines.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+from pathlib import Path
+from string import Template
+from typing import Dict, Iterable, Optional, Tuple
+import re
+import xml.etree.ElementTree as ET
+
+try:  # Prefer the markdown package when available.
+    import markdown as _markdown
+except ImportError:  # pragma: no cover - exercised in CI if markdown is absent.
+    _markdown = None
+
+@dataclass(frozen=True)
+class TemplateDefinition:
+    """Represents an HTML template available to the editor."""
+
+    name: str
+    label: str
+    body: Template
+
+
+class TemplateManager:
+    """Loads and renders HTML templates stored in a directory."""
+
+    def __init__(self, template_dir: Path):
+        self.template_dir = template_dir
+        self._templates: Dict[str, TemplateDefinition] = {}
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Reload template files from disk."""
+        self._templates.clear()
+        if not self.template_dir.exists():
+            return
+        for file in sorted(self.template_dir.glob("*.html")):
+            name = file.stem
+            label = name.replace("_", " ").title()
+            content = file.read_text(encoding="utf-8")
+            self._templates[name] = TemplateDefinition(name, label, Template(content))
+
+    def names(self) -> Iterable[str]:
+        return self._templates.keys()
+
+    def labels(self) -> Dict[str, str]:
+        return {name: definition.label for name, definition in self._templates.items()}
+
+    def render(
+        self,
+        template_name: str,
+        *,
+        html_content: str,
+        metadata: Dict[str, str],
+    ) -> str:
+        """Render ``html_content`` inside the requested template."""
+        definition = self._templates.get(template_name)
+        if definition is None and self._templates:
+            # Fallback to the first template available.
+            definition = next(iter(self._templates.values()))
+        if definition is None:
+            # No templates available: return the bare content.
+            return html_content
+
+        author = metadata.get("author", "")
+        template_vars = {
+            "title": metadata.get("title", "Untitled Document"),
+            "author": author,
+            "author_line": f"<p class='byline'><em>{author}</em></p>" if author else "",
+            "styles": metadata.get("styles", ""),
+            "extra_head": metadata.get("extra_head", ""),
+            "content": html_content,
+        }
+        return definition.body.safe_substitute(template_vars)
+
+
+@dataclass
+class ConversionResult:
+    """Container for conversion outputs."""
+
+    metadata: Dict[str, str]
+    body_markdown: str
+    html: str
+    template_used: Optional[str]
+
+
+def parse_front_matter(text: str) -> Tuple[Dict[str, str], str]:
+    """Extract YAML-like front matter from ``text``.
+
+    Supports ``key: value`` pairs until the closing ``---`` delimiter. Values are
+    stripped but otherwise left as-is to avoid surprising the author.
+    """
+
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, text
+
+    metadata: Dict[str, str] = {}
+    body_start_index: Optional[int] = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            body_start_index = index + 1
+            break
+        if not line.strip() or line.strip().startswith("#"):
+            # Allow comments inside front matter.
+            continue
+        if ":" in line:
+            key, value = line.split(":", 1)
+            metadata[key.strip()] = value.strip()
+    if body_start_index is None:
+        return {}, text
+    body_lines = lines[body_start_index:]
+    return metadata, "\n".join(body_lines).lstrip("\n")
+
+
+def _markdown_to_html(markdown_text: str) -> str:
+    """Convert Markdown to HTML, preferring the external ``markdown`` package."""
+
+    if _markdown is not None:
+        md = _markdown.Markdown(
+            extensions=["fenced_code", "tables", "codehilite"],
+            output_format="xhtml1",
+        )
+        return md.convert(markdown_text)
+
+    # Fallback conversion that supports a subset of Markdown syntax. We focus on
+    # headings, emphasis, code spans, and paragraphs to keep tests meaningful.
+    html_lines = []
+    in_code_block = False
+    for raw_line in markdown_text.splitlines():
+        line = raw_line.rstrip()
+        if line.startswith("```"):
+            if not in_code_block:
+                html_lines.append("<pre><code>")
+                in_code_block = True
+            else:
+                html_lines.append("</code></pre>")
+                in_code_block = False
+            continue
+        if in_code_block:
+            html_lines.append(escape(line))
+            continue
+        if not line:
+            html_lines.append("<p></p>")
+            continue
+        heading_match = re.match(r"^(#{1,6})\s+(.*)", line)
+        if heading_match:
+            level = len(heading_match.group(1))
+            content = heading_match.group(2)
+            html_lines.append(f"<h{level}>{_inline_format(content)}</h{level}>")
+            continue
+        html_lines.append(f"<p>{_inline_format(line)}</p>")
+    if in_code_block:
+        html_lines.append("</code></pre>")
+    return "\n".join(html_lines)
+
+
+def _inline_format(text: str) -> str:
+    """Apply very small subset of Markdown inline formatting for the fallback."""
+
+    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
+    text = re.sub(r"\*(.+?)\*", r"<em>\1</em>", text)
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    text = re.sub(r"\[(.+?)\]\((.+?)\)", r"<a href='\2'>\1</a>", text)
+    return text
+
+
+def convert_markdown(
+    text: str,
+    *,
+    template_manager: TemplateManager,
+    preferred_template: Optional[str] = None,
+) -> ConversionResult:
+    """Convert Markdown (with optional front matter) into HTML."""
+
+    metadata, body = parse_front_matter(text)
+    template_name = metadata.get("template") or preferred_template
+    available = list(template_manager.names())
+    if available:
+        if template_name not in available:
+            template_name = available[0]
+    body_html = _markdown_to_html(body)
+    html = template_manager.render(template_name or "", html_content=body_html, metadata=metadata)
+    return ConversionResult(metadata=metadata, body_markdown=body, html=html, template_used=template_name)
+
+
+def convert_to_xml(result: ConversionResult) -> str:
+    """Serialise the conversion result into a small XML document."""
+
+    root = ET.Element("document")
+    meta = ET.SubElement(root, "front_matter")
+    for key, value in sorted(result.metadata.items()):
+        node = ET.SubElement(meta, key)
+        node.text = value
+
+    template_node = ET.SubElement(root, "template")
+    template_node.text = result.template_used or ""
+
+    content = ET.SubElement(root, "content_html")
+    content.text = result.html
+
+    return ET.tostring(root, encoding="unicode")
+
+
+__all__ = [
+    "ConversionResult",
+    "TemplateDefinition",
+    "TemplateManager",
+    "convert_markdown",
+    "convert_to_xml",
+    "parse_front_matter",
+]

--- a/Practical/Markdown Editor/editor.py
+++ b/Practical/Markdown Editor/editor.py
@@ -1,0 +1,398 @@
+"""Tkinter-based Markdown editor with live preview and export helpers."""
+from __future__ import annotations
+
+import json
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+from tkinter.scrolledtext import ScrolledText
+from pathlib import Path
+from typing import Optional
+import re
+
+from .converter import (
+    ConversionResult,
+    TemplateManager,
+    convert_markdown,
+    convert_to_xml,
+)
+
+try:  # Optional dependency that renders HTML in Tkinter.
+    from tkhtmlview import HTMLScrolledText  # type: ignore
+except Exception:  # pragma: no cover - graceful fallback when unavailable.
+    HTMLScrolledText = None
+
+APP_TITLE = "Markdown Editor"
+BASE_DIR = Path(__file__).resolve().parent
+TEMPLATE_DIR = BASE_DIR / "templates"
+AUTOSAVE_INTERVAL_MS = 5000
+
+THEMES = {
+    "Light": {
+        "background": "#ffffff",
+        "foreground": "#111827",
+        "insertbackground": "#2563eb",
+        "selectbackground": "#bfdbfe",
+        "linehighlight": "#f1f5f9",
+        "heading": "#0f172a",
+        "bold": "#1d4ed8",
+        "italic": "#2563eb",
+        "code": "#0f172a",
+        "link": "#2563eb",
+    },
+    "Dark": {
+        "background": "#0f172a",
+        "foreground": "#e2e8f0",
+        "insertbackground": "#38bdf8",
+        "selectbackground": "#1d4ed8",
+        "linehighlight": "#1e293b",
+        "heading": "#38bdf8",
+        "bold": "#facc15",
+        "italic": "#f472b6",
+        "code": "#f59e0b",
+        "link": "#93c5fd",
+    },
+}
+
+
+class MarkdownEditorApp:
+    def __init__(self, root: tk.Tk):
+        self.root = root
+        self.root.title(APP_TITLE)
+        self.root.geometry("1200x720")
+
+        self.template_manager = TemplateManager(TEMPLATE_DIR)
+        self.current_path: Optional[Path] = None
+        self.current_result: Optional[ConversionResult] = None
+        self.template_var = tk.StringVar()
+        self.theme_var = tk.StringVar(value="Light")
+        self.status_var = tk.StringVar(value="Ready")
+        self._template_choices: list[tuple[str, str]] = []
+
+        self.highlight_job: Optional[str] = None
+        self.preview_job: Optional[str] = None
+        self.autosave_job: Optional[str] = None
+
+        self._build_menu()
+        self._build_toolbar()
+        self._build_body()
+        self._build_status_bar()
+
+        self._apply_theme("Light")
+        self._schedule_autosave()
+
+        self.root.bind("<Control-n>", lambda _event: self.new_file())
+        self.root.bind("<Control-o>", lambda _event: self.open_file())
+        self.root.bind("<Control-s>", lambda _event: self.save_file())
+        self.root.bind("<Control-S>", lambda _event: self.save_file(save_as=True))
+        self.root.bind("<Control-e>", lambda _event: self.export_html())
+        self.root.bind("<Control-E>", lambda _event: self.export_xml())
+        self.root.bind("<Control-l>", lambda _event: self.toggle_theme())
+        self.root.bind("<F5>", lambda _event: self.refresh_now())
+
+    # UI building helpers -------------------------------------------------
+    def _build_menu(self) -> None:
+        menubar = tk.Menu(self.root)
+
+        file_menu = tk.Menu(menubar, tearoff=False)
+        file_menu.add_command(label="New", command=self.new_file, accelerator="Ctrl+N")
+        file_menu.add_command(label="Open…", command=self.open_file, accelerator="Ctrl+O")
+        file_menu.add_command(label="Save", command=self.save_file, accelerator="Ctrl+S")
+        file_menu.add_command(
+            label="Save As…", command=lambda: self.save_file(save_as=True), accelerator="Ctrl+Shift+S"
+        )
+        file_menu.add_separator()
+        file_menu.add_command(label="Export HTML…", command=self.export_html, accelerator="Ctrl+E")
+        file_menu.add_command(label="Export XML…", command=self.export_xml, accelerator="Ctrl+Shift+E")
+        file_menu.add_separator()
+        file_menu.add_command(label="Exit", command=self.root.quit)
+        menubar.add_cascade(label="File", menu=file_menu)
+
+        view_menu = tk.Menu(menubar, tearoff=False)
+        view_menu.add_radiobutton(label="Light", command=lambda: self._apply_theme("Light"), value="Light")
+        view_menu.add_radiobutton(label="Dark", command=lambda: self._apply_theme("Dark"), value="Dark")
+        menubar.add_cascade(label="View", menu=view_menu)
+
+        self.root.config(menu=menubar)
+
+    def _build_toolbar(self) -> None:
+        toolbar = ttk.Frame(self.root, padding=(8, 4))
+        toolbar.pack(side=tk.TOP, fill=tk.X)
+
+        ttk.Label(toolbar, text="Template:").pack(side=tk.LEFT, padx=(0, 4))
+        self.template_combo = ttk.Combobox(
+            toolbar,
+            textvariable=self.template_var,
+            state="readonly",
+            width=24,
+        )
+        self.template_combo.pack(side=tk.LEFT)
+        self.template_combo.bind("<<ComboboxSelected>>", lambda _event: self._on_template_selected())
+
+        self._sync_template_combo()
+
+        ttk.Button(toolbar, text="Refresh", command=self.refresh_now).pack(side=tk.LEFT, padx=6)
+        ttk.Button(toolbar, text="Templates Folder", command=self._open_templates_folder).pack(side=tk.LEFT)
+
+    def _build_body(self) -> None:
+        paned = ttk.PanedWindow(self.root, orient=tk.HORIZONTAL)
+        paned.pack(fill=tk.BOTH, expand=True)
+
+        self.editor = ScrolledText(paned, undo=True, wrap=tk.WORD)
+        self.editor.pack(fill=tk.BOTH, expand=True)
+        self.editor.bind("<<Modified>>", self._on_modified)
+        paned.add(self.editor, weight=3)
+
+        if HTMLScrolledText is not None:
+            self.preview = HTMLScrolledText(paned, html="<h2>Preview</h2><p>Start typing…</p>")
+        else:
+            self.preview = ScrolledText(paned, state=tk.DISABLED, wrap=tk.WORD)
+            self.preview.configure(height=10)
+            self.preview.configure(cursor="arrow")
+            self.preview.configure(insertbackground="#000000")
+            self.preview.configure(tabs=(12,))
+            self.preview.configure(background="#f1f5f9")
+            self.preview.configure(foreground="#0f172a")
+            self.preview.configure(font=("Consolas", 11))
+            self._update_preview_fallback("<h2>Preview</h2>\n<p>Install tkhtmlview for rendered output.</p>")
+        paned.add(self.preview, weight=2)
+
+    def _build_status_bar(self) -> None:
+        status = ttk.Label(self.root, textvariable=self.status_var, anchor=tk.W)
+        status.pack(side=tk.BOTTOM, fill=tk.X)
+
+    # Events ---------------------------------------------------------------
+    def _on_modified(self, _event: tk.Event) -> None:
+        if self.editor.edit_modified():
+            self.editor.edit_modified(False)
+            self._schedule_highlight()
+            self._schedule_preview()
+
+    def _on_template_selected(self) -> None:
+        label_to_name = {label: name for name, label in self._template_choices}
+        selected_label = self.template_var.get()
+        template_name = label_to_name.get(selected_label)
+        if template_name:
+            self.current_result = None  # Force regenerate with new template.
+            self.refresh_now(preferred_template=template_name)
+
+    # Highlighting --------------------------------------------------------
+    def _schedule_highlight(self) -> None:
+        if self.highlight_job:
+            self.root.after_cancel(self.highlight_job)
+        self.highlight_job = self.root.after(120, self._highlight_markdown)
+
+    def _highlight_markdown(self) -> None:
+        text = self.editor.get("1.0", tk.END)
+        for tag in ("heading", "bold", "italic", "code", "link", "line"):  # reset
+            self.editor.tag_remove(tag, "1.0", tk.END)
+
+        theme = THEMES[self.theme_var.get()]
+        self.editor.tag_configure("heading", foreground=theme["heading"], font=("Segoe UI", 13, "bold"))
+        self.editor.tag_configure("bold", foreground=theme["bold"], font=("Segoe UI", 11, "bold"))
+        self.editor.tag_configure("italic", foreground=theme["italic"], font=("Segoe UI", 11, "italic"))
+        self.editor.tag_configure("code", foreground=theme["code"], font=("Consolas", 11))
+        self.editor.tag_configure("link", foreground=theme["link"], underline=True)
+        self.editor.tag_configure("line", background=theme["linehighlight"])
+
+        for match in re.finditer(r"^.*$", text, re.MULTILINE):
+            start = f"1.0+{match.start()}c"
+            end = f"1.0+{match.end()}c"
+            if match.group(0).strip():
+                self.editor.tag_add("line", start, end)
+
+        for pattern, tag in [
+            (r"^#{1,6}.+$", "heading"),
+            (r"\*\*(.+?)\*\*", "bold"),
+            (r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", "italic"),
+            (r"`([^`]+)`", "code"),
+            (r"```.+?```", "code"),
+            (r"\[(.+?)\]\((.+?)\)", "link"),
+        ]:
+            for match in re.finditer(pattern, text, re.MULTILINE | re.DOTALL):
+                start = f"1.0+{match.start()}c"
+                end = f"1.0+{match.end()}c"
+                self.editor.tag_add(tag, start, end)
+
+    # Preview -------------------------------------------------------------
+    def _schedule_preview(self) -> None:
+        if self.preview_job:
+            self.root.after_cancel(self.preview_job)
+        self.preview_job = self.root.after(200, self.refresh_now)
+
+    def refresh_now(self, preferred_template: Optional[str] = None) -> None:
+        self.template_manager.refresh()
+        self._sync_template_combo()
+        text = self.editor.get("1.0", tk.END).rstrip()
+        if not text.strip():
+            self._update_preview("<p><em>Start typing to see the preview…</em></p>")
+            self.status_var.set("Empty document")
+            return
+
+        template_name = preferred_template or self._template_name_from_label(self.template_var.get())
+        try:
+            result = convert_markdown(text, template_manager=self.template_manager, preferred_template=template_name)
+        except Exception as exc:  # pragma: no cover - defensive; conversion errors are rare.
+            self.status_var.set(f"Conversion error: {exc}")
+            return
+
+        self.current_result = result
+        if result.template_used and result.template_used != template_name:
+            self.template_var.set(self.template_manager.labels().get(result.template_used, result.template_used))
+
+        self._update_preview(result.html)
+        meta_summary = ", ".join(f"{key}: {value}" for key, value in result.metadata.items()) or "No front matter"
+        self.status_var.set(f"Preview updated • {meta_summary}")
+
+    def _update_preview(self, html: str) -> None:
+        if HTMLScrolledText is not None and isinstance(self.preview, HTMLScrolledText):
+            self.preview.set_html(html)
+        else:
+            self._update_preview_fallback(html)
+
+    def _update_preview_fallback(self, html: str) -> None:
+        self.preview.configure(state=tk.NORMAL)
+        self.preview.delete("1.0", tk.END)
+        self.preview.insert(tk.END, html)
+        self.preview.configure(state=tk.DISABLED)
+
+    def _sync_template_combo(self) -> None:
+        labels = sorted(self.template_manager.labels().items(), key=lambda item: item[1])
+        self._template_choices = labels
+        human_labels = [label for _, label in labels]
+        self.template_combo.configure(values=human_labels)
+        if human_labels and self.template_var.get() not in human_labels:
+            self.template_var.set(human_labels[0])
+
+    # File operations -----------------------------------------------------
+    def new_file(self) -> None:
+        if not self._confirm_discard_changes():
+            return
+        self.editor.delete("1.0", tk.END)
+        self.current_path = None
+        self.status_var.set("New document")
+
+    def open_file(self) -> None:
+        if not self._confirm_discard_changes():
+            return
+        path = filedialog.askopenfilename(filetypes=[("Markdown", "*.md"), ("All files", "*.*")])
+        if not path:
+            return
+        data = Path(path).read_text(encoding="utf-8")
+        self.editor.delete("1.0", tk.END)
+        self.editor.insert("1.0", data)
+        self.current_path = Path(path)
+        self.status_var.set(f"Opened {self.current_path.name}")
+        self.refresh_now()
+
+    def save_file(self, save_as: bool = False) -> None:
+        if self.current_path is None or save_as:
+            path = filedialog.asksaveasfilename(
+                defaultextension=".md",
+                filetypes=[("Markdown", "*.md"), ("All files", "*.*")],
+            )
+            if not path:
+                return
+            self.current_path = Path(path)
+        data = self.editor.get("1.0", tk.END)
+        self.current_path.write_text(data.rstrip() + "\n", encoding="utf-8")
+        self.status_var.set(f"Saved {self.current_path.name}")
+
+    def export_html(self) -> None:
+        if self.current_result is None:
+            self.refresh_now()
+        if self.current_result is None:
+            messagebox.showinfo(APP_TITLE, "Nothing to export yet – type some Markdown first.")
+            return
+        path = filedialog.asksaveasfilename(defaultextension=".html", filetypes=[("HTML", "*.html")])
+        if not path:
+            return
+        Path(path).write_text(self.current_result.html, encoding="utf-8")
+        self.status_var.set(f"Exported HTML to {Path(path).name}")
+
+    def export_xml(self) -> None:
+        if self.current_result is None:
+            self.refresh_now()
+        if self.current_result is None:
+            messagebox.showinfo(APP_TITLE, "Nothing to export yet – type some Markdown first.")
+            return
+        xml_payload = convert_to_xml(self.current_result)
+        path = filedialog.asksaveasfilename(defaultextension=".xml", filetypes=[("XML", "*.xml")])
+        if not path:
+            return
+        Path(path).write_text(xml_payload, encoding="utf-8")
+        self.status_var.set(f"Exported XML to {Path(path).name}")
+
+    # Utilities -----------------------------------------------------------
+    def _confirm_discard_changes(self) -> bool:
+        content = self.editor.get("1.0", tk.END).strip()
+        if not content:
+            return True
+        if self.current_path is None:
+            prompt = "Discard the current unsaved document?"
+        else:
+            prompt = f"Discard changes to {self.current_path.name}?"
+        return messagebox.askyesno(APP_TITLE, prompt)
+
+    def _template_name_from_label(self, label: str) -> Optional[str]:
+        for name, human in self.template_manager.labels().items():
+            if human == label:
+                return name
+        return None
+
+    def _apply_theme(self, theme_name: str) -> None:
+        theme = THEMES[theme_name]
+        self.theme_var.set(theme_name)
+        self.editor.configure(
+            background=theme["background"],
+            foreground=theme["foreground"],
+            insertbackground=theme["insertbackground"],
+            selectbackground=theme["selectbackground"],
+        )
+        if HTMLScrolledText is None:
+            self.preview.configure(background=theme["linehighlight"], foreground=theme["foreground"])
+        self._highlight_markdown()
+
+    def toggle_theme(self) -> None:
+        next_theme = "Dark" if self.theme_var.get() == "Light" else "Light"
+        self._apply_theme(next_theme)
+
+    def _open_templates_folder(self) -> None:
+        path = TEMPLATE_DIR
+        try:
+            if tk.TkVersion >= 8.6:
+                self.root.tk.call("::tk::dialog::file::ShowFolder", path)
+        except Exception:
+            # Portable fallback – show a message containing the path.
+            messagebox.showinfo(APP_TITLE, f"Templates live at:\n{path}")
+
+    def _schedule_autosave(self) -> None:
+        if self.autosave_job:
+            self.root.after_cancel(self.autosave_job)
+        self.autosave_job = self.root.after(AUTOSAVE_INTERVAL_MS, self._autosave_snapshot)
+
+    def _autosave_snapshot(self) -> None:
+        content = self.editor.get("1.0", tk.END).strip()
+        if content:
+            scratch = BASE_DIR / ".autosave.json"
+            snapshot = {
+                "path": str(self.current_path) if self.current_path else None,
+                "content": content,
+            }
+            scratch.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+            self.status_var.set("Autosaved draft")
+        self._schedule_autosave()
+
+    # Application entry point ---------------------------------------------
+    def run(self) -> None:
+        self.refresh_now()
+        self.root.mainloop()
+
+
+def main() -> None:
+    root = tk.Tk()
+    app = MarkdownEditorApp(root)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/Practical/Markdown Editor/requirements.txt
+++ b/Practical/Markdown Editor/requirements.txt
@@ -1,0 +1,3 @@
+markdown>=3.6,<3.7
+# Optional but recommended for the live HTML preview widget
+tkhtmlview>=0.2.0,<0.3

--- a/Practical/Markdown Editor/templates/dark.html
+++ b/Practical/Markdown Editor/templates/dark.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>$title</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            font-family: "Fira Sans", "Segoe UI", sans-serif;
+            margin: 0 auto;
+            max-width: 900px;
+            padding: 2.5rem 1.5rem 4rem;
+            background: #0f172a;
+            color: #e2e8f0;
+        }
+        a { color: #38bdf8; }
+        pre {
+            background: #020617;
+            border-radius: 0.6rem;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+        code {
+            background: rgba(148, 163, 184, 0.1);
+            padding: 0.15rem 0.35rem;
+            border-radius: 0.35rem;
+        }
+        h1, h2, h3, h4 { color: #f8fafc; }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+        }
+        th, td {
+            border: 1px solid rgba(148, 163, 184, 0.3);
+            padding: 0.65rem 0.75rem;
+        }
+        blockquote {
+            border-left: 4px solid rgba(56, 189, 248, 0.5);
+            padding-left: 1rem;
+            color: #cbd5f5;
+        }
+        .byline {
+            color: rgba(226, 232, 240, 0.65);
+        }
+        $styles
+    </style>
+    $extra_head
+</head>
+<body>
+<header>
+    <h1>$title</h1>
+    $author_line
+</header>
+<main>
+$content
+</main>
+</body>
+</html>

--- a/Practical/Markdown Editor/templates/default.html
+++ b/Practical/Markdown Editor/templates/default.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>$title</title>
+    <style>
+        body {
+            font-family: "Segoe UI", Arial, sans-serif;
+            margin: 2rem auto;
+            max-width: 960px;
+            line-height: 1.6;
+            color: #1f2933;
+            background: #f8fafc;
+            padding: 0 1.5rem 4rem;
+        }
+        h1, h2, h3, h4, h5, h6 {
+            color: #1a202c;
+            margin-top: 2rem;
+        }
+        pre {
+            background: #0f172a;
+            color: #f8fafc;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+        }
+        code {
+            background: rgba(15, 23, 42, 0.08);
+            padding: 0.2rem 0.4rem;
+            border-radius: 0.3rem;
+        }
+        a {
+            color: #2563eb;
+        }
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+        th, td {
+            border: 1px solid #cbd5e1;
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+        blockquote {
+            border-left: 4px solid #94a3b8;
+            padding-left: 1rem;
+            color: #475569;
+        }
+        .byline {
+            margin-top: -1rem;
+            color: #64748b;
+        }
+        $styles
+    </style>
+    $extra_head
+</head>
+<body>
+<header>
+    <h1>$title</h1>
+    $author_line
+</header>
+<main>
+$content
+</main>
+</body>
+</html>

--- a/Practical/Markdown Editor/tests/test_converter.py
+++ b/Practical/Markdown Editor/tests/test_converter.py
@@ -1,0 +1,48 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = BASE_DIR / "converter.py"
+TEMPLATE_DIR = BASE_DIR / "templates"
+
+spec = importlib.util.spec_from_file_location("markdown_editor.converter", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+TemplateManager = module.TemplateManager
+convert_markdown = module.convert_markdown
+convert_to_xml = module.convert_to_xml
+parse_front_matter = module.parse_front_matter
+
+
+class ConverterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manager = TemplateManager(TEMPLATE_DIR)
+
+    def test_front_matter_parsing(self) -> None:
+        metadata, body = parse_front_matter("""---\ntitle: Sample\nauthor: Alice\n---\n\n# Heading\n""")
+        self.assertEqual(metadata["title"], "Sample")
+        self.assertEqual(metadata["author"], "Alice")
+        self.assertTrue(body.startswith("# Heading"))
+
+    def test_conversion_applies_template(self) -> None:
+        text = """---\ntitle: Doc\ntemplate: dark\n---\n\n# Hello\n\nSome **bold** text."""
+        result = convert_markdown(text, template_manager=self.manager)
+        self.assertIn("<h1>Doc</h1>", result.html)
+        self.assertIn("<strong>bold</strong>", result.html)
+        self.assertEqual(result.template_used, "dark")
+
+    def test_xml_conversion_contains_metadata(self) -> None:
+        text = """---\ntitle: XML Demo\nauthor: Bob\n---\n\nContent line."""
+        result = convert_markdown(text, template_manager=self.manager, preferred_template="default")
+        xml_payload = convert_to_xml(result)
+        self.assertIn("<title>XML Demo</title>", xml_payload)
+        self.assertIn("<content_html>", xml_payload)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/Practical/README.md
+++ b/Practical/README.md
@@ -59,6 +59,7 @@ Brief synopses; dive into each folder for details.
 | Imageboard | Minimal Flask + SQLite anonymous imageboard (threads, replies, uploads, quoting, thumbnails). | Flask, Pillow, SQLite, Jinja filters |
 | ImgToASCII | Convert images to ASCII art (CLI + Tk GUI). | Pillow, NumPy, Tkinter |
 | IP Tracking visualization | Fetch IP geolocation data & plot interactive map. | requests, pandas, plotly, tqdm |
+| Markdown Editor | Desktop Markdown editor with live preview & exports. | Tkinter, markdown |
 | Markov Chain Sentence Generator | Train simple Markov model over corpora (CLI + GUI). | Dataclasses, Tkinter |
 | Paint (clone) | Lightweight Tk canvas paint app with palette + save. | Tkinter, Pillow (optional) |
 | PDF Tagger | Add arbitrary JSON metadata tags to PDFs. | pypdf |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ While this is a personal project, the principles behind it are universal. If you
 | 37 | Basic Relational Database Software (SQL Support Handle Relationships Focus on Efficiency) | Not Yet |
 | 38 | Pixel Editor | Not Yet |
 | 39 | Trivial File Transfer Protocol (TFTP): Allow a client to put a file onto a remote host | Not Yet |
-| 40 | Markdown (HTML/XML) Editor | Not Yet |
+| 40 | Markdown (HTML/XML) Editor | [View Solution](./Practical/Markdown%20Editor/) |
 | 41 | IP Tracking Visualization | [View Solution](./Practical/IP%20Tracking%20visualization/) |
 | 42 | Port Scanner | [View Solution](./Practical/Port%20Scanner/) |
 | 43 | Old School Demo Effect (Plasma Tunnel Scrollers Zoomers etc...) | Not Yet |


### PR DESCRIPTION
## Summary
- add a Tkinter-based Markdown editor with syntax highlighting, live HTML preview, theming, and export features
- introduce reusable conversion utilities for front matter parsing, templating, and XML packaging
- document the new tool, update project indexes, and supply unit tests for conversion helpers

## Testing
- python -m unittest discover "Practical/Markdown Editor/tests"


------
https://chatgpt.com/codex/tasks/task_b_68d6c2b94ca883298b441e12fa721847