### PR TITLE
Add ID3 reader utility with CLI, GUI, and tests

### DIFF
--- a/Practical/ID3 Reader/README.md
+++ b/Practical/ID3 Reader/README.md
@@ -1,0 +1,56 @@
+# ID3 Reader
+
+A lightweight toolkit for inspecting and exporting MP3 metadata. The reader understands the two
+most common tagging families – **ID3v1 (and v1.1 track extensions)** and **ID3v2.x (2.2–2.4, tested with v2.3)** – and
+normalises their fields into a single friendly view. Use the CLI to print summaries or export JSON/CSV, or launch the Tk GUI
+for an interactive browser.
+
+## Features
+
+- Detects ID3v1/v1.1 footers and ID3v2.x headers in the same file.
+- Normalises common fields (`title`, `artist`, `album`, `year`, `genre`, `track`, `album_artist`, `comment`).
+- Provides both command line and Tkinter GUI frontends.
+- Exports batches of MP3 tags to JSON or CSV for cataloguing.
+- Includes pytest fixtures that validate ID3v1 and ID3v2 parsing without requiring large audio samples.
+
+## Quick start
+
+```bash
+python "Practical/ID3 Reader/id3_reader.py" example.mp3
+```
+
+Optional arguments:
+
+```bash
+python "Practical/ID3 Reader/id3_reader.py" track1.mp3 track2.mp3 \
+    --json tags.json --csv tags.csv --fields title artist album year
+```
+
+- `--json` / `--csv` export all parsed tracks.
+- `--fields` limits console output to a subset of fields (defaults to all normalised tags).
+
+### GUI browser
+
+```bash
+python "Practical/ID3 Reader/gui.py"
+```
+
+Use **Open File** to pick an MP3. Metadata appears in a table and can be exported to JSON/CSV from the toolbar.
+
+## Implementation notes
+
+- ID3v2 parsing uses [`mutagen`](https://mutagen.readthedocs.io/). Text frames are converted to UTF‑8 strings and grouped by
+  frame identifier.
+- ID3v1/v1.1 parsing is handled manually so that we can surface the version number even when no ID3v2 header exists.
+- When both versions are present, ID3v2 values win and ID3v1 fills in any missing fields.
+
+## Testing
+
+From the repository root:
+
+```bash
+pytest Practical/ID3\ Reader/tests
+```
+
+The fixtures synthesise small MP3 files containing only metadata blocks to keep the repository lightweight while still
+covering ID3v1 and ID3v2 behaviour.

--- a/Practical/ID3 Reader/gui.py
+++ b/Practical/ID3 Reader/gui.py
@@ -1,0 +1,121 @@
+"""Simple Tkinter GUI for the ID3 Reader."""
+from __future__ import annotations
+
+import importlib.util
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+from typing import Optional
+
+MODULE_PATH = Path(__file__).resolve().with_name("id3_reader.py")
+SPEC = importlib.util.spec_from_file_location("id3_reader_gui_helper", MODULE_PATH)
+id3_reader = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(id3_reader)  # type: ignore[arg-type]
+
+ID3Metadata = id3_reader.ID3Metadata
+export_csv = id3_reader.export_csv
+export_json = id3_reader.export_json
+parse_id3 = id3_reader.parse_id3
+
+
+class ID3ReaderApp(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("ID3 Reader")
+        self.geometry("680x420")
+
+        self.metadata: Optional[ID3Metadata] = None
+
+        self._build_widgets()
+
+    def _build_widgets(self) -> None:
+        toolbar = tk.Frame(self)
+        toolbar.pack(fill=tk.X, padx=6, pady=4)
+
+        open_btn = tk.Button(toolbar, text="Open File…", command=self.open_file)
+        open_btn.pack(side=tk.LEFT, padx=(0, 6))
+
+        export_json_btn = tk.Button(toolbar, text="Export JSON", command=self.export_json)
+        export_json_btn.pack(side=tk.LEFT, padx=(0, 6))
+
+        export_csv_btn = tk.Button(toolbar, text="Export CSV", command=self.export_csv)
+        export_csv_btn.pack(side=tk.LEFT)
+
+        self.tree = ttk.Treeview(self, columns=("value",), show="tree")
+        self.tree.pack(fill=tk.BOTH, expand=True, padx=6, pady=(0, 6))
+
+        self.status = tk.StringVar(value="Select an MP3 file to inspect.")
+        status_bar = tk.Label(self, textvariable=self.status, anchor="w")
+        status_bar.pack(fill=tk.X, padx=6, pady=(0, 6))
+
+    def open_file(self) -> None:
+        file_path = filedialog.askopenfilename(
+            title="Open MP3", filetypes=(("MP3 files", "*.mp3"), ("All files", "*.*"))
+        )
+        if not file_path:
+            return
+        try:
+            self.metadata = parse_id3(file_path)
+        except Exception as exc:  # noqa: BLE001 - display to user
+            messagebox.showerror("ID3 Reader", str(exc))
+            return
+        self._populate_tree(self.metadata)
+        versions = ", ".join(self.metadata.versions)
+        self.status.set(f"Loaded {Path(file_path).name} ({versions}).")
+
+    def export_json(self) -> None:
+        if not self._ensure_metadata():
+            return
+        output_path = filedialog.asksaveasfilename(
+            title="Export JSON", defaultextension=".json", filetypes=(("JSON", "*.json"),)
+        )
+        if not output_path:
+            return
+        export_json([self.metadata], output_path)
+        self.status.set(f"Exported JSON to {output_path}.")
+
+    def export_csv(self) -> None:
+        if not self._ensure_metadata():
+            return
+        output_path = filedialog.asksaveasfilename(
+            title="Export CSV", defaultextension=".csv", filetypes=(("CSV", "*.csv"),)
+        )
+        if not output_path:
+            return
+        export_csv([self.metadata], output_path)
+        self.status.set(f"Exported CSV to {output_path}.")
+
+    def _populate_tree(self, metadata: ID3Metadata) -> None:
+        self.tree.delete(*self.tree.get_children())
+
+        root_id = self.tree.insert("", tk.END, text=Path(metadata.file_path).name)
+        versions_id = self.tree.insert(root_id, tk.END, text=f"Versions: {', '.join(metadata.versions)}")
+        self.tree.item(root_id, open=True)
+        self.tree.item(versions_id, open=True)
+
+        tags_id = self.tree.insert(root_id, tk.END, text="Normalised Tags")
+        for key, value in sorted(metadata.tags.items()):
+            self.tree.insert(tags_id, tk.END, text=f"{key}: {value}")
+
+        raw_id = self.tree.insert(root_id, tk.END, text="Raw Frames")
+        for frame_id, values in sorted(metadata.raw_frames.items()):
+            frame_node = self.tree.insert(raw_id, tk.END, text=frame_id)
+            for value in values:
+                display = value if len(value) < 80 else value[:77] + "…"
+                self.tree.insert(frame_node, tk.END, text=display)
+
+    def _ensure_metadata(self) -> bool:
+        if self.metadata is None:
+            messagebox.showwarning("ID3 Reader", "Load a file before exporting.")
+            return False
+        return True
+
+
+def launch() -> None:
+    app = ID3ReaderApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    launch()

--- a/Practical/ID3 Reader/id3_reader.py
+++ b/Practical/ID3 Reader/id3_reader.py
@@ -1,0 +1,377 @@
+"""ID3 Reader CLI utilities.
+
+Parses ID3v1/v1.1 and ID3v2 metadata from MP3 files and offers helpers for
+formatting and exporting the discovered tags. The module is importable for use
+in other scripts but can also be executed directly to inspect one or more MP3
+files.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from mutagen.id3 import ID3, ID3NoHeaderError
+
+SUPPORTED_VERSIONS = ("ID3v1", "ID3v1.1", "ID3v2.2", "ID3v2.3", "ID3v2.4")
+
+_FRAME_ID_TO_FIELD = {
+    "TIT1": "grouping",
+    "TIT2": "title",
+    "TIT3": "subtitle",
+    "TALB": "album",
+    "TPE1": "artist",
+    "TPE2": "album_artist",
+    "TPE3": "conductor",
+    "TPE4": "remixer",
+    "TRCK": "track",
+    "TPOS": "disc",
+    "TDRC": "year",
+    "TYER": "year",
+    "TDAT": "date",
+    "TCON": "genre",
+    "COMM": "comment",
+    "USLT": "lyrics",
+}
+
+_ID3V1_GENRES = [
+    "Blues",
+    "Classic Rock",
+    "Country",
+    "Dance",
+    "Disco",
+    "Funk",
+    "Grunge",
+    "Hip-Hop",
+    "Jazz",
+    "Metal",
+    "New Age",
+    "Oldies",
+    "Other",
+    "Pop",
+    "R&B",
+    "Rap",
+    "Reggae",
+    "Rock",
+    "Techno",
+    "Industrial",
+    "Alternative",
+    "Ska",
+    "Death Metal",
+    "Pranks",
+    "Soundtrack",
+    "Euro-Techno",
+    "Ambient",
+    "Trip-Hop",
+    "Vocal",
+    "Jazz+Funk",
+    "Fusion",
+    "Trance",
+    "Classical",
+    "Instrumental",
+    "Acid",
+    "House",
+    "Game",
+    "Sound Clip",
+    "Gospel",
+    "Noise",
+    "AlternRock",
+    "Bass",
+    "Soul",
+    "Punk",
+    "Space",
+    "Meditative",
+    "Instrumental Pop",
+    "Instrumental Rock",
+    "Ethnic",
+    "Gothic",
+    "Darkwave",
+    "Techno-Industrial",
+    "Electronic",
+    "Pop-Folk",
+    "Eurodance",
+    "Dream",
+    "Southern Rock",
+    "Comedy",
+    "Cult",
+    "Gangsta",
+    "Top 40",
+    "Christian Rap",
+    "Pop/Funk",
+    "Jungle",
+    "Native American",
+    "Cabaret",
+    "New Wave",
+    "Psychadelic",
+    "Rave",
+    "Showtunes",
+    "Trailer",
+    "Lo-Fi",
+    "Tribal",
+    "Acid Punk",
+    "Acid Jazz",
+    "Polka",
+    "Retro",
+    "Musical",
+    "Rock & Roll",
+    "Hard Rock",
+]
+
+
+@dataclass
+class ID3Metadata:
+    """Normalised metadata from one MP3 file."""
+
+    file_path: Path
+    versions: List[str] = field(default_factory=list)
+    tags: Dict[str, str] = field(default_factory=dict)
+    raw_frames: Dict[str, List[str]] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Convert to a JSON-serialisable dictionary."""
+
+        return {
+            "file_path": str(self.file_path),
+            "versions": self.versions,
+            "tags": self.tags,
+            "raw_frames": self.raw_frames,
+        }
+
+
+def parse_id3(file_path: Path | str) -> ID3Metadata:
+    """Parse ID3 metadata from *file_path*.
+
+    Args:
+        file_path: Path to an MP3 file.
+
+    Returns:
+        An :class:`ID3Metadata` instance.
+
+    Raises:
+        FileNotFoundError: If *file_path* does not exist.
+        ValueError: If no ID3 metadata is found.
+    """
+
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"{path} does not exist")
+
+    metadata = ID3Metadata(file_path=path)
+
+    _parse_id3v2(path, metadata)
+    _parse_id3v1(path, metadata)
+
+    if not metadata.versions:
+        raise ValueError(f"No ID3 tags found in {path}")
+
+    # Deduplicate versions while preserving order.
+    seen = set()
+    ordered_versions = []
+    for version in metadata.versions:
+        if version not in seen:
+            ordered_versions.append(version)
+            seen.add(version)
+    metadata.versions = ordered_versions
+
+    return metadata
+
+
+def _parse_id3v2(path: Path, metadata: ID3Metadata) -> None:
+    try:
+        tag = ID3(path)
+    except ID3NoHeaderError:
+        return
+
+    version_tuple = getattr(tag, "version", None)
+    if version_tuple and len(version_tuple) >= 2:
+        version_name = f"ID3v{version_tuple[0]}.{version_tuple[1]}"
+        metadata.versions.append(version_name)
+
+    for frame in tag.values():
+        frame_id = getattr(frame, "FrameID", None) or getattr(frame, "__name__", "Unknown")
+        values = _extract_frame_text(frame)
+        if not values:
+            continue
+        metadata.raw_frames.setdefault(frame_id, []).extend(values)
+
+        field = _FRAME_ID_TO_FIELD.get(frame_id)
+        if field:
+            joined = "; ".join(values)
+            metadata.tags[field] = joined
+
+
+def _parse_id3v1(path: Path, metadata: ID3Metadata) -> None:
+    if path.stat().st_size < 128:
+        return
+
+    with path.open("rb") as fh:
+        fh.seek(-128, 2)
+        footer = fh.read(128)
+
+    if len(footer) != 128 or not footer.startswith(b"TAG"):
+        return
+
+    title = footer[3:33].rstrip(b"\x00 ").decode("latin-1", errors="replace")
+    artist = footer[33:63].rstrip(b"\x00 ").decode("latin-1", errors="replace")
+    album = footer[63:93].rstrip(b"\x00 ").decode("latin-1", errors="replace")
+    year = footer[93:97].rstrip(b"\x00 ").decode("latin-1", errors="replace")
+    comment = footer[97:127]
+    genre_index = footer[127]
+
+    track = None
+    if comment[-2] == 0:
+        track = comment[-1]
+        comment = comment[:-2]
+    comment_text = comment.rstrip(b"\x00 ").decode("latin-1", errors="replace")
+
+    version = "ID3v1.1" if track else "ID3v1"
+    metadata.versions.append(version)
+
+    id3v1_tags = {
+        "title": title,
+        "artist": artist,
+        "album": album,
+        "year": year,
+        "comment": comment_text,
+    }
+    if track:
+        id3v1_tags["track"] = str(track)
+
+    if genre_index < len(_ID3V1_GENRES):
+        id3v1_tags["genre"] = _ID3V1_GENRES[genre_index]
+    else:
+        id3v1_tags["genre"] = str(genre_index)
+
+    metadata.raw_frames.setdefault("ID3v1", []).append(json.dumps(id3v1_tags))
+
+    for key, value in id3v1_tags.items():
+        metadata.tags.setdefault(key, value)
+
+
+def _extract_frame_text(frame) -> List[str]:
+    values: List[str] = []
+    if hasattr(frame, "text"):
+        texts = frame.text
+        if isinstance(texts, (list, tuple)):
+            for entry in texts:
+                values.append(str(entry))
+        else:
+            values.append(str(texts))
+    elif frame.FrameID == "COMM":
+        values.append(str(getattr(frame, "text", "")))
+    elif hasattr(frame, "url"):
+        values.append(str(frame.url))
+    return [value for value in (v.strip() for v in values) if value]
+
+
+def export_json(metadata: Sequence[ID3Metadata], output_path: Path | str) -> None:
+    path = Path(output_path)
+    data = [item.to_dict() for item in metadata]
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def export_csv(metadata: Sequence[ID3Metadata], output_path: Path | str, *, fields: Optional[Sequence[str]] = None) -> None:
+    path = Path(output_path)
+    if fields is None:
+        fields = _collect_all_fields(metadata)
+
+    rows = []
+    for item in metadata:
+        row = {field: item.tags.get(field, "") for field in fields}
+        row["file_path"] = str(item.file_path)
+        row["versions"] = ", ".join(item.versions)
+        rows.append(row)
+
+    fieldnames = ["file_path", "versions", *fields]
+
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _collect_all_fields(metadata: Iterable[ID3Metadata]) -> List[str]:
+    fields = []
+    for item in metadata:
+        for key in item.tags:
+            if key not in fields:
+                fields.append(key)
+    return fields
+
+
+def _format_for_cli(metadata: Sequence[ID3Metadata], fields: Optional[Sequence[str]]) -> str:
+    if not metadata:
+        return "No files parsed."
+
+    if fields is None:
+        fields = _collect_all_fields(metadata)
+
+    column_widths: Dict[str, int] = {
+        "file_path": max(len("File"), *(len(str(item.file_path)) for item in metadata)),
+        "versions": max(len("Versions"), *(len(", ".join(item.versions)) for item in metadata)),
+    }
+    for field in fields:
+        column_widths[field] = max(len(field), *(len(item.tags.get(field, "")) for item in metadata))
+
+    headers = [
+        ("File", column_widths["file_path"]),
+        ("Versions", column_widths["versions"]),
+        *[(field, column_widths[field]) for field in fields],
+    ]
+
+    lines = []
+    header_line = "  ".join(title.ljust(width) for title, width in headers)
+    lines.append(header_line)
+    lines.append("  ".join("-" * width for _, width in headers))
+
+    for item in metadata:
+        row_values = [
+            str(item.file_path).ljust(column_widths["file_path"]),
+            ", ".join(item.versions).ljust(column_widths["versions"]),
+        ]
+        for field in fields:
+            row_values.append(item.tags.get(field, "").ljust(column_widths[field]))
+        lines.append("  ".join(row_values))
+
+    return "\n".join(lines)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inspect ID3 metadata and export results.")
+    parser.add_argument("files", nargs="+", help="One or more MP3 files to inspect.")
+    parser.add_argument("--json", dest="json_path", help="Export parsed tags to this JSON file.")
+    parser.add_argument("--csv", dest="csv_path", help="Export parsed tags to this CSV file.")
+    parser.add_argument(
+        "--fields",
+        nargs="*",
+        help="Limit console output to these normalised tag fields (defaults to all discovered fields).",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    metadata_items: List[ID3Metadata] = []
+    for file_arg in args.files:
+        try:
+            metadata_items.append(parse_id3(file_arg))
+        except (FileNotFoundError, ValueError) as exc:
+            parser.error(str(exc))
+
+    print(_format_for_cli(metadata_items, args.fields))
+
+    if args.json_path:
+        export_json(metadata_items, args.json_path)
+    if args.csv_path:
+        export_csv(metadata_items, args.csv_path, fields=args.fields)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Practical/ID3 Reader/tests/test_id3_reader.py
+++ b/Practical/ID3 Reader/tests/test_id3_reader.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import json
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "id3_reader.py"
+SPEC = importlib.util.spec_from_file_location("id3_reader", MODULE_PATH)
+id3_reader = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = id3_reader
+SPEC.loader.exec_module(id3_reader)  # type: ignore[arg-type]
+
+parse_id3 = id3_reader.parse_id3
+export_json = id3_reader.export_json
+export_csv = id3_reader.export_csv
+
+
+def _write_id3v1_file(path: Path) -> None:
+    title = "Test Title".ljust(30, " ")
+    artist = "Test Artist".ljust(30, " ")
+    album = "Test Album".ljust(30, " ")
+    year = "1999"
+    comment = ("Comment" + "\x00" * 20).ljust(30, "\x00")
+    genre = bytes([17])  # Rock
+    data = b"TAG" + title.encode("latin-1") + artist.encode("latin-1") + album.encode("latin-1")
+    data += year.encode("latin-1") + comment.encode("latin-1") + genre
+    path.write_bytes(data)
+
+
+def _syncsafe(size: int) -> bytes:
+    return bytes(
+        [
+            (size >> 21) & 0x7F,
+            (size >> 14) & 0x7F,
+            (size >> 7) & 0x7F,
+            size & 0x7F,
+        ]
+    )
+
+
+def _text_frame(frame_id: str, text: str) -> bytes:
+    payload = b"\x00" + text.encode("latin-1")
+    header = frame_id.encode("ascii") + len(payload).to_bytes(4, "big") + b"\x00\x00"
+    return header + payload
+
+
+def _comment_frame(text: str) -> bytes:
+    payload = b"\x00eng" + b"\x00" + text.encode("latin-1")
+    header = b"COMM" + len(payload).to_bytes(4, "big") + b"\x00\x00"
+    return header + payload
+
+
+def _write_id3v2_file(path: Path) -> None:
+    frames = b"".join(
+        [
+            _text_frame("TIT2", "V2 Title"),
+            _text_frame("TPE1", "V2 Artist"),
+            _text_frame("TALB", "V2 Album"),
+            _text_frame("TDRC", "2024"),
+            _text_frame("TCON", "Electronic"),
+            _text_frame("TRCK", "4"),
+            _comment_frame("ID3v2 comment"),
+        ]
+    )
+    header = b"ID3" + bytes([3, 0, 0]) + _syncsafe(len(frames))
+    path.write_bytes(header + frames)
+
+
+def test_parse_id3v1(tmp_path: Path) -> None:
+    mp3_path = tmp_path / "id3v1.mp3"
+    _write_id3v1_file(mp3_path)
+
+    metadata = parse_id3(mp3_path)
+
+    assert "ID3v1" in metadata.versions[0]
+    assert metadata.tags["title"] == "Test Title"
+    assert metadata.tags["genre"] == "Rock"
+
+
+def test_parse_id3v2(tmp_path: Path) -> None:
+    mp3_path = tmp_path / "id3v2.mp3"
+    _write_id3v2_file(mp3_path)
+
+    metadata = parse_id3(mp3_path)
+
+    assert "ID3v2" in metadata.versions[0]
+    assert metadata.tags["title"] == "V2 Title"
+    assert metadata.tags["artist"] == "V2 Artist"
+    assert metadata.tags["year"] == "2024"
+    assert metadata.tags["comment"] == "ID3v2 comment"
+
+
+def test_export_json_and_csv(tmp_path: Path) -> None:
+    mp3_path = tmp_path / "sample.mp3"
+    _write_id3v2_file(mp3_path)
+
+    metadata = parse_id3(mp3_path)
+    json_path = tmp_path / "tags.json"
+    csv_path = tmp_path / "tags.csv"
+
+    export_json([metadata], json_path)
+    export_csv([metadata], csv_path)
+
+    json_content = json.loads(json_path.read_text(encoding="utf-8"))
+    assert json_content[0]["tags"]["title"] == "V2 Title"
+
+    csv_lines = csv_path.read_text(encoding="utf-8").splitlines()
+    assert csv_lines[0].startswith("file_path,versions")
+    assert "V2 Title" in csv_lines[1]

--- a/Practical/README.md
+++ b/Practical/README.md
@@ -70,6 +70,7 @@ Brief synopses; dive into each folder for details.
 | Vector Product | Vector math utilities & 3D plotting. | matplotlib |
 | Old School cringe | Retro rotating cube + assets demo. | matplotlib.animation, NumPy |
 | Graphing Calculator | Basic expression plotting GUI. | Tkinter, eval sandboxing |
+| ID3 Reader | Inspect MP3 ID3 tags, export JSON/CSV, includes Tk GUI. | mutagen, Tkinter |
 | Paint / Clone | Simple drawing & export. | Tkinter |
 
 > Some tiny folders (e.g. helper assets) may not appear above—table focuses on active code artifacts.

--- a/Practical/requirements.txt
+++ b/Practical/requirements.txt
@@ -18,6 +18,9 @@ tqdm>=4.66,<4.67            # Optional progress bars (IP tracking) – optional 
 # Imaging
 Pillow>=10.4,<10.5          # Image handling (imageboard, ASCII converter, seam carving GUI thumbnails)
 
+# Audio metadata
+mutagen>=1.47,<1.48         # ID3 Reader MP3 tag parser
+
 # PDF handling (PDF Tagger)
 pypdf>=4.3,<4.4             # Preferred modern PDF library
 # PyPDF3  (legacy fallback) not listed intentionally; install manually only if needed

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ While this is a personal project, the principles behind it are universal. If you
 | 18 | Image to ASCII Art | [View Solution](./Practical/ImgToASCII/) |
 | 19 | Booru (Image Board) Image Downloader | [View Solution](./Practical/Booru%20Imageboard%20Downloader/) |
 | 20 | Image Converter | Not Yet |
-| 21 | ID3 Reader | Not Yet |
+| 21 | ID3 Reader | [View Solution](./Practical/ID3%20Reader/) |
 | 22 | Sound Synthesis (Sine square sawtooth etc...) ("Fuck You" mode: Realtime MIDI Playback with Custom instruments) | Not Yet |
 | 23 | C++ IDE Plugin for Sublime/Atom (Auto-Complete Go-To Symbol Declaration and Definition using Clang's AST) | Not Yet |
 | 24 | Simple Version Control supporting checkout commit (with commit message) unlocking and per-file configuration of number of revisions kept | Not Yet |

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ requests>=2.32,<2.33          # External API calls (IP tracking)
 # Documents / Files
 #############################
 pypdf>=4.3,<4.4               # PDF Tagger metadata operations
+mutagen>=1.47,<1.48           # MP3/ID3 parsing utilities (ID3 Reader)
 
 #############################
 # Visualization / 3D / UI (Optional)


### PR DESCRIPTION
## Summary
- add an ID3 Reader subproject with CLI helpers for normalising and exporting MP3 metadata
- provide a Tkinter GUI frontend and documentation describing supported ID3 versions and usage
- add pytest-backed fixtures plus dependency updates for mutagen

## Testing
- pytest Practical/ID3 Reader/tests

------
https://chatgpt.com/codex/tasks/task_b_68d6c2a08f20832986c3d5f2b4402dc6