### PR TITLE
Add LAN music streaming server and client solution

### DIFF
--- a/Practical/Music Streaming/README.md
+++ b/Practical/Music Streaming/README.md
@@ -1,0 +1,127 @@
+# Music Streaming Challenge
+
+A lightweight LAN music streaming stack consisting of a Flask-based server and
+an interactive CLI client. The server scans a media folder for audio files
+(MP3, FLAC, WAV, OGG, M4A, AAC), exposes a playlist API, and streams tracks over
+HTTP using chunked transfer. Clients can discover the server automatically,
+stream tracks with configurable buffering, and play them back via FFmpeg's
+`ffplay` or save the stream to disk.
+
+## Features
+
+- **Playlist management:** automatic metadata extraction (title, artist, album,
+  duration) with endpoints to refresh, select, skip, and fetch the current
+  track.
+- **Chunked streaming:** files are served as generator-based responses so large
+  media never loads fully into memory.
+- **LAN discovery:** UDP broadcast pings reveal active servers without manual
+  configuration.
+- **Buffered playback:** client delays playback until a configurable byte budget
+  has been downloaded, reducing stutter on slower networks.
+- **Metadata aware CLI:** interactive prompt to list tracks, jump to entries,
+  change buffer size, and stream sequentially.
+
+## Project Structure
+
+```
+Practical/Music Streaming/
+├── README.md          # You're here
+├── server.py          # Flask app + playlist manager + discovery responder
+└── client.py          # CLI client for discovery, playlist control, streaming
+```
+
+## Requirements
+
+Install dependencies from the Practical suite's consolidated requirements file
+plus FFmpeg for audio playback:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r ../requirements.txt
+# Optional but recommended: install FFmpeg so `ffplay` is available.
+```
+
+Additional packages introduced for this challenge:
+
+- `mutagen` – read metadata (ID3/FLAC/etc.).
+- `requests` (already used elsewhere) – HTTP client.
+
+The CLI defaults to `ffplay` for playback. If FFmpeg is missing, streams are
+saved to a temporary file and the path is printed so you can open it manually.
+
+## Running the Server
+
+1. Place audio files inside a media directory (defaults to `./media`).
+2. Start the server:
+
+   ```bash
+   python server.py --media ./media --host 0.0.0.0 --port 8000
+   ```
+
+   - `--media` : directory containing audio files.
+   - `--host`  : listening interface (`0.0.0.0` exposes to LAN).
+   - `--port`  : HTTP port (default `8000`).
+   - `--discovery-port` : UDP port for discovery pings (default `9999`).
+
+3. The server logs the public URL and waits for clients. Drop new files into the
+   media directory at any time and call `POST /api/playlist/refresh` (or use the
+   client's `refresh` command) to rescan.
+
+## Running the Client
+
+1. Ensure the server is running on the same network.
+2. Launch the client:
+
+   ```bash
+   python client.py
+   ```
+
+   By default the client broadcasts a discovery message and lists available
+   servers. Use `--host`/`--port` to skip discovery.
+
+3. At the prompt type `list`, `play <n>`, `next`, `prev`, `refresh`, or `buffer
+   <bytes>` to control playback.
+
+   Example session:
+
+   ```text
+   $ python client.py
+   Broadcasting discovery packet...
+   Found server at 192.168.1.42:8000
+   Available tracks:
+   [01] Orbital Sunrise by Demo Artist (Space Jams) — 05:12
+   [02] Ambient Clouds — 03:45
+   Commands:
+     list              - show playlist
+     play <n>          - select and stream track number n
+     next / prev       - skip forward/backward using server playlist order
+     refresh           - rescan playlist from server
+     buffer <bytes>    - change local buffer threshold before playback
+     quit              - exit the client
+   music> play 1
+   Requesting http://192.168.1.42:8000/api/stream/track-0
+   Title: Orbital Sunrise | Artist: Demo Artist | Album: Space Jams | Duration: 05:12 | Source file: sunrise.mp3
+   Buffered 512 KiB in 1.2s. Starting playback...
+   ```
+
+If FFmpeg is missing, the client saves the stream as a temporary file and tells
+you where to find it.
+
+## Deployment Notes
+
+- **Service separation:** The Flask app is stateless with respect to playlist
+  scanning. Use systemd, Docker, or another process supervisor to keep it
+  running. Mount your media directory into the container/VM and open the HTTP &
+  discovery ports.
+- **Reverse proxy:** When exposing outside your LAN, proxy through Nginx/Traefik
+  to add TLS and auth. Forward `/api/stream/*` without buffering for best
+  results.
+- **Scaling:** For larger libraries, consider caching metadata and precomputing
+  playlists. The current implementation targets personal/home use.
+
+## Marking the Challenge
+
+This implementation completes the **Practical #13 – Music Streaming** challenge
+from the `/g/` list with a functional streaming server, client, documentation,
+and deployment guidance.

--- a/Practical/Music Streaming/client.py
+++ b/Practical/Music Streaming/client.py
@@ -1,0 +1,403 @@
+"""Interactive CLI client for the music streaming server.
+
+Features
+--------
+* Discovers servers on the local network via UDP broadcast.
+* Fetches playlist/metadata from the HTTP API.
+* Streams audio using a buffered pipe into ``ffplay`` (FFmpeg) for playback.
+* Falls back to saving the streamed media to a temporary file if FFmpeg is absent.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Deque, Dict, List, Optional
+
+import requests
+
+DISCOVERY_MESSAGE = b"MUSIC_STREAM_DISCOVERY"
+DEFAULT_DISCOVERY_PORT = 9999
+DEFAULT_HTTP_PORT = 8000
+CHUNK_SIZE = 64 * 1024
+DEFAULT_BUFFER_BYTES = 512 * 1024
+API_PREFIX = "/api"
+
+
+@dataclass
+class ServerInfo:
+    host: str
+    port: int
+    tracks: List[Dict[str, object]]
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}{API_PREFIX}"
+
+
+class MusicStreamClient:
+    def __init__(self, server: ServerInfo, buffer_bytes: int = DEFAULT_BUFFER_BYTES) -> None:
+        self.server = server
+        self.session = requests.Session()
+        self.buffer_bytes = buffer_bytes
+        self.playlist: List[Dict[str, object]] = []
+        self.current: Optional[Dict[str, object]] = None
+
+    # --- API helpers -------------------------------------------------
+    def refresh_playlist(self) -> None:
+        response = self.session.get(f"{self.server.base_url}/playlist", timeout=5)
+        response.raise_for_status()
+        payload = response.json()
+        self.playlist = payload.get("tracks", [])
+        self.current = payload.get("current")
+
+    def select_track(self, track_id: str) -> Dict[str, object]:
+        response = self.session.post(
+            f"{self.server.base_url}/playlist/select",
+            json={"id": track_id},
+            timeout=5,
+        )
+        response.raise_for_status()
+        selected = response.json().get("selected")
+        self.current = selected
+        return selected
+
+    def next_track(self) -> Optional[Dict[str, object]]:
+        response = self.session.post(f"{self.server.base_url}/playlist/next", timeout=5)
+        response.raise_for_status()
+        current = response.json().get("current")
+        self.current = current
+        return current
+
+    def previous_track(self) -> Optional[Dict[str, object]]:
+        response = self.session.post(f"{self.server.base_url}/playlist/previous", timeout=5)
+        response.raise_for_status()
+        current = response.json().get("current")
+        self.current = current
+        return current
+
+    # --- Streaming ---------------------------------------------------
+    def stream(self, track_id: str) -> None:
+        """Stream the specified track and play it using FFmpeg (``ffplay``)."""
+        stream_url = f"{self.server.base_url}/stream/{track_id}"
+        print(f"Requesting {stream_url}")
+        response = self.session.get(stream_url, stream=True, timeout=10)
+        if response.status_code != 200:
+            print(f"Error {response.status_code}: {response.text}")
+            return
+
+        filename = _parse_filename(response.headers.get("Content-Disposition", ""))
+        meta_text = _format_track_metadata(response.headers, filename)
+        print(meta_text)
+
+        ffplay_path = shutil.which("ffplay")
+        if ffplay_path:
+            self._play_with_ffplay(response, ffplay_path)
+        else:
+            print("ffplay executable not found. Buffering to a temporary file instead.")
+            self._buffer_to_tempfile(response, filename)
+
+    def _play_with_ffplay(self, response: requests.Response, ffplay_path: str) -> None:
+        buffer: Deque[bytes] = deque()
+        buffered_bytes = 0
+        started = False
+        start_time = time.time()
+
+        process = subprocess.Popen(
+            [ffplay_path, "-autoexit", "-nodisp", "-loglevel", "error", "-"],
+            stdin=subprocess.PIPE,
+        )
+        assert process.stdin is not None  # mypy hint
+
+        try:
+            for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
+                if not chunk:
+                    continue
+                buffer.append(chunk)
+                buffered_bytes += len(chunk)
+                if not started:
+                    if buffered_bytes >= self.buffer_bytes:
+                        started = True
+                        elapsed = time.time() - start_time
+                        print(f"Buffered {buffered_bytes/1024:.0f} KiB in {elapsed:.1f}s. Starting playback...")
+                    else:
+                        print(
+                            f"Buffering {buffered_bytes/1024:.0f} KiB / {self.buffer_bytes/1024:.0f} KiB",
+                            end="\r",
+                            flush=True,
+                        )
+                        continue
+                while buffer:
+                    process.stdin.write(buffer.popleft())
+        except KeyboardInterrupt:
+            print("\nStopping playback...")
+        finally:
+            # Flush remaining buffer
+            while buffer:
+                try:
+                    process.stdin.write(buffer.popleft())
+                except BrokenPipeError:
+                    break
+            try:
+                process.stdin.close()
+            except BrokenPipeError:
+                pass
+            process.wait()
+            response.close()
+
+    def _buffer_to_tempfile(self, response: requests.Response, filename: Optional[str]) -> None:
+        suffix = Path(filename).suffix if filename else ".bin"
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+            total = 0
+            for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
+                if not chunk:
+                    continue
+                handle.write(chunk)
+                total += len(chunk)
+                print(f"Downloaded {total/1024:.0f} KiB", end="\r", flush=True)
+            temp_path = Path(handle.name)
+        print()
+        print(
+            textwrap.dedent(
+                f"""
+                Stream saved to {temp_path} ({total/1024:.1f} KiB).
+                Install FFmpeg for instant playback, or open this file with your preferred media player.
+                """
+            ).strip()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+def discover_servers(port: int, timeout: float) -> List[ServerInfo]:
+    """Broadcasts a discovery packet and collects responses."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    sock.settimeout(timeout)
+    responses: List[ServerInfo] = []
+
+    try:
+        sock.sendto(DISCOVERY_MESSAGE, ("<broadcast>", port))
+        start = time.time()
+        while True:
+            remaining = timeout - (time.time() - start)
+            if remaining <= 0:
+                break
+            sock.settimeout(remaining)
+            try:
+                payload, addr = sock.recvfrom(32_768)
+            except socket.timeout:
+                break
+            try:
+                data = json.loads(payload.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            host = data.get("host") or addr[0]
+            port = int(data.get("port", DEFAULT_HTTP_PORT))
+            tracks = data.get("tracks", [])
+            responses.append(ServerInfo(host=host, port=port, tracks=tracks))
+    finally:
+        sock.close()
+
+    return responses
+
+
+def _parse_filename(content_disposition: str) -> Optional[str]:
+    if not content_disposition:
+        return None
+    parts = content_disposition.split(";")
+    for part in parts:
+        if "=" not in part:
+            continue
+        key, value = part.strip().split("=", 1)
+        if key.lower() == "filename":
+            return value.strip('"')
+    return None
+
+
+def _format_track_metadata(headers: Dict[str, str], filename: Optional[str]) -> str:
+    title = headers.get("X-Track-Title")
+    artist = headers.get("X-Track-Artist")
+    album = headers.get("X-Track-Album")
+    duration = headers.get("X-Track-Duration")
+    pieces = []
+    if title:
+        pieces.append(f"Title: {title}")
+    if artist:
+        pieces.append(f"Artist: {artist}")
+    if album:
+        pieces.append(f"Album: {album}")
+    if duration:
+        try:
+            seconds = float(duration)
+            minutes = int(seconds // 60)
+            secs = int(seconds % 60)
+            pieces.append(f"Duration: {minutes:02d}:{secs:02d}")
+        except (TypeError, ValueError):
+            pieces.append(f"Duration: {duration} seconds")
+    if filename:
+        pieces.append(f"Source file: {filename}")
+    return " | ".join(pieces) or "Streaming audio"
+
+
+def _format_duration(duration_seconds: Optional[float]) -> str:
+    if duration_seconds is None:
+        return "??:??"
+    minutes = int(duration_seconds // 60)
+    seconds = int(duration_seconds % 60)
+    return f"{minutes:02d}:{seconds:02d}"
+
+
+def _print_playlist(playlist: List[Dict[str, object]]) -> None:
+    if not playlist:
+        print("Playlist is empty. Add audio files to the server's media directory and refresh.")
+        return
+    print("Available tracks:")
+    for idx, track in enumerate(playlist, start=1):
+        title = track.get("title") or track.get("filename")
+        artist = track.get("artist")
+        album = track.get("album")
+        duration = _format_duration(track.get("duration_seconds"))
+        extra = ""
+        if artist:
+            extra += f" by {artist}"
+        if album:
+            extra += f" ({album})"
+        print(f"[{idx:02d}] {title}{extra} — {duration}")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Music streaming client")
+    parser.add_argument("--host", help="Skip discovery and connect to this host")
+    parser.add_argument("--port", type=int, default=DEFAULT_HTTP_PORT, help="HTTP port of the server")
+    parser.add_argument("--discovery-port", type=int, default=DEFAULT_DISCOVERY_PORT, help="UDP discovery port")
+    parser.add_argument("--timeout", type=float, default=3.0, help="Discovery timeout in seconds")
+    parser.add_argument("--buffer", type=int, default=DEFAULT_BUFFER_BYTES, help="Bytes to buffer before playback")
+    return parser.parse_args()
+
+
+def choose_server(args: argparse.Namespace) -> Optional[ServerInfo]:
+    if args.host:
+        server = ServerInfo(host=args.host, port=args.port, tracks=[])
+        print(f"Connecting directly to {server.host}:{server.port}")
+        return server
+
+    print("Broadcasting discovery packet...")
+    servers = discover_servers(args.discovery_port, args.timeout)
+    if not servers:
+        print("No servers discovered. Ensure the server is running and reachable on the network.")
+        return None
+    if len(servers) == 1:
+        server = servers[0]
+        print(f"Found server at {server.host}:{server.port}")
+        return server
+
+    print("Multiple servers discovered:")
+    for index, server in enumerate(servers, start=1):
+        print(f"  [{index}] {server.host}:{server.port} ({len(server.tracks)} tracks)")
+    while True:
+        selection = input("Select server number (or press Enter to cancel): ").strip()
+        if not selection:
+            return None
+        try:
+            choice = int(selection)
+        except ValueError:
+            print("Enter a numeric choice.")
+            continue
+        if 1 <= choice <= len(servers):
+            return servers[choice - 1]
+        print("Choice out of range.")
+
+
+def interactive_loop(client: MusicStreamClient) -> None:
+    client.refresh_playlist()
+    _print_playlist(client.playlist)
+    help_text = textwrap.dedent(
+        """
+        Commands:
+          list              - show playlist
+          play <n>          - select and stream track number n
+          next / prev       - skip forward/backward using server playlist order
+          refresh           - rescan playlist from server
+          buffer <bytes>    - change local buffer threshold before playback
+          quit              - exit the client
+        """
+    ).strip()
+    print(help_text)
+
+    while True:
+        try:
+            raw = input("music> ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+        if not raw:
+            continue
+        parts = raw.split()
+        command = parts[0].lower()
+
+        if command == "quit" or command == "exit":
+            return
+        if command == "help":
+            print(help_text)
+        elif command == "list":
+            _print_playlist(client.playlist)
+        elif command == "refresh":
+            client.refresh_playlist()
+            _print_playlist(client.playlist)
+        elif command == "buffer" and len(parts) == 2:
+            try:
+                client.buffer_bytes = int(parts[1])
+                print(f"Buffer threshold set to {client.buffer_bytes} bytes")
+            except ValueError:
+                print("Provide an integer number of bytes")
+        elif command in {"next", "prev", "previous"}:
+            next_track = client.next_track() if command == "next" else client.previous_track()
+            if not next_track:
+                print("Playlist is empty")
+                continue
+            print(f"Selected: {next_track.get('title') or next_track.get('filename')}")
+            client.stream(next_track["id"])  # type: ignore[index]
+        elif command == "play" and len(parts) == 2:
+            try:
+                index = int(parts[1]) - 1
+            except ValueError:
+                print("Provide a numeric track number")
+                continue
+            if not (0 <= index < len(client.playlist)):
+                print("Track number out of range")
+                continue
+            track = client.playlist[index]
+            client.select_track(track["id"])  # type: ignore[index]
+            print(f"Playing {track.get('title') or track.get('filename')}")
+            client.stream(track["id"])  # type: ignore[index]
+        else:
+            print("Unknown command. Type 'help' for options.")
+
+
+def main() -> None:
+    args = parse_arguments()
+    server = choose_server(args)
+    if not server:
+        sys.exit(1)
+
+    client = MusicStreamClient(server, buffer_bytes=args.buffer)
+    try:
+        interactive_loop(client)
+    finally:
+        client.session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/Practical/Music Streaming/server.py
+++ b/Practical/Music Streaming/server.py
@@ -1,0 +1,362 @@
+"""Streaming audio server with playlist management and LAN discovery.
+
+Usage::
+    python server.py --media ./media --host 0.0.0.0 --port 8000
+
+The server exposes a JSON API for playlist management and streams audio
+content using chunked HTTP responses suitable for large media files.
+"""
+from __future__ import annotations
+
+import argparse
+import atexit
+import json
+import mimetypes
+import socket
+import threading
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from flask import Flask, Response, abort, jsonify, request
+from mutagen import File as MutagenFile
+
+CHUNK_SIZE = 64 * 1024
+SUPPORTED_EXTENSIONS = {".mp3", ".flac", ".wav", ".ogg", ".m4a", ".aac"}
+
+
+@dataclass
+class Track:
+    """Represents a single audio asset on disk."""
+
+    id: str
+    path: Path
+    title: str
+    artist: Optional[str]
+    album: Optional[str]
+    duration_seconds: Optional[float]
+
+    @property
+    def filename(self) -> str:
+        return self.path.name
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        payload = asdict(self)
+        payload["filename"] = self.filename
+        # Convert Path to string for JSON serialisation
+        payload["path"] = str(self.path)
+        return payload
+
+
+class PlaylistManager:
+    """Thread-safe access to the playlist and currently selected track."""
+
+    def __init__(self, media_root: Path) -> None:
+        self.media_root = media_root
+        self._lock = threading.RLock()
+        self._tracks: List[Track] = []
+        self._current_index: int = 0
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Rescan the media directory for playable files."""
+        with self._lock:
+            candidates = sorted(
+                (
+                    path
+                    for ext in SUPPORTED_EXTENSIONS
+                    for path in self.media_root.rglob(f"*{ext}")
+                ),
+                key=lambda p: (p.parent.name.lower(), p.name.lower()),
+            )
+            tracks: List[Track] = []
+            for idx, path in enumerate(candidates):
+                metadata = self._extract_metadata(path)
+                tracks.append(
+                    Track(
+                        id=f"track-{idx}",
+                        path=path,
+                        title=metadata.get("title") or path.stem,
+                        artist=metadata.get("artist"),
+                        album=metadata.get("album"),
+                        duration_seconds=metadata.get("duration"),
+                    )
+                )
+            self._tracks = tracks
+            if self._current_index >= len(self._tracks):
+                self._current_index = 0 if self._tracks else -1
+
+    def _extract_metadata(self, path: Path) -> Dict[str, Optional[str]]:
+        data: Dict[str, Optional[str]] = {
+            "title": None,
+            "artist": None,
+            "album": None,
+            "duration": None,
+        }
+        try:
+            audio = MutagenFile(path)
+        except Exception:
+            return data
+        if not audio:
+            return data
+        info = getattr(audio, "info", None)
+        if info and getattr(info, "length", None):
+            data["duration"] = float(info.length)
+        tags = getattr(audio, "tags", {}) or {}
+        for key in ("TIT2", "TITLE"):
+            if key in tags:
+                data["title"] = self._read_mutagen_tag(tags[key])
+                break
+        for key in ("TPE1", "ARTIST"):
+            if key in tags:
+                data["artist"] = self._read_mutagen_tag(tags[key])
+                break
+        for key in ("TALB", "ALBUM"):
+            if key in tags:
+                data["album"] = self._read_mutagen_tag(tags[key])
+                break
+        return data
+
+    @staticmethod
+    def _read_mutagen_tag(tag: object) -> Optional[str]:
+        try:
+            if hasattr(tag, "text"):
+                values = tag.text
+                if isinstance(values, (list, tuple)):
+                    return str(values[0]) if values else None
+                return str(values)
+            return str(tag)
+        except Exception:
+            return None
+
+    def all_tracks(self) -> List[Track]:
+        with self._lock:
+            return list(self._tracks)
+
+    def current_track(self) -> Optional[Track]:
+        with self._lock:
+            if 0 <= self._current_index < len(self._tracks):
+                return self._tracks[self._current_index]
+            return None
+
+    def select(self, track_id: str) -> Track:
+        with self._lock:
+            for idx, track in enumerate(self._tracks):
+                if track.id == track_id:
+                    self._current_index = idx
+                    return track
+        raise KeyError(f"Unknown track id: {track_id}")
+
+    def next(self) -> Optional[Track]:
+        with self._lock:
+            if not self._tracks:
+                return None
+            self._current_index = (self._current_index + 1) % len(self._tracks)
+            return self._tracks[self._current_index]
+
+    def previous(self) -> Optional[Track]:
+        with self._lock:
+            if not self._tracks:
+                return None
+            self._current_index = (self._current_index - 1) % len(self._tracks)
+            return self._tracks[self._current_index]
+
+    def get(self, track_id: str) -> Track:
+        with self._lock:
+            for track in self._tracks:
+                if track.id == track_id:
+                    return track
+        raise KeyError(f"Unknown track id: {track_id}")
+
+
+class DiscoveryResponder:
+    """Responds to LAN discovery pings via UDP."""
+
+    def __init__(
+        self,
+        playlist: PlaylistManager,
+        http_host: str,
+        http_port: int,
+        discovery_port: int,
+        advertised_host: Optional[str] = None,
+    ) -> None:
+        self.playlist = playlist
+        self.http_host = http_host
+        self.http_port = http_port
+        self.discovery_port = discovery_port
+        self.advertised_host = advertised_host or self._resolve_host(http_host)
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    @staticmethod
+    def _resolve_host(host: str) -> str:
+        if host and host != "0.0.0.0":
+            return host
+        probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            probe.connect(("8.8.8.8", 80))
+            resolved = probe.getsockname()[0]
+        except OSError:
+            resolved = "127.0.0.1"
+        finally:
+            probe.close()
+        return resolved
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(target=self._serve, name="discovery", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        # poke the socket to unblock
+        try:
+            poke = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            poke.sendto(b"", ("127.0.0.1", self.discovery_port))
+            poke.close()
+        except OSError:
+            pass
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+
+    def _serve(self) -> None:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("", self.discovery_port))
+        with sock:
+            while not self._stop.is_set():
+                try:
+                    data, addr = sock.recvfrom(1024)
+                except OSError:
+                    break
+                if self._stop.is_set():
+                    break
+                if not data:
+                    continue
+                if data.strip().upper() != b"MUSIC_STREAM_DISCOVERY":
+                    continue
+                payload = {
+                    "host": self.advertised_host,
+                    "port": self.http_port,
+                    "tracks": [track.to_dict() for track in self.playlist.all_tracks()],
+                }
+                try:
+                    sock.sendto(json.dumps(payload).encode("utf-8"), addr)
+                except OSError:
+                    continue
+
+
+def create_app(playlist: PlaylistManager) -> Flask:
+    app = Flask(__name__)
+
+    @app.get("/api/health")
+    def health() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/api/playlist")
+    def get_playlist() -> Response:
+        tracks = [track.to_dict() for track in playlist.all_tracks()]
+        current = playlist.current_track()
+        payload = {
+            "tracks": tracks,
+            "current": current.to_dict() if current else None,
+        }
+        return jsonify(payload)
+
+    @app.post("/api/playlist/refresh")
+    def refresh_playlist() -> Response:
+        playlist.refresh()
+        return jsonify({"ok": True, "count": len(playlist.all_tracks())})
+
+    @app.post("/api/playlist/select")
+    def select_track() -> Response:
+        data = request.get_json(force=True, silent=True) or {}
+        track_id = data.get("id")
+        if not track_id:
+            abort(400, "Missing 'id' in payload")
+        try:
+            track = playlist.select(track_id)
+        except KeyError:
+            abort(404, f"Unknown track id: {track_id}")
+        return jsonify({"selected": track.to_dict()})
+
+    @app.post("/api/playlist/next")
+    def next_track() -> Response:
+        track = playlist.next()
+        return jsonify({"current": track.to_dict() if track else None})
+
+    @app.post("/api/playlist/previous")
+    def previous_track() -> Response:
+        track = playlist.previous()
+        return jsonify({"current": track.to_dict() if track else None})
+
+    @app.get("/api/stream/<track_id>")
+    def stream(track_id: str):
+        try:
+            track = playlist.get(track_id)
+        except KeyError:
+            abort(404, "Track not found")
+
+        if not track.path.exists():
+            abort(404, "File missing")
+
+        mimetype, _ = mimetypes.guess_type(str(track.path))
+        mimetype = mimetype or "application/octet-stream"
+
+        def generate() -> Iterable[bytes]:
+            with track.path.open("rb") as handle:
+                while True:
+                    chunk = handle.read(CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    yield chunk
+
+        headers = {
+            "Content-Disposition": f"inline; filename={track.filename}",
+            "X-Track-Title": track.title or track.filename,
+        }
+        if track.artist:
+            headers["X-Track-Artist"] = track.artist
+        if track.album:
+            headers["X-Track-Album"] = track.album
+        if track.duration_seconds:
+            headers["X-Track-Duration"] = str(track.duration_seconds)
+
+        return Response(generate(), mimetype=mimetype, headers=headers)
+
+    return app
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audio streaming server")
+    parser.add_argument("--media", type=Path, default=Path("media"), help="Directory containing audio files")
+    parser.add_argument("--host", default="0.0.0.0", help="Host/interface to bind the HTTP server")
+    parser.add_argument("--port", type=int, default=8000, help="Port for the HTTP server")
+    parser.add_argument("--discovery-port", type=int, default=9999, help="UDP discovery port")
+    parser.add_argument("--debug", action="store_true", help="Enable Flask debug mode")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    media = args.media
+    media.mkdir(parents=True, exist_ok=True)
+
+    playlist = PlaylistManager(media)
+    app = create_app(playlist)
+
+    discovery = DiscoveryResponder(playlist, args.host, args.port, args.discovery_port)
+    discovery.start()
+    atexit.register(discovery.stop)
+
+    print(f"Audio streaming server ready on http://{discovery.advertised_host}:{args.port}")
+    print(f"Serving media from: {media.resolve()}")
+    if not playlist.all_tracks():
+        print("No audio tracks found yet. Drop MP3/FLAC/WAV files into the media directory.")
+
+    app.run(host=args.host, port=args.port, debug=args.debug, threaded=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/Practical/README.md
+++ b/Practical/README.md
@@ -60,6 +60,7 @@ Brief synopses; dive into each folder for details.
 | ImgToASCII | Convert images to ASCII art (CLI + Tk GUI). | Pillow, NumPy, Tkinter |
 | IP Tracking visualization | Fetch IP geolocation data & plot interactive map. | requests, pandas, plotly, tqdm |
 | Markov Chain Sentence Generator | Train simple Markov model over corpora (CLI + GUI). | Dataclasses, Tkinter |
+| Music Streaming | LAN audio streaming server/client with discovery + buffering. | Flask, mutagen, FFmpeg |
 | Paint (clone) | Lightweight Tk canvas paint app with palette + save. | Tkinter, Pillow (optional) |
 | PDF Tagger | Add arbitrary JSON metadata tags to PDFs. | pypdf |
 | Port Scanner | Concurrent TCP port scanning (CLI + GUI + export). | sockets, ThreadPoolExecutor, Tkinter |

--- a/Practical/requirements.txt
+++ b/Practical/requirements.txt
@@ -11,6 +11,7 @@ plotly>=5.22,<5.23          # Interactive geo plots for IP tracking
 # Web / networking
 Flask>=3.0,<3.1             # Imageboard web app
 requests>=2.32,<2.33        # IP tracking API calls
+mutagen>=1.47,<1.48         # Audio metadata for music streaming server
 
 # Data processing / progress
 tqdm>=4.66,<4.67            # Optional progress bars (IP tracking) – optional but recommended

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ While this is a personal project, the principles behind it are universal. If you
 | 10 | To-Do List Application (Web app or CLI) | [View Solution](./Practical/ToDoList-CLI/) |
 | 11 | Verlet Integration (Verlet Cloth) | Not Yet |
 | 12 | TCP/UDP Chat Server + Client | Not Yet |
-| 13 | Music Streaming | Not Yet |
+| 13 | Music Streaming | [View Solution](./Practical/Music%20Streaming/) |
 | 14 | Shazam | Not Yet |
 | 15 | Chatbot (with conversation retention) | Not Yet |
 | 16 | Curses Text Editor (with Emacs /Vim Keybindings) | Not Yet |


### PR DESCRIPTION
## Summary
- add a Flask-based music streaming server with playlist management, UDP discovery, and chunked audio responses
- implement an interactive CLI client that discovers the server, streams audio with buffering, and falls back to saving files if ffplay is unavailable
- document setup/deployment steps and mark the practical music streaming challenge as solved while recording the mutagen dependency

## Testing
- python -m compileall 'Practical/Music Streaming'

------
https://chatgpt.com/codex/tasks/task_b_68d6c29168388329aa0a616e31902439