### PR TITLE
Add encrypted upload CLI with docs and tests

### DIFF
--- a/Practical/Encrypted Upload/README.md
+++ b/Practical/Encrypted Upload/README.md
@@ -1,0 +1,129 @@
+# Encrypted Upload CLI
+
+The Encrypted Upload CLI encrypts files locally with AES-GCM and sends them to an upload target. It supports Amazon S3 buckets and generic HTTP endpoints so you can integrate it into existing storage workflows.
+
+## Features
+
+- **Authenticated encryption** with AES-256-GCM and per-upload nonces.
+- **Password-based key derivation** via PBKDF2-HMAC-SHA256 or direct hexadecimal keys.
+- **Integrity manifests** that capture hashes, encryption parameters, and upload metadata.
+- **Optional manifest signing** using HMAC-SHA256 for offline verification.
+- **Pluggable upload targets**: S3 (via `boto3`) or arbitrary HTTP forms/JSON APIs.
+
+## Quick Start
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Create an endpoint configuration file, for example `endpoints.json`:
+   ```json
+   {
+     "endpoints": [
+       {
+         "name": "personal-s3",
+         "type": "s3",
+         "bucket": "my-upload-bucket",
+         "region": "us-east-1",
+         "key_prefix": "encrypted/",
+         "expires_in": 7200
+       },
+       {
+         "name": "staging-http",
+         "type": "http",
+         "url": "https://uploads.example.net/files",
+         "method": "POST",
+         "response_url_field": "download_url"
+       }
+     ]
+   }
+   ```
+
+3. Encrypt and upload a file:
+   ```bash
+   python "Practical/Encrypted Upload/encrypted_upload.py" upload \
+       --file report.pdf \
+       --config endpoints.json \
+       --endpoint personal-s3 \
+       --password "correct horse battery staple" \
+       --manifest manifest.json \
+       --signing-key 1f2d3c4b5a69788790abccddeeff0011
+   ```
+
+4. The CLI prints a shareable link, writes the encrypted payload to the remote storage, and stores the manifest (with optional signature) locally.
+
+## Manifest Format
+
+Each manifest is JSON with the following schema:
+
+```json
+{
+  "original_filename": "report.pdf",
+  "filesize": 12345,
+  "sha256": "...",
+  "encryption": {
+    "algorithm": "AES-256-GCM",
+    "nonce": "base64==",
+    "salt": "base64==",
+    "associated_data": "report.pdf"
+  },
+  "upload": {
+    "endpoint": "personal-s3",
+    "object_key": "encrypted/2024-08-19T10-03-15Z_report.pdf.enc",
+    "timestamp": "2024-08-19T10:03:16Z",
+    "link": "https://my-upload-bucket.s3.us-east-1.amazonaws.com/encrypted/2024-08-19T10-03-15Z_report.pdf.enc"
+  },
+  "signature": {
+    "algorithm": "HMAC-SHA256",
+    "value": "base64=="
+  }
+}
+```
+
+The `signature` block is only present when `--signing-key` is provided.
+
+## Upload Targets
+
+### Amazon S3
+
+The CLI uploads with the AWS SDK (`boto3`). Provide credentials through the standard AWS environment variables, shared configuration files, or an assigned IAM role. Configure your endpoint block with:
+
+- `bucket` (required): target S3 bucket name.
+- `region` (required): AWS region for the bucket.
+- `key_prefix` (optional): path prefix prepended to generated object keys.
+- `expires_in` (optional): seconds for the generated pre-signed URL (default 3600).
+
+The shareable link is produced via a pre-signed `GetObject` URL.
+
+### Generic HTTP Endpoint
+
+For custom storage services, specify a JSON block with:
+
+- `url`: where the encrypted file is uploaded.
+- `method`: `POST` (default) or `PUT`.
+- `field_name`: multipart field name for the binary payload (default `file`).
+- `headers`: optional dictionary of HTTP headers.
+- `response_url_field`: JSON field that contains a download URL (default `url`).
+
+The CLI performs a multipart request (`files={field_name: (filename, encrypted_bytes)}`) and expects a JSON response.
+
+## Security Considerations
+
+- **Key management is your responsibility.** Never hardcode keys or reuse weak passwords.
+- **Password-derived keys need strong passphrases.** Use a password manager to generate random phrases.
+- **Salts and nonces are randomly generated** per upload and stored in the encrypted payload/manifest. Do not modify them.
+- **Manifests contain sensitive metadata.** Store them securely and consider encrypting or signing them for audit purposes.
+- **Review your HTTP targets.** Ensure TLS is enforced and the server validates authentication before storing uploads.
+- **Audit dependencies and environments** before using this tool in production. This repository is educational and does not replace a vetted security solution.
+
+## Testing
+
+Run automated tests (which include mocked S3 and HTTP servers):
+
+```bash
+pytest Practical/Encrypted\ Upload/tests
+```
+
+These tests ensure encryption correctness, manifest integrity, and upload flows without contacting external services.
+

--- a/Practical/Encrypted Upload/encrypted_upload.py
+++ b/Practical/Encrypted Upload/encrypted_upload.py
@@ -1,0 +1,311 @@
+"""AES-GCM encrypted upload CLI supporting S3 and generic HTTP targets."""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import requests
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+try:  # boto3 is optional until an S3 endpoint is used
+    import boto3
+except ImportError:  # pragma: no cover - boto3 always available in tests
+    boto3 = None
+
+MAGIC = b"EU01"
+DEFAULT_CONTENT_TYPE = "application/octet-stream"
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when the configuration file is invalid."""
+
+
+def load_config(config_path: Path) -> Dict[str, Any]:
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:  # pragma: no cover - defensive
+        raise ConfigurationError(f"Configuration file not found: {config_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ConfigurationError(f"Invalid JSON in configuration file: {config_path}") from exc
+
+    if "endpoints" not in data or not isinstance(data["endpoints"], list):
+        raise ConfigurationError("Configuration must contain an 'endpoints' list")
+    return data
+
+
+def find_endpoint(config: Dict[str, Any], name: str) -> Dict[str, Any]:
+    for endpoint in config.get("endpoints", []):
+        if endpoint.get("name") == name:
+            return endpoint
+    raise ConfigurationError(f"Endpoint '{name}' not found in configuration")
+
+
+@dataclass
+class EncryptionResult:
+    payload: bytes
+    nonce: bytes
+    salt: bytes
+    sha256: str
+    filesize: int
+    key_bits: int
+
+
+def derive_key(password: Optional[str], key_hex: Optional[str]) -> Tuple[bytes, bytes]:
+    if password and key_hex:
+        raise ValueError("Provide either a password or a hex key, not both")
+    if password:
+        salt = os.urandom(16)
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=salt,
+            iterations=200_000,
+        )
+        key = kdf.derive(password.encode("utf-8"))
+        return key, salt
+    if key_hex:
+        try:
+            key = bytes.fromhex(key_hex)
+        except ValueError as exc:
+            raise ValueError("Key must be a hexadecimal string") from exc
+        if len(key) not in (16, 24, 32):
+            raise ValueError("Key must decode to 16, 24, or 32 bytes for AES")
+        return key, b""
+    raise ValueError("A password or hex key is required")
+
+
+def encrypt_file(path: Path, key: bytes, salt: bytes, associated_data: bytes) -> EncryptionResult:
+    data = path.read_bytes()
+    nonce = os.urandom(12)
+    aesgcm = AESGCM(key)
+    ciphertext = aesgcm.encrypt(nonce, data, associated_data)
+
+    if len(salt) > 255:
+        raise ValueError("Salt length cannot exceed 255 bytes")
+    if len(nonce) > 255:
+        raise ValueError("Nonce length cannot exceed 255 bytes")
+
+    header = MAGIC + bytes((len(salt), len(nonce)))
+    payload = header + salt + nonce + ciphertext
+    sha256 = hashlib.sha256(payload).hexdigest()
+    return EncryptionResult(
+        payload=payload,
+        nonce=nonce,
+        salt=salt,
+        sha256=sha256,
+        filesize=len(data),
+        key_bits=len(key) * 8,
+    )
+
+
+def parse_payload(payload: bytes) -> Tuple[bytes, bytes, bytes]:
+    if not payload.startswith(MAGIC):
+        raise ValueError("Payload missing magic header")
+    if len(payload) < 6:
+        raise ValueError("Payload too short")
+    salt_len = payload[4]
+    nonce_len = payload[5]
+    expected_len = 6 + salt_len + nonce_len
+    if len(payload) < expected_len:
+        raise ValueError("Payload truncated")
+    salt = payload[6 : 6 + salt_len]
+    nonce = payload[6 + salt_len : 6 + salt_len + nonce_len]
+    ciphertext = payload[6 + salt_len + nonce_len :]
+    return salt, nonce, ciphertext
+
+
+def decrypt_payload(payload: bytes, key: bytes, associated_data: bytes) -> bytes:
+    salt, nonce, ciphertext = parse_payload(payload)
+    aesgcm = AESGCM(key)
+    return aesgcm.decrypt(nonce, ciphertext, associated_data)
+
+
+def ensure_boto3():
+    if boto3 is None:
+        raise RuntimeError("boto3 is required for S3 uploads but is not installed")
+    return boto3
+
+
+def generate_object_key(filename: str, prefix: str = "") -> str:
+    safe_name = filename.replace("/", "_").replace(" ", "_")
+    if prefix and not prefix.endswith("/"):
+        prefix = f"{prefix}/"
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{prefix}{timestamp}_{safe_name}.enc"
+
+
+def upload_to_s3(payload: bytes, endpoint: Dict[str, Any], object_key: str, content_type: str) -> str:
+    boto3_mod = ensure_boto3()
+    region = endpoint.get("region")
+    bucket = endpoint.get("bucket")
+    if not bucket or not region:
+        raise ConfigurationError("S3 endpoint requires 'bucket' and 'region'")
+
+    profile = endpoint.get("profile")
+    session = boto3_mod.Session(profile_name=profile) if profile else boto3_mod.Session()
+    client = session.client("s3", region_name=region)
+    client.put_object(Bucket=bucket, Key=object_key, Body=payload, ContentType=content_type)
+
+    expires_in = int(endpoint.get("expires_in", 3600))
+    return client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket, "Key": object_key},
+        ExpiresIn=expires_in,
+    )
+
+
+def upload_to_http(payload: bytes, endpoint: Dict[str, Any], object_key: str, content_type: str, filename: str) -> str:
+    url = endpoint.get("url")
+    if not url:
+        raise ConfigurationError("HTTP endpoint requires a 'url'")
+    method = endpoint.get("method", "POST").upper()
+    headers = endpoint.get("headers", {}) or {}
+    response_url_field = endpoint.get("response_url_field", "url")
+
+    if method == "POST":
+        field_name = endpoint.get("field_name", "file")
+        data = {"object_key": object_key}
+        files = {field_name: (filename + ".enc", payload, content_type)}
+        response = requests.post(url, data=data, files=files, headers=headers, timeout=endpoint.get("timeout", 30))
+    elif method == "PUT":
+        headers = {**headers, "Content-Type": content_type, "X-Object-Key": object_key}
+        response = requests.put(url, data=payload, headers=headers, timeout=endpoint.get("timeout", 30))
+    else:
+        raise ConfigurationError(f"Unsupported HTTP method '{method}'")
+
+    response.raise_for_status()
+    if response.headers.get("Content-Type", "").startswith("application/json"):
+        json_body = response.json()
+        if response_url_field not in json_body:
+            raise RuntimeError(f"HTTP response missing '{response_url_field}' field")
+        return json_body[response_url_field]
+    # Fallback: accept Location header or the URL itself
+    return response.headers.get("Location", url)
+
+
+def build_manifest(
+    result: EncryptionResult,
+    endpoint_name: str,
+    object_key: str,
+    share_url: str,
+    filename: str,
+    associated_data: bytes,
+    signing_key_hex: Optional[str],
+) -> Dict[str, Any]:
+    manifest: Dict[str, Any] = {
+        "original_filename": filename,
+        "filesize": result.filesize,
+        "sha256": result.sha256,
+        "encryption": {
+            "algorithm": f"AES-{result.key_bits}-GCM",
+            "nonce": base64.b64encode(result.nonce).decode("ascii"),
+            "salt": base64.b64encode(result.salt).decode("ascii"),
+            "associated_data": associated_data.decode("utf-8", errors="ignore"),
+        },
+        "upload": {
+            "endpoint": endpoint_name,
+            "object_key": object_key,
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "link": share_url,
+        },
+    }
+    if signing_key_hex:
+        try:
+            signing_key = bytes.fromhex(signing_key_hex)
+        except ValueError as exc:
+            raise ValueError("Signing key must be hexadecimal") from exc
+        serialized = json.dumps(manifest, sort_keys=True).encode("utf-8")
+        signature = hmac.new(signing_key, serialized, hashlib.sha256).digest()
+        manifest["signature"] = {
+            "algorithm": "HMAC-SHA256",
+            "value": base64.b64encode(signature).decode("ascii"),
+        }
+    return manifest
+
+
+def save_manifest(manifest: Dict[str, Any], manifest_path: Path) -> None:
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+
+def handle_upload(args: argparse.Namespace) -> int:
+    file_path = Path(args.file)
+    if not file_path.is_file():
+        raise FileNotFoundError(f"Input file not found: {file_path}")
+
+    config = load_config(Path(args.config))
+    endpoint = find_endpoint(config, args.endpoint)
+
+    key, salt = derive_key(args.password, args.key)
+    associated_data = file_path.name.encode("utf-8")
+    result = encrypt_file(file_path, key, salt, associated_data)
+
+    object_key = generate_object_key(file_path.name, endpoint.get("key_prefix", ""))
+    content_type = args.content_type or DEFAULT_CONTENT_TYPE
+
+    if endpoint.get("type") == "s3":
+        share_url = upload_to_s3(result.payload, endpoint, object_key, content_type)
+    elif endpoint.get("type") == "http":
+        share_url = upload_to_http(result.payload, endpoint, object_key, content_type, file_path.name)
+    else:
+        raise ConfigurationError(f"Unsupported endpoint type '{endpoint.get('type')}'")
+
+    manifest = build_manifest(
+        result=result,
+        endpoint_name=endpoint["name"],
+        object_key=object_key,
+        share_url=share_url,
+        filename=file_path.name,
+        associated_data=associated_data,
+        signing_key_hex=args.signing_key,
+    )
+
+    if args.manifest:
+        save_manifest(manifest, Path(args.manifest))
+
+    print(share_url)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Encrypt a file and upload it to a remote endpoint.")
+    subparsers = parser.add_subparsers(dest="command")
+
+    upload_parser = subparsers.add_parser("upload", help="Encrypt and upload a file")
+    upload_parser.add_argument("--file", required=True, help="Path to the file to encrypt")
+    upload_parser.add_argument("--config", required=True, help="Path to the endpoints configuration JSON")
+    upload_parser.add_argument("--endpoint", required=True, help="Name of the endpoint to use")
+    group = upload_parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--password", help="Password used to derive the AES key")
+    group.add_argument("--key", help="Hex-encoded AES key (16/24/32 bytes)")
+    upload_parser.add_argument("--manifest", help="Path to write the manifest JSON")
+    upload_parser.add_argument("--signing-key", help="Hex-encoded HMAC key for signing the manifest")
+    upload_parser.add_argument("--content-type", help="Override the uploaded content type")
+    upload_parser.set_defaults(func=handle_upload)
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return 1
+    try:
+        return args.func(args)
+    except Exception as exc:  # pragma: no cover - CLI protection
+        parser.exit(status=1, message=f"error: {exc}\n")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/Practical/Encrypted Upload/tests/test_encrypted_upload.py
+++ b/Practical/Encrypted Upload/tests/test_encrypted_upload.py
@@ -1,0 +1,188 @@
+import argparse
+import base64
+import hmac
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import boto3
+import pytest
+import requests
+from moto import mock_aws
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "encrypted_upload.py"
+
+
+def load_module():
+    import importlib.util
+    import sys
+
+    spec = importlib.util.spec_from_file_location("encrypted_upload", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_encrypt_roundtrip_password(tmp_path):
+    module = load_module()
+    secret = "classified".encode()
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_bytes(secret)
+
+    key, salt = module.derive_key(password="correct horse", key_hex=None)
+    result = module.encrypt_file(sample_file, key, salt, b"sample.txt")
+
+    recovered = module.decrypt_payload(result.payload, key, b"sample.txt")
+    assert recovered == secret
+    assert result.sha256 == module.hashlib.sha256(result.payload).hexdigest()
+
+
+class MultipartCaptureHandler(BaseHTTPRequestHandler):
+    stored_payload = None
+    stored_key = None
+
+    def do_POST(self):  # noqa: N802 - http handler naming
+        import cgi
+
+        form = cgi.FieldStorage(
+            fp=self.rfile,
+            headers=self.headers,
+            environ={
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": self.headers.get("Content-Type"),
+            },
+        )
+        file_item = form["file"]
+        self.__class__.stored_payload = file_item.file.read()
+        self.__class__.stored_key = form["object_key"].value
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"url": "https://example.test/download"}).encode())
+
+    def log_message(self, *_):  # silence noisy handler
+        return
+
+
+@pytest.fixture
+def http_server():
+    server = HTTPServer(("127.0.0.1", 0), MultipartCaptureHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_http_upload_flow(tmp_path, http_server, monkeypatch):
+    module = load_module()
+    MultipartCaptureHandler.stored_payload = None
+    MultipartCaptureHandler.stored_key = None
+    real_post = requests.post
+
+    # Avoid making real HTTP requests by forcing requests to talk to our server
+    def fake_post(url, data, files, headers, timeout):
+        response = real_post(
+            f"http://127.0.0.1:{http_server.server_address[1]}/",
+            data=data,
+            files=files,
+            headers=headers,
+            timeout=timeout,
+        )
+        return response
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    sample_file = tmp_path / "document.txt"
+    sample_file.write_text("payload")
+
+    config = {
+        "endpoints": [
+            {
+                "name": "local-http",
+                "type": "http",
+                "url": "http://example.invalid/upload",
+                "method": "POST",
+                "response_url_field": "url",
+            }
+        ]
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+    manifest_path = tmp_path / "manifest.json"
+
+    args = argparse.Namespace(
+        file=str(sample_file),
+        config=str(config_path),
+        endpoint="local-http",
+        password=None,
+        key="0f" * 32,
+        manifest=str(manifest_path),
+        signing_key=None,
+        content_type=None,
+    )
+
+    assert module.handle_upload(args) == 0
+    assert MultipartCaptureHandler.stored_payload is not None
+    salt, nonce, ciphertext = module.parse_payload(MultipartCaptureHandler.stored_payload)
+    assert len(nonce) == 12
+    manifest = json.loads(manifest_path.read_text())
+    assert base64.b64encode(salt).decode() == manifest["encryption"]["salt"]
+    assert MultipartCaptureHandler.stored_key == manifest["upload"]["object_key"]
+
+
+@mock_aws
+def test_s3_upload_and_manifest(tmp_path):
+    module = load_module()
+    sample_file = tmp_path / "topsecret.txt"
+    sample_file.write_text("classified")
+
+    client = boto3.client("s3", region_name="us-east-1")
+    client.create_bucket(Bucket="test-bucket")
+
+    config = {
+        "endpoints": [
+            {
+                "name": "secure-s3",
+                "type": "s3",
+                "bucket": "test-bucket",
+                "region": "us-east-1",
+                "key_prefix": "uploads/",
+                "expires_in": 600,
+            }
+        ]
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+    manifest_path = tmp_path / "manifest.json"
+
+    args = argparse.Namespace(
+        file=str(sample_file),
+        config=str(config_path),
+        endpoint="secure-s3",
+        password="swordfish",
+        key=None,
+        manifest=str(manifest_path),
+        signing_key="aa" * 32,
+        content_type=None,
+    )
+
+    assert module.handle_upload(args) == 0
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["upload"]["endpoint"] == "secure-s3"
+    assert manifest["encryption"]["algorithm"].startswith("AES-")
+
+    # Validate signature
+    signature = manifest.pop("signature")
+    serialized = json.dumps(manifest, sort_keys=True).encode()
+    expected_sig = hmac.new(bytes.fromhex(args.signing_key), serialized, module.hashlib.sha256).digest()
+    assert base64.b64encode(expected_sig).decode() == signature["value"]
+
+    obj = client.get_object(Bucket="test-bucket", Key=manifest["upload"]["object_key"])
+    stored_payload = obj["Body"].read()
+    assert stored_payload.startswith(module.MAGIC)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ While this is a personal project, the principles behind it are universal. If you
 | 30 | IP/URL Obsucrification (<http://www.pc-help.org/obscure.htm>) | Not Yet |
 | 31 | Radix Base Converter (Given a radix base convert it to decimal) | [View Solution](./Practical/Radix%20Base%20Converter/) |
 | 32 | Chan aggregator (Let's user view various boards from different 'chans') (Bonus: Add 4ChanX and Archiving Functionality) | Not Yet |
-| 33 | Encrypt a File and Upload it online | Not Yet |
+| 33 | Encrypt a File and Upload it online | [View Solution](./Practical/Encrypted%20Upload/) |
 | 34 | Make a Text Editor that autosaves and includes the date in the filename | [View Solution](./Practical/AutoSave%20Text%20Editor/) |
 | 35 | Create an HSV Color Representation | [View Solution](./Practical/HSV%20color%20wheel/) |
 | 36 | Window Manager | Not Yet |
@@ -80,6 +80,8 @@ While this is a personal project, the principles behind it are universal. If you
 | 142 | Seam Carving | [View Solution](./Practical/Seam%20Carving/) |
 | 143 | Bayesian Filter | [View Solution](./Practical/Bayesian%20Filter/) |
 | 144 | WMS viewer that isn't web based | Not Yet |
+
+> **Security notice:** The encrypted upload utility in this repository is educational. Review the [project documentation](./Practical/Encrypted%20Upload/README.md) before using it with sensitive information and ensure keys, manifests, and remote endpoints are secured.
 
 ### Algorithmic
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,8 @@ colorama>=0.4.6,<0.5          # Cross-platform ANSI colors (todo list future imp
 #############################
 # Security / Parsing (Future placeholders)
 #############################
+cryptography>=43.0.0,<44.0.0  # AES-GCM encryption for secure uploads
+boto3>=1.34,<1.35             # S3 uploads and presigned URLs
 # beautifulsoup4>=4.12,<4.13  # For potential web crawler enhancements
 # lxml>=5.2,<5.3              # Faster HTML/XML parsing (optional)
 
@@ -51,7 +53,8 @@ colorama>=0.4.6,<0.5          # Cross-platform ANSI colors (todo list future imp
 #############################
 # ruff>=0.5,<0.6              # Linting
 # mypy>=1.11,<1.12            # Static type checking
-# pytest>=8.3,<8.4            # Testing framework
+pytest>=8.3,<8.4              # Testing framework
+moto>=5.0,<5.1                # Mock AWS services for S3 upload tests
 
 # NOTES:
 # 1. If you only work inside one sub-area (e.g., Emulation or Practical/Imageboard), prefer that folder's requirements file.


### PR DESCRIPTION
## Summary
- add an AES-GCM encrypted upload CLI with configuration-driven S3 and HTTP targets plus manifest signing
- document usage, configuration, and security considerations for the encrypted upload challenge and link it from the root README
- extend repository requirements with cryptography, boto3, moto, and pytest support for the new feature

## Testing
- pytest Practical/Encrypted\ Upload/tests

------
https://chatgpt.com/codex/tasks/task_b_68d6c2b0dd4c8329ba0cad8335405335