### PR TITLE
Add simple VCS CLI with documentation and tests

### DIFF
--- a/Practical/README.md
+++ b/Practical/README.md
@@ -66,6 +66,7 @@ Brief synopses; dive into each folder for details.
 | Producer Consumer | Modernized concurrency patterns (Py/Java/C/C++ examples). | threading, semaphores, queues |
 | Radix Base Converter | Arbitrary base conversion (2..36) with GUI. | Pure Python, Tkinter |
 | Seam Carving | Content-aware image resizing (CLI + GUI + progress). | OpenCV, NumPy, Pillow (GUI) |
+| Simple VCS | File-based version control with per-file revision caps, locking, and CLI. | Python stdlib |
 | ToDoList-CLI | File‑backed todo manager (undo, prioritize, search). | Dataclasses, color output |
 | Vector Product | Vector math utilities & 3D plotting. | matplotlib |
 | Old School cringe | Retro rotating cube + assets demo. | matplotlib.animation, NumPy |

--- a/Practical/Simple VCS/README.md
+++ b/Practical/Simple VCS/README.md
@@ -1,0 +1,90 @@
+# Simple Version Control
+
+A lightweight, file-oriented version control system implemented in Python. It fulfils the `/g/` programming challenge requirement for "Simple Version Control supporting checkout commit (with commit message) unlocking and per-file configuration of number of revisions kept".
+
+## Features
+
+- File-level commit history with commit messages.
+- Configurable revision limits per tracked file; older revisions are pruned automatically.
+- Locking semantics to prevent accidental commits on protected files.
+- Checkout command to restore any stored revision back into the working directory.
+- Diff and log commands for quick inspection of file history.
+- JSON-based repository metadata stored in `.svc/config.json` plus on-disk revision snapshots.
+- Tested with `pytest`, covering commit/checkout cycles, revision pruning, locks, and CLI inspection commands.
+
+## Command Overview
+
+All commands are available through the CLI entry point: `python -m simple_vcs <command>`. Pass `--path PATH` to target a repository outside the current directory.
+
+### `init`
+
+Initialises a new repository by creating `.svc/config.json` and the revision store.
+
+```bash
+python -m simple_vcs init
+```
+
+Use `--force` to overwrite an existing repository configuration.
+
+### `commit`
+
+Creates a new revision for one or more files and stores their contents alongside a commit message.
+
+```bash
+python -m simple_vcs commit -m "Describe the change" path/to/file.txt
+```
+
+### `checkout`
+
+Restores a committed revision into the working tree. If `--revision` is omitted, the latest revision is used.
+
+```bash
+python -m simple_vcs checkout path/to/file.txt --revision 20240101120000-123
+```
+
+### `config`
+
+Manages repository configuration such as revision limits and file locks, or prints the current configuration as JSON.
+
+```bash
+python -m simple_vcs config set-limit notes.txt 3
+python -m simple_vcs config lock notes.txt
+python -m simple_vcs config unlock notes.txt
+python -m simple_vcs config show
+```
+
+### `diff`
+
+Shows a unified diff between the working copy and a stored revision (latest by default).
+
+```bash
+python -m simple_vcs diff notes.txt
+```
+
+### `log`
+
+Lists all known revisions for the specified file.
+
+```bash
+python -m simple_vcs log notes.txt
+```
+
+## Usage Example
+
+```bash
+python -m simple_vcs init
+printf "v1" > demo.txt
+python -m simple_vcs commit -m "Add demo" demo.txt
+printf "v2" > demo.txt
+python -m simple_vcs commit -m "Update demo" demo.txt
+python -m simple_vcs log demo.txt
+python -m simple_vcs checkout demo.txt --revision <first-revision-id>
+```
+
+## Running the Tests
+
+From the repository root:
+
+```bash
+pytest Practical/Simple\ VCS/tests
+```

--- a/Practical/Simple VCS/simple_vcs/__init__.py
+++ b/Practical/Simple VCS/simple_vcs/__init__.py
@@ -1,0 +1,5 @@
+"""Simple VCS package."""
+
+from .repository import Repository
+
+__all__ = ["Repository"]

--- a/Practical/Simple VCS/simple_vcs/__main__.py
+++ b/Practical/Simple VCS/simple_vcs/__main__.py
@@ -1,0 +1,7 @@
+"""Module entry-point for ``python -m simple_vcs``."""
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/Practical/Simple VCS/simple_vcs/cli.py
+++ b/Practical/Simple VCS/simple_vcs/cli.py
@@ -1,0 +1,157 @@
+"""Command line interface for the simple VCS."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+from .repository import Repository
+
+
+def _parse_files(values: Iterable[str], root: Path) -> List[Path]:
+    return [root / value for value in values]
+
+
+def _cmd_init(args: argparse.Namespace) -> None:
+    repo = Repository(Path(args.path))
+    repo.init(force=args.force)
+    print(f"Initialised repository at {repo.config_dir}")
+
+
+def _cmd_commit(args: argparse.Namespace) -> None:
+    repo = Repository(Path(args.path))
+    files = _parse_files(args.files, Path(args.path))
+    revisions = repo.commit(files, message=args.message)
+    for path, revision in zip(args.files, revisions):
+        print(f"Committed {path} as {revision.revision_id}: {revision.message}")
+
+
+def _cmd_checkout(args: argparse.Namespace) -> None:
+    repo = Repository(Path(args.path))
+    revision = repo.checkout(Path(args.path) / args.file, revision_id=args.revision)
+    print(f"Checked out {args.file} revision {revision.revision_id}")
+
+
+def _cmd_config(args: argparse.Namespace) -> None:
+    repo = Repository(Path(args.path))
+    file_arg = getattr(args, "file", None)
+    target = Path(args.path) / file_arg if file_arg else None
+    if args.action == "set-limit":
+        repo.set_revision_limit(target, args.limit)  # type: ignore[arg-type]
+        print(f"Updated revision limit for {args.file} to {args.limit}")
+    elif args.action == "lock":
+        repo.lock_file(target)  # type: ignore[arg-type]
+        print(f"Locked {args.file}")
+    elif args.action == "unlock":
+        repo.unlock_file(target)  # type: ignore[arg-type]
+        print(f"Unlocked {args.file}")
+    elif args.action == "show":
+        status = repo.show_status()
+        data = {
+            path: {
+                "revision_limit": entry.revision_limit,
+                "locked": entry.locked,
+                "revisions": [rev.to_dict() for rev in entry.revisions],
+            }
+            for path, entry in status.items()
+        }
+        print(json.dumps(data, indent=2, sort_keys=True))
+    else:  # pragma: no cover - argparse should prevent this
+        raise ValueError(f"Unknown config action: {args.action}")
+
+
+def _cmd_diff(args: argparse.Namespace) -> None:
+    repo = Repository(Path(args.path))
+    diff_output = repo.diff(Path(args.path) / args.file, revision_id=args.revision)
+    if diff_output:
+        print(diff_output)
+    else:
+        print("No differences found.")
+
+
+def _cmd_log(args: argparse.Namespace) -> None:
+    repo = Repository(Path(args.path))
+    revisions = repo.list_revisions(Path(args.path) / args.file)
+    if not revisions:
+        print("No revisions recorded yet.")
+        return
+    for revision in revisions:
+        print(f"{revision.revision_id}\t{revision.timestamp:.0f}\t{revision.message}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Simple file-based version control tool")
+    parser.add_argument(
+        "--path",
+        default=".",
+        help="Path to the repository root (defaults to current directory)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # init
+    parser_init = subparsers.add_parser("init", help="Initialise a new repository")
+    parser_init.add_argument("--force", action="store_true", help="Overwrite existing repository")
+    parser_init.set_defaults(func=_cmd_init)
+
+    # commit
+    parser_commit = subparsers.add_parser("commit", help="Commit one or more files")
+    parser_commit.add_argument("-m", "--message", required=True, help="Commit message")
+    parser_commit.add_argument("files", nargs="+", help="Files to commit")
+    parser_commit.set_defaults(func=_cmd_commit)
+
+    # checkout
+    parser_checkout = subparsers.add_parser("checkout", help="Restore a committed revision")
+    parser_checkout.add_argument("file", help="File to restore")
+    parser_checkout.add_argument("--revision", help="Specific revision identifier")
+    parser_checkout.set_defaults(func=_cmd_checkout)
+
+    # config
+    parser_config = subparsers.add_parser("config", help="Inspect or modify repository configuration")
+    config_subparsers = parser_config.add_subparsers(dest="action", required=True)
+
+    parser_config_show = config_subparsers.add_parser("show", help="Display tracked files")
+    parser_config_show.set_defaults(func=_cmd_config)
+
+    parser_config_limit = config_subparsers.add_parser("set-limit", help="Set revision limit for a file")
+    parser_config_limit.add_argument("file", help="File to update")
+    parser_config_limit.add_argument("limit", type=int, help="Number of revisions to keep")
+    parser_config_limit.set_defaults(func=_cmd_config)
+
+    parser_config_lock = config_subparsers.add_parser("lock", help="Lock a file against commits")
+    parser_config_lock.add_argument("file", help="File to lock")
+    parser_config_lock.set_defaults(func=_cmd_config)
+
+    parser_config_unlock = config_subparsers.add_parser("unlock", help="Unlock a file")
+    parser_config_unlock.add_argument("file", help="File to unlock")
+    parser_config_unlock.set_defaults(func=_cmd_config)
+
+    # diff
+    parser_diff = subparsers.add_parser("diff", help="Show differences from a committed revision")
+    parser_diff.add_argument("file", help="File to compare")
+    parser_diff.add_argument("--revision", help="Specific revision identifier")
+    parser_diff.set_defaults(func=_cmd_diff)
+
+    # log
+    parser_log = subparsers.add_parser("log", help="List revisions for a file")
+    parser_log.add_argument("file", help="File to inspect")
+    parser_log.set_defaults(func=_cmd_log)
+
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        args.func(args)
+    except Exception as exc:  # pragma: no cover - CLI convenience
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/Practical/Simple VCS/simple_vcs/repository.py
+++ b/Practical/Simple VCS/simple_vcs/repository.py
@@ -1,0 +1,254 @@
+"""Simple version control repository management."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+CONFIG_DIR_NAME = ".svc"
+CONFIG_FILE_NAME = "config.json"
+STORE_DIR_NAME = "store"
+DEFAULT_REVISION_LIMIT = 5
+
+
+@dataclass
+class Revision:
+    """Metadata about a single revision."""
+
+    revision_id: str
+    message: str
+    timestamp: float
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "revision_id": self.revision_id,
+            "message": self.message,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "Revision":
+        return cls(
+            revision_id=str(data["revision_id"]),
+            message=str(data.get("message", "")),
+            timestamp=float(data.get("timestamp", 0.0)),
+        )
+
+
+@dataclass
+class FileEntry:
+    """Configuration and revisions for a tracked file."""
+
+    revision_limit: int = DEFAULT_REVISION_LIMIT
+    locked: bool = False
+    revisions: List[Revision] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "revision_limit": self.revision_limit,
+            "locked": self.locked,
+            "revisions": [rev.to_dict() for rev in self.revisions],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "FileEntry":
+        revisions = [Revision.from_dict(item) for item in data.get("revisions", [])]
+        return cls(
+            revision_limit=int(data.get("revision_limit", DEFAULT_REVISION_LIMIT)),
+            locked=bool(data.get("locked", False)),
+            revisions=revisions,
+        )
+
+
+class Repository:
+    """Encapsulates repository operations."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root).resolve()
+        self.config_dir = self.root / CONFIG_DIR_NAME
+        self.config_path = self.config_dir / CONFIG_FILE_NAME
+        self.store_dir = self.config_dir / STORE_DIR_NAME
+        self._config: Dict[str, object] = {}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _load_config(self) -> None:
+        if not self.config_path.exists():
+            raise RuntimeError("Repository not initialized. Run 'init' first.")
+        with self.config_path.open("r", encoding="utf8") as fh:
+            data = json.load(fh)
+        files = {
+            path: FileEntry.from_dict(entry)
+            for path, entry in data.get("files", {}).items()
+        }
+        self._config = {"files": files}
+
+    def _save_config(self) -> None:
+        files: Dict[str, FileEntry] = self._config.get("files", {})  # type: ignore[assignment]
+        serializable = {
+            "version": 1,
+            "files": {path: entry.to_dict() for path, entry in files.items()},
+        }
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        with self.config_path.open("w", encoding="utf8") as fh:
+            json.dump(serializable, fh, indent=2, sort_keys=True)
+
+    def _ensure_loaded(self) -> None:
+        if not self._config:
+            self._load_config()
+
+    def _get_relative_path(self, file_path: Path) -> str:
+        try:
+            relative = file_path.resolve().relative_to(self.root)
+        except ValueError as exc:  # pragma: no cover - guard clause
+            raise RuntimeError("File must reside inside the repository root") from exc
+        return relative.as_posix()
+
+    def _get_file_entry(self, relative_path: str) -> FileEntry:
+        self._ensure_loaded()
+        files: Dict[str, FileEntry] = self._config.setdefault("files", {})  # type: ignore[assignment]
+        if relative_path not in files:
+            files[relative_path] = FileEntry()
+        return files[relative_path]
+
+    def _store_revision_path(self, relative_path: str, revision_id: str) -> Path:
+        safe_path = Path(relative_path)
+        storage_path = self.store_dir / safe_path
+        storage_path.mkdir(parents=True, exist_ok=True)
+        return storage_path / revision_id
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def init(self, force: bool = False) -> None:
+        """Initialise a repository."""
+
+        if self.config_path.exists() and not force:
+            raise RuntimeError("Repository already initialised. Use force=True to overwrite.")
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        self.store_dir.mkdir(parents=True, exist_ok=True)
+        self._config = {"files": {}}
+        self._save_config()
+
+    def set_revision_limit(self, file_path: Path, limit: int) -> None:
+        if limit < 1:
+            raise ValueError("Revision limit must be at least 1")
+        relative = self._get_relative_path(file_path)
+        entry = self._get_file_entry(relative)
+        entry.revision_limit = limit
+        self._save_config()
+
+    def lock_file(self, file_path: Path) -> None:
+        relative = self._get_relative_path(file_path)
+        entry = self._get_file_entry(relative)
+        entry.locked = True
+        self._save_config()
+
+    def unlock_file(self, file_path: Path) -> None:
+        relative = self._get_relative_path(file_path)
+        entry = self._get_file_entry(relative)
+        entry.locked = False
+        self._save_config()
+
+    def get_file_entry(self, file_path: Path) -> FileEntry:
+        relative = self._get_relative_path(file_path)
+        self._ensure_loaded()
+        files: Dict[str, FileEntry] = self._config.get("files", {})  # type: ignore[assignment]
+        if relative not in files:
+            raise RuntimeError(f"File '{relative}' is not tracked yet.")
+        return files[relative]
+
+    def commit(self, files: List[Path], message: str) -> List[Revision]:
+        if not message:
+            raise ValueError("Commit message must not be empty")
+        self._ensure_loaded()
+        committed: List[Revision] = []
+        for file_path in files:
+            absolute = file_path.resolve()
+            if not absolute.exists():
+                raise FileNotFoundError(f"Cannot commit missing file: {file_path}")
+            relative = self._get_relative_path(absolute)
+            entry = self._get_file_entry(relative)
+            if entry.locked:
+                raise RuntimeError(f"File '{relative}' is locked and cannot be committed.")
+            revision_id = time.strftime("%Y%m%d%H%M%S", time.gmtime()) + f"-{int(time.time() * 1000) % 1000:03d}"
+            storage_path = self._store_revision_path(relative, revision_id)
+            shutil.copy2(absolute, storage_path)
+            revision = Revision(revision_id=revision_id, message=message, timestamp=time.time())
+            entry.revisions.append(revision)
+            # Enforce revision limit
+            while len(entry.revisions) > entry.revision_limit:
+                oldest = entry.revisions.pop(0)
+                old_path = self._store_revision_path(relative, oldest.revision_id)
+                if old_path.exists():
+                    old_path.unlink()
+            committed.append(revision)
+        self._save_config()
+        return committed
+
+    def list_revisions(self, file_path: Path) -> List[Revision]:
+        entry = self.get_file_entry(file_path)
+        return list(entry.revisions)
+
+    def checkout(self, file_path: Path, revision_id: Optional[str] = None) -> Revision:
+        entry = self.get_file_entry(file_path)
+        if not entry.revisions:
+            raise RuntimeError("No revisions recorded for this file.")
+        revision: Revision
+        if revision_id is None:
+            revision = entry.revisions[-1]
+        else:
+            matches = [rev for rev in entry.revisions if rev.revision_id == revision_id]
+            if not matches:
+                raise RuntimeError(f"Revision '{revision_id}' not found.")
+            revision = matches[0]
+        relative = self._get_relative_path(Path(file_path))
+        stored = self._store_revision_path(relative, revision.revision_id)
+        if not stored.exists():
+            raise RuntimeError("Stored revision is missing from the repository store.")
+        destination = self.root / relative
+        shutil.copy2(stored, destination)
+        return revision
+
+    def diff(self, file_path: Path, revision_id: Optional[str] = None) -> str:
+        import difflib
+
+        entry = self.get_file_entry(file_path)
+        if not entry.revisions:
+            raise RuntimeError("No revisions available for diff.")
+        revision: Revision
+        if revision_id is None:
+            revision = entry.revisions[-1]
+        else:
+            matches = [rev for rev in entry.revisions if rev.revision_id == revision_id]
+            if not matches:
+                raise RuntimeError(f"Revision '{revision_id}' not found.")
+            revision = matches[0]
+        relative = self._get_relative_path(Path(file_path))
+        stored = self._store_revision_path(relative, revision.revision_id)
+        if not stored.exists():
+            raise RuntimeError("Stored revision is missing from disk.")
+        with stored.open("r", encoding="utf8", errors="replace") as fh:
+            stored_lines = fh.readlines()
+        working_path = self.root / relative
+        if working_path.exists():
+            with working_path.open("r", encoding="utf8", errors="replace") as fh:
+                working_lines = fh.readlines()
+        else:
+            working_lines = []
+        diff = difflib.unified_diff(
+            stored_lines,
+            working_lines,
+            fromfile=f"revision:{revision.revision_id}",
+            tofile="working",  # emphasise diff direction
+        )
+        return "".join(diff)
+
+    def show_status(self) -> Dict[str, FileEntry]:
+        self._ensure_loaded()
+        return dict(self._config.get("files", {}))  # type: ignore[return-value]

--- a/Practical/Simple VCS/tests/test_simple_vcs.py
+++ b/Practical/Simple VCS/tests/test_simple_vcs.py
@@ -1,0 +1,112 @@
+"""Tests for the simple VCS implementation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from simple_vcs.cli import main as cli_main
+from simple_vcs.repository import Repository
+
+
+@pytest.fixture()
+def repo_dir(tmp_path: Path) -> Path:
+    (tmp_path / "workspace").mkdir()
+    return tmp_path / "workspace"
+
+
+def run_cli(repo_dir: Path, *args: str) -> int:
+    argv = ["--path", str(repo_dir), *args]
+    return cli_main(argv)
+
+
+def test_init_and_commit_cycle(repo_dir: Path) -> None:
+    run_cli(repo_dir, "init")
+    target_file = repo_dir / "example.txt"
+    target_file.write_text("first", encoding="utf8")
+    assert run_cli(repo_dir, "commit", "-m", "Initial", "example.txt") == 0
+
+    target_file.write_text("second", encoding="utf8")
+    assert run_cli(repo_dir, "commit", "-m", "Update", "example.txt") == 0
+
+    # Only two revisions should be present by default
+    repo = Repository(repo_dir)
+    revisions = repo.list_revisions(target_file)
+    assert len(revisions) == 2
+
+    # Checkout previous revision
+    run_cli(repo_dir, "checkout", "example.txt", "--revision", revisions[0].revision_id)
+    assert target_file.read_text(encoding="utf8") == "first"
+
+    # Checkout head
+    run_cli(repo_dir, "checkout", "example.txt")
+    assert target_file.read_text(encoding="utf8") == "second"
+
+
+def test_revision_limit_enforced(repo_dir: Path) -> None:
+    run_cli(repo_dir, "init")
+    target = repo_dir / "limited.txt"
+    target.write_text("zero", encoding="utf8")
+
+    run_cli(repo_dir, "config", "set-limit", "limited.txt", "2")
+
+    for idx in range(4):
+        target.write_text(f"value-{idx}", encoding="utf8")
+        run_cli(repo_dir, "commit", "-m", f"commit {idx}", "limited.txt")
+
+    repo = Repository(repo_dir)
+    revisions = repo.list_revisions(target)
+    assert len(revisions) == 2
+    assert [rev.message for rev in revisions] == ["commit 2", "commit 3"]
+
+
+def test_lock_prevents_commits(repo_dir: Path) -> None:
+    run_cli(repo_dir, "init")
+    target = repo_dir / "locked.txt"
+    target.write_text("content", encoding="utf8")
+    run_cli(repo_dir, "commit", "-m", "Initial", "locked.txt")
+
+    run_cli(repo_dir, "config", "lock", "locked.txt")
+    target.write_text("content 2", encoding="utf8")
+    exit_code = run_cli(repo_dir, "commit", "-m", "Update", "locked.txt")
+    assert exit_code == 1
+
+
+def test_diff_and_log_commands(repo_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    run_cli(repo_dir, "init")
+    target = repo_dir / "log.txt"
+    target.write_text("one", encoding="utf8")
+    run_cli(repo_dir, "commit", "-m", "Add one", "log.txt")
+    target.write_text("two", encoding="utf8")
+    run_cli(repo_dir, "commit", "-m", "Add two", "log.txt")
+
+    run_cli(repo_dir, "log", "log.txt")
+    captured = capsys.readouterr()
+    assert "Add one" in captured.out
+    assert "Add two" in captured.out
+
+    target.write_text("two plus", encoding="utf8")
+    run_cli(repo_dir, "diff", "log.txt")
+    captured = capsys.readouterr()
+    assert "two plus" in captured.out
+
+
+def test_config_show_outputs_json(repo_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    run_cli(repo_dir, "init")
+    file_path = repo_dir / "data.txt"
+    file_path.write_text("data", encoding="utf8")
+    run_cli(repo_dir, "commit", "-m", "Initial", "data.txt")
+    capsys.readouterr()  # Clear previous command output
+    exit_code = run_cli(repo_dir, "config", "show")
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    parsed = json.loads(captured.out)
+    assert "data.txt" in parsed
+    assert parsed["data.txt"]["revisions"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ While this is a personal project, the principles behind it are universal. If you
 | 21 | ID3 Reader | Not Yet |
 | 22 | Sound Synthesis (Sine square sawtooth etc...) ("Fuck You" mode: Realtime MIDI Playback with Custom instruments) | Not Yet |
 | 23 | C++ IDE Plugin for Sublime/Atom (Auto-Complete Go-To Symbol Declaration and Definition using Clang's AST) | Not Yet |
-| 24 | Simple Version Control supporting checkout commit (with commit message) unlocking and per-file configuration of number of revisions kept | Not Yet |
+| 24 | Simple Version Control supporting checkout commit (with commit message) unlocking and per-file configuration of number of revisions kept | [View Solution](./Practical/Simple%20VCS/) |
 | 25 | Imageboard (Imagine vichan) | Not Yet |
 | 26 | Password Manager | Not Yet |
 | 27 | Create a Torrent Client (CLI or GUI) | Not Yet |

--- a/simple_vcs/__init__.py
+++ b/simple_vcs/__init__.py
@@ -1,0 +1,15 @@
+"""Proxy package to expose the Simple VCS implementation at repository root."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_impl_dir = Path(__file__).resolve().parent.parent / "Practical" / "Simple VCS" / "simple_vcs"
+if not _impl_dir.exists():  # pragma: no cover - defensive
+    raise ImportError("simple_vcs implementation directory is missing")
+
+__path__ = [str(_impl_dir)]
+
+from .repository import Repository  # noqa: E402  # isort:skip
+
+__all__ = ["Repository"]

--- a/simple_vcs/__main__.py
+++ b/simple_vcs/__main__.py
@@ -1,0 +1,7 @@
+"""Root package entry point delegating to the implementation."""
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a file-based simple version control implementation with commit, checkout, diff, log, and configuration commands
- document usage in Practical/Simple VCS/README.md and link the new project from the main README files
- supply pytest coverage for commit/checkout cycles, revision limits, locking, diff/log, and config output

## Testing
- pytest Practical/Simple\ VCS/tests

------
https://chatgpt.com/codex/tasks/task_b_68d6c2a5f780832980a1a71713d642ac