### PR TITLE
Add pyproject extras and update dependency docs

### DIFF
--- a/Algorithmic/README.md
+++ b/Algorithmic/README.md
@@ -15,6 +15,20 @@ This directory contains a curated collection of algorithmic programming challeng
 3. **Test**: Run `pytest` in this directory to check your understanding and verify correctness.
 4. **Learn**: Read the code and comments—many scripts are written to be beginner-friendly and include explanations.
 
+## Using pyproject.toml
+
+Create a virtual environment, then install the extras that match the problems you want to explore:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\Activate.ps1
+python -m pip install -e .[algorithmic]      # Core numerics + utilities
+python -m pip install -e .[visual]           # Plotting / colour science add-ons
+python -m pip install -e .[media]            # YouTube downloader helper for ytmp3
+```
+
+Need linting or tests? Add `.[developer]` for pytest, ruff, and mypy.
+
 ## Example Topics
 
 - **Ciphers**: Caesar, Atbash, Affine, Vigenère, ROT13
@@ -33,11 +47,7 @@ This directory contains a curated collection of algorithmic programming challeng
 
 ## Requirements
 
-Install dependencies with:
-
-```bash
-pip install -r requirements.txt
-```
+Dependencies now live in optional extras defined in the root `pyproject.toml`. For most scripts `python -m pip install -e .[algorithmic]` is sufficient; add `visual` or `media` as shown above for plotting/downloading helpers.
 
 ---
 

--- a/Algorithmic/requirements.txt
+++ b/Algorithmic/requirements.txt
@@ -1,33 +1,6 @@
-# Requirements for the Algorithmic collection
-# Install with: pip install -r requirements.txt
-# Canonical pins are shared across the repo; optional tools note their future pyproject extras.
-
-# Core numerical / plotting
-numpy>=1.26,<2.0              # Arrays, vector ops, Monte Carlo demos – planned extra: algorithmic-core
-matplotlib>=3.8,<3.9          # Plotting for vector product & cube rotation – planned extra: algorithmic-visuals
-pandas>=2.2,<2.3              # Tabular summaries (sorting visualizer exports) – planned extra: algorithmic-data
-
-# Image handling / steganography
-Pillow>=10.4,<10.5            # Image IO for steganography scripts – planned extra: algorithmic-imaging
-
-# Web requests / parsing
-requests>=2.31,<3.0           # HTTP requests for web scraping demos – planned extra: algorithmic-web
-beautifulsoup4>=4.12,<5.0     # HTML parsing for crawler demo – planned extra: algorithmic-web
-
-# Audio / video (optional, used by ytmp3 script; yt-dlp preferred)
-yt-dlp>=2024.7.1              # YouTube downloader (planned extra: algorithmic-media)
-# youtube_dl                  # Legacy fallback only; install manually if required
-
-# CLI tooling / type aids (optional)
-argparse; python_version<'3.10'  # Backport for Python 3.9 users
-
-# Testing
-pytest>=8.3,<8.4              # Unit tests for algorithmic utilities – planned extra: dev
-
-# Optional: if affine cipher brute force speed-ups are desired (not required)
-# sympy>=1.12                 # Planned extra: algorithmic-math
-
-# NOTE:
-# - Keep this list aligned with scripts' imports.
-# - Some scripts gracefully degrade if a lib is absent (e.g., matplotlib optional for JSON output).
-# - Optional stacks above will migrate to pyproject extras as they are published.
+# Dependencies for algorithmic challenges are published via optional extras in pyproject.toml.
+# Typical installs:
+#   python -m pip install -e .[algorithmic]
+#   python -m pip install -e .[visual]     # plotting/imagery helpers
+#   python -m pip install -e .[media]      # YouTube downloader support
+# See Algorithmic/README.md for context and the root README for a full table of extras.

--- a/Artificial Intelligence/README.md
+++ b/Artificial Intelligence/README.md
@@ -18,7 +18,12 @@ This folder contains a collection of classic and educational artificial intellig
 1. **Install dependencies** (recommended in a virtual environment):
 
    ```bash
-   pip install -r requirements.txt
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\Activate.ps1
+   python -m pip install -e .[ai]
+   # Optional helpers
+   python -m pip install -e .[algorithmic]  # plotting + scipy utilities
+   python -m pip install -e .[developer]   # pytest/ruff/mypy
    ```
 
 2. **Run any script directly**. For example, to solve a Sudoku puzzle:
@@ -34,10 +39,14 @@ This folder contains a collection of classic and educational artificial intellig
    python "Basic Neural Network/BNN.py"
    ```
 
+## Using pyproject.toml
+
+The AI projects share dependencies with the rest of the repository via optional extras. Install `.[ai]` for the default numpy/scikit-learn stack, then layer on `algorithmic` or `developer` as needed. Editable installs keep your working tree synced with the environment, so changes you make are immediately importable.
+
 ## Requirements
 
 - Python 3.8 or newer
-- See `requirements.txt` for Python package dependencies
+- Install extras from `pyproject.toml` such as `ai`, `algorithmic`, and `developer` depending on what you plan to run
 
 ## Contributing
 

--- a/Artificial Intelligence/requirements.txt
+++ b/Artificial Intelligence/requirements.txt
@@ -1,8 +1,5 @@
-# Artificial Intelligence Module Requirements
-# These are the core dependencies for Python-based AI scripts in this folder.
-# Pins stay aligned with the repo-wide canonical versions for consistency.
-
-numpy>=1.26,<2.0              # Shared math utilities (BNN.py, board evaluators) – planned extra: ai-core
-
-# No external dependencies required for Connect4 or BNN beyond numpy.
-# Future pyproject extras will expose optional ML stacks as they are added.
+# The AI demos pull dependencies from pyproject extras.
+# Common installs:
+#   python -m pip install -e .[ai]
+#   python -m pip install -e .[algorithmic]  # numerical tooling & plotting
+# See Artificial Intelligence/README.md for setup notes.

--- a/Emulation/README.md
+++ b/Emulation/README.md
@@ -31,10 +31,14 @@ python -m venv .venv
 . .venv/Scripts/Activate.ps1
 ```
 
-### 1.3. Install everything (heavier, simplest)
+### 1.3. Install via pyproject extras
+
+From the repo root install the extras that match the demos you want to run:
 
 ```pwsh
-pip install -r requirements.txt
+python -m pip install -e .[visual]
+python -m pip install -e .[algorithmic]   # optional math helpers
+python -m pip install -e .[ai]            # palette clustering (scikit-learn)
 ```
 
 ### 1.4. Or install just what you need (see Section 3)
@@ -54,20 +58,30 @@ pip install -r requirements.txt
 
 > Some folders may contain experimental or WIP code; stable scripts include `5cs.py`, `comp.py`, `hierholzer.py`, `ClockSynced.py`.
 
----
+## Using pyproject.toml
+
+Editable installs keep the code you edit inside this repo linked to your environment.
+
+1. Create a virtual environment (recommended).
+   ```pwsh
+   python -m venv .venv
+   . .venv/\Scripts\Activate.ps1  # Windows
+   ```
+2. Move to the repository root and install extras, e.g. `python -m pip install -e .[visual]`.
+3. Stack extras together: `.[visual,algorithmic]` for plotting + numerical helpers, `.[visual,ai]` for VPython + scikit-learn palette clustering.
+
 
 ## 3. Selective Installs
 
-Install only the dependencies you need:
+Install only the extras you need:
 
-| Feature | Minimal Install |
-|---------|-----------------|
-| Palette extraction (5 color scheme) | `pip install numpy Pillow matplotlib` (+ `scikit-learn` for KMeans) |
-| Faster palette via OpenCV (optional) | `pip install opencv-python` |
-| Component color visualizer (CompColor) | `pip install numpy Pillow` |
-| SpinnyCube VPython 3D version | `pip install vpython` |
-
-Most other scripts run with only the Python standard library.
+| Feature | Extras | Notes |
+|---------|--------|-------|
+| Palette extraction (5 color scheme) | `visual,algorithmic` | Includes numpy, Pillow, matplotlib, scikit-learn. |
+| OpenCV acceleration | `visual` | Adds `opencv-python` alongside Pillow/imageio. |
+| Component color visualizer (CompColor) | `visual` | Only Pillow + numpy required. |
+| SpinnyCube VPython 3D version | `visual` | VPython is part of the visual extra. |
+| Pure stdlib demos (Eulerian path, ASCII clock) | *(none)* | Standard library only. |
 
 ---
 
@@ -134,16 +148,13 @@ python "SpinnyCube/spinny.py" --mode vpython --edge-color "#ff8800"
 
 ## 6. Dependencies Overview
 
-See `requirements.txt` for consolidated install. Rationale:
+All third-party packages are grouped in `pyproject.toml` extras:
 
-- `numpy` foundational for pixel arrays and math
-- `Pillow` robust image loading/saving (JPEG/PNG, read metadata)
-- `matplotlib` quick visual diagnostics and palette swatches
-- `scikit-learn` reliable KMeans (convergence, inertia reporting)
-- `opencv-python` (optional) faster image ops & resizing
-- `vpython` 3D interactive rendering (only for SpinnyCube in vpython mode)
+- `visual` &mdash; Pillow, matplotlib, imageio, opencv-python, colour-science, vpython
+- `algorithmic` &mdash; numpy + scipy for numeric helpers
+- `ai` &mdash; scikit-learn when you want KMeans palette clustering
 
-You can safely omit any that a script does not import.
+Activate the extras relevant to your experiment; the rest of the suite remains pure stdlib.
 
 ---
 
@@ -153,7 +164,7 @@ You can safely omit any that a script does not import.
 2. Add a short module docstring explaining purpose & expected inputs.
 3. For new visualizations, provide at least one static sample output (PNG/JPG) if feasible.
 4. Prefer deterministic seeds in examples when randomness is involved.
-5. Document optional dependencies with a brief comment in `requirements.txt`.
+5. Document optional dependencies by extending the relevant `pyproject.toml` extras and README tables.
 6. Avoid introducing heavy frameworks; simplicity is a goal here.
 
 ### Extension Ideas

--- a/Emulation/requirements.txt
+++ b/Emulation/requirements.txt
@@ -1,16 +1,5 @@
-# Consolidated third-party dependencies for the Emulation suite
-# Pins mirror the repo-wide canonical versions; optional pieces point to future pyproject extras.
-# Many scripts are pure-stdlib; install only what you need.
-
-numpy>=1.26,<2.0              # Array math for color conversions – planned extra: emulation-core
-Pillow>=10.4,<10.5            # Image loading/saving (palette extraction) – planned extra: emulation-imaging
-matplotlib>=3.8,<3.9          # Visualization for 5 color scheme plots – planned extra: emulation-visuals
-scikit-learn>=1.5,<1.6        # KMeans clustering for palette extraction – planned extra: emulation-ml
-opencv-python>=4.10,<5.0      # Optional acceleration for palette & filters – planned extra: emulation-imaging
-
-# Optional / specialized
-vpython>=7.6,<7.7             # 3D interactive rendering for SpinnyCube – planned extra: emulation-visuals
-
-# NOTE:
-# - No dependency is required for Eulerian path algorithms or ASCII clock (pure stdlib).
-# - Optional items above will be exposed as pyproject extras once available.
+# The Emulation suite now relies on the repository's pyproject extras.
+# Install what you need with:
+#   python -m pip install -e .[visual]
+#   python -m pip install -e .[algorithmic]
+# Optional 3D/ML helpers live in extras such as [visual] and [ai]; see Emulation/README.md for guidance.

--- a/Games/README.md
+++ b/Games/README.md
@@ -5,6 +5,8 @@ Welcome to the **Games** folder of the Pro-g-rammingChallenges4 repository! This
 ## Contents
 
 - **Connect4** (`Connect4.java`, `connect4.py`): Play the classic Connect Four game in Java or Python.
+
+
 - **Knight Tour** (`knight.py`): Solve the Knight's Tour puzzle using Python.
 - **Minesweeper** (`mine.py`): A simple command-line Minesweeper game in Python.
 - **RPS** (Rock Paper Scissors):
@@ -16,15 +18,32 @@ Welcome to the **Games** folder of the Pro-g-rammingChallenges4 repository! This
 - **Sudoku** (`sudoku.py`): Sudoku puzzle generator and solver in Python (uses numpy).
 - **Yahtzee** (`Yahtzee.java`, `yahtzee.py`): Play Yahtzee in Java or Python.
 
+
+## Using pyproject.toml
+
+Create a virtual environment, then install the extras for the games you want to run:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\Activate.ps1
+python -m pip install -e .[games]
+# Optional helpers
+python -m pip install -e .[visual]  # matplotlib-based scoreboards
+python -m pip install -e .[audio]   # shared sound backends (pygame, sounddevice)
+```
+
+Editable installs keep your local changes immediately playable.
+
 ## How to Run
 
 ### Python Games
 
 - Make sure you have Python 3.8+ installed.
-- Install dependencies (if needed):
+- Install dependencies via pyproject extras:
 
   ```sh
-  pip install -r requirements.txt
+  python -m pip install -e .[games]
+  # Add .[visual] for matplotlib stats or .[audio] for richer sound
   ```
 
 - Run the desired game:

--- a/Games/requirements.txt
+++ b/Games/requirements.txt
@@ -1,19 +1,7 @@
-# requirements.txt for Games folder
-# Only Python games with external dependencies are listed here; pins follow the canonical repo versions.
-
-# General (for all Python games)
-# Standard-library-only games do not require extra packages.
-
-# For games using numpy (e.g., Sudoku generator/solver)
-numpy>=1.26,<2.0              # Grid math utilities – planned extra: games-core
-
-# For games using matplotlib (e.g., Shuffle/cards.py)
-matplotlib>=3.8,<3.9          # Plotting for statistics/visualizations – planned extra: games-visuals
-
-# For games using sound (Simon mini-game)
-pygame>=2.6,<2.7              # Optional sound support – planned extra: games-audio
-
-# For games using tkinter (GUI titles such as Simon, Snake)
-# tkinter ships with most Python installs; install separately on Linux if missing.
-
-# Future pyproject extras will expose groups such as "games-core" and "games-audio" covering these needs.
+# Python game dependencies are exposed via the repo's optional extras.
+# Install the full toolkit with:
+#   python -m pip install -e .[games]
+# Optional helpers:
+#   python -m pip install -e .[visual]   # matplotlib visualisations
+#   python -m pip install -e .[audio]    # shared sound backends
+# Consult Games/README.md for per-title suggestions.

--- a/Practical/Markdown Editor/requirements.txt
+++ b/Practical/Markdown Editor/requirements.txt
@@ -1,7 +1,4 @@
-# Requirements for the Markdown Editor subproject
-# Each pin matches the repo-wide canonical versions for consistency.
-
-markdown>=3.6,<3.7            # Core Markdown rendering (Markdown Editor) – planned extra: practical-markdown
-tkhtmlview>=0.2.0,<0.3        # Optional live HTML preview widget – planned extra: practical-markdown
-
-# Future pyproject extras will expose a "practical-markdown" group covering these libraries.
+# Markdown Editor dependencies now live in pyproject extras.
+# Install just this stack with:
+#   python -m pip install -e .[markdown]
+# or include it via the larger practical extra: `python -m pip install -e .[practical]`.

--- a/Practical/README.md
+++ b/Practical/README.md
@@ -30,15 +30,19 @@ python -m venv .venv
 . .venv/Scripts/Activate.ps1   # PowerShell activation
 ```
 
-### 1.3. Install consolidated dependencies
+### 1.3. Install via pyproject extras
 
-This installs everything needed for ALL tools (heavier, but simple):
+From the repo root install the bundles you need (editable install keeps code + env in sync):
 
 ```pwsh
-pip install -r requirements.txt
+python -m pip install -e .[practical]
+# Optional focused stacks
+python -m pip install -e .[audio]     # Sound synthesis, WAV equalizer
+python -m pip install -e .[desktop]   # Window manager, key press bot
+python -m pip install -e .[web]       # Imageboard, IP tracking dashboard
 ```
 
-Want minimal installs? See "Selective Installs" below.
+You can mix extras (e.g., `.[practical,audio]`). See "Selective Installs" for a quick matrix.
 
 ### 1.4. Run something
 
@@ -47,6 +51,10 @@ python "Imageboard/imageboard.py" --help
 python "Seam Carving/resize.py" --help
 python "ToDoList-CLI/todo.py" add "Ship awesome README"
 ```
+
+## Using pyproject.toml
+
+All Practical projects share the repo-wide optional extras. Install `.[practical]` for the full toolkit or combine targeted extras (audio, web, desktop, markdown, geo, midi) depending on what you plan to explore. Editable installs (`pip install -e .[extra]`) keep your changes instantly runnable. See the table below for combinations.
 
 ---
 
@@ -104,21 +112,22 @@ Brief synopses; dive into each folder for details.
 
 ---
 
-## 3. Selective Installs
+## 3. Selective Installs (pyproject extras)
 
-If you only need a subset, install manually:
+Mix and match extras to keep installs lean. Combine them in a single command, e.g. `python -m pip install -e .[practical,audio]`.
 
-| Feature | Minimal Install |
-|---------|-----------------|
-| Imageboard | `pip install Flask Pillow` |
-| Seam Carving | `pip install opencv-python numpy` (Pillow optional for GUI) |
-| IP Map | `pip install requests pandas plotly tqdm` |
-| IRC Client | no extra packages (Python 3.10+ standard library) |
-| PDF Tagger | `pip install pypdf` |
-| ASCII Converter | `pip install Pillow numpy` |
-| Vector / Rotating Cube | `pip install matplotlib numpy` |
+| Focus | Extras | Notes |
+|-------|--------|-------|
+| All practical projects | `practical` | Pulls every dependency pinned for the Practical/ tree. |
+| Audio pipelines (Shazam clone, WAV Equalizer, Sound Synthesis) | `audio` (or `practical,audio`) | Adds librosa, sounddevice, mutagen, scipy. |
+| Web-facing tools (Imageboard, IP Tracker, Encrypted Upload) | `practical,web` | Flask + requests + tqdm convenience. |
+| Imaging & GUI editors (Seam Carving, Pixel Editor, ImgToASCII) | `practical,visual` | Brings in Pillow, OpenCV, plotly/imageio for exports. |
+| Desktop automation (Window Manager, Key Press Bot) | `practical,desktop` | Installs python-xlib, pynput, pyautogui, colorama. |
+| Geospatial tooling (WMS viewer) | `practical,geo` | Provides pyproj + PyYAML configuration helpers. |
+| Markdown editor suite | `practical,markdown` | Adds markdown + tkhtmlview widgets. |
+| MIDI workflow | `practical,midi` | Installs mido + python-rtmidi. |
 
-You can also break the monolithic `requirements.txt` later into extras (see "Future Improvements").
+Need test tooling? Add `developer` for pytest, ruff, and mypy.
 
 ---
 

--- a/Practical/requirements.txt
+++ b/Practical/requirements.txt
@@ -1,51 +1,8 @@
-# Consolidated dependencies for all Practical subprojects
-# Pins are canonical across the repo; inline notes flag the tools that import them.
-# Optional stacks note their future pyproject extras so you can install selectively.
-
-# Core scientific / numeric
-numpy>=1.26,<2.0              # Shared array ops (Shazam clone, Seam Carving, Equalizer) – planned extra: practical-core
-scipy>=1.11,<1.13             # Signal processing (Shazam clone, WAV Equalizer) – planned extra: practical-audio
-librosa>=0.10,<0.11           # Audio fingerprinting (Shazam clone) – planned extra: practical-audio
-soundfile>=0.12,<0.13         # Audio decoding backend (Shazam clone) – planned extra: practical-audio
-sounddevice>=0.4,<0.5         # Live audio IO (WAV Equalizer, Synth performer) – planned extra: practical-audio
-pandas>=2.2,<2.3              # Dataframes (IP Tracking visualization) – planned extra: practical-data
-opencv-python>=4.10,<5.0      # Seam carving energy maps (Seam Carving GUI) – planned extra: practical-imaging
-matplotlib>=3.8,<3.9          # Plotting (Vector product demo, rotating cube) – planned extra: practical-visuals
-pygame>=2.6,<2.7              # Audio cues & demos (Old School timeline) – planned extra: practical-games
-imageio>=2.34,<2.35           # GIF export (Retro demo capture) – planned extra: practical-visuals
-plotly>=5.22,<5.23            # Interactive geo plots (IP Tracking dashboard) – planned extra: practical-visuals
-
-# Web / networking
-Flask>=3.0,<3.1               # Imageboard web app – planned extra: practical-web
-requests>=2.31,<3.0           # API calls (IP Tracking, WMS viewer) – planned extra: practical-web
-mutagen>=1.47,<1.48           # Audio metadata (Music streaming server, ID3 reader) – planned extra: practical-audio
-pyproj>=3.6,<3.7              # Coordinate transforms (WMS viewer) – planned extra: practical-geo
-
-# Data processing / progress
-PyYAML>=6.0.2,<6.1            # Config parsing (WMS viewer) – planned extra: practical-geo
-tqdm>=4.66,<4.67              # Optional progress bars (IP Tracking) – planned extra: practical-cli
-
-# Imaging
-Pillow>=10.4,<10.5            # Imageboard thumbnails & ASCII converter – planned extra: practical-imaging
-
-# PDF handling
-pypdf>=4.3,<4.4               # PDF Tagger metadata edits – planned extra: practical-docs
-
-# Desktop / input automation
-python-xlib>=0.33,<0.34       # PracticalWM window manager – planned extra: practical-desktop
-colorama>=0.4.6,<0.5          # Optional CLI colors (future CLI polish) – planned extra: practical-cli
-pynput>=1.7,<1.8              # Cross-platform input control (automation tools) – planned extra: practical-desktop
-pyautogui>=0.9,<0.10          # High-level key typing helpers (automation tools) – planned extra: practical-desktop
-
-# Security / encryption
-cryptography>=42.0,<44.0      # Password manager + encrypted upload – planned extra: practical-security
-boto3>=1.34,<1.35             # AWS S3 uploads (Encrypted upload) – planned extra: practical-cloud
-
-# MIDI tooling
-mido>=1.3,<1.4                # MIDI parsing/editing utilities – planned extra: practical-midi
-python-rtmidi>=1.5,<1.6       # RtMidi backend for realtime playback – planned extra: practical-midi
-
-# NOTE:
-# - Many desktop GUI tools rely only on the Python standard library (tkinter, threading, etc.).
-# - For a lighter install, cherry-pick lines relevant to your project or wait for pyproject extras listed above.
-# - Optional instrumentation (e.g., tqdm, colorama) can be removed if you need a barebones footprint.
+# Practical tools share the central pyproject optional extras.
+# Install everything with:
+#   python -m pip install -e .[practical]
+# Or mix and match targeted stacks:
+#   python -m pip install -e .[audio]
+#   python -m pip install -e .[web]
+#   python -m pip install -e .[desktop]
+# See Practical/README.md for a matrix of extras per project.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,43 @@ While this is a personal project, the principles behind it are universal. If you
 4. **Re-implement and Explore:** Once you have a solid solution, try implementing it in a new language. Experiment with different algorithms, data structures, and programming styles. This is a great way to deepen your understanding and expand your skills.
 5. **Never Stop Learning:** Keep challenging yourself. Contribute to open source, start new projects, and keep building your portfolio.
 
+## Using pyproject.toml
+
+The repository now ships a `pyproject.toml` so you can install challenge stacks as editable extras.
+
+1. **Create a virtual environment** (recommended):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # PowerShell: .venv\Scripts\Activate.ps1
+   ```
+2. **Install the extras you need**:
+   ```bash
+   python -m pip install -e .[practical]
+   python -m pip install -e .[algorithmic]
+   ```
+   Combine extras (e.g., `.[practical,visual]`) or grab everything with `.[all]`.
+3. **Run scripts/tests** directly from the repo. Editable installs keep your checkout in sync with the environment.
+
+| Extra | Covers | Highlights |
+| ----- | ------ | ---------- |
+| `practical` | `Practical/` utilities, desktop apps, and web tools | Flask imageboard, Seam Carving, Shazam clone, WMS viewer |
+| `algorithmic` | `Algorithmic/` problem set helpers | Steganography, stock analysis, crawler tooling |
+| `visual` | Visualization add-ons used across categories | Matplotlib demos, colour-science palettes, VPython spinny cube |
+| `audio` | Audio processing stacks | WAV equalizer, Shazam clone, music streaming |
+| `games` | Python games in `Games/` | Sudoku solver, Simon, Shuffle stats |
+| `ai` | `Artificial Intelligence/` demos | A* Sudoku, Connect4 AI, neural network |
+| `web` | HTTP and dashboard helpers | Imageboard, IP tracking, web crawlers |
+| `desktop` | GUI/automation conveniences | Window manager, key press bot, Tk front-ends |
+| `markdown` | Markdown Editor stack | Live preview, HTML export |
+| `geo` | Geospatial helpers | WMS viewer, map projections |
+| `media` | Download/encoding helpers | YouTube to MP3 workflows |
+| `security` | Crypto utilities | Password manager, encrypted upload |
+| `documents` | PDF tooling | PDF Tagger |
+| `midi` | MIDI pipeline | MIDI player/editor, synth tools |
+| `developer` | Repo test/lint helpers | pytest, ruff, mypy |
+
+See the category READMEs for per-project suggestions; each now points back to these extras.
+
 ## Challenges
 
 ### Practical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,173 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pro-g-rammingchallenges4"
+version = "0.1.0"
+description = "Packaging metadata and optional extras for the Pro-g-ramming challenge repository."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "saintwithataint" }]
+license = { text = "MIT" }
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+keywords = ["challenges", "algorithms", "education", "games"]
+dependencies = []
+
+[project.optional-dependencies]
+practical = [
+    "numpy>=1.26,<2.0",
+    "pandas>=2.2,<2.3",
+    "requests>=2.31,<3.0",
+    "Flask>=3.0,<3.1",
+    "pypdf>=4.3,<4.4",
+    "mutagen>=1.47,<1.48",
+    "cryptography>=42.0,<44.0",
+    "tqdm>=4.66,<4.67",
+    "boto3>=1.34,<1.35",
+    "scipy>=1.11,<1.13",
+    "opencv-python>=4.10,<5.0",
+    "Pillow>=10.4,<10.5",
+    "plotly>=5.22,<5.23",
+    "imageio>=2.34,<2.35",
+    "pygame>=2.6,<2.7",
+    "librosa>=0.10,<0.11",
+    "soundfile>=0.12,<0.13",
+    "sounddevice>=0.4,<0.5",
+    "mido>=1.3,<1.4",
+    "python-rtmidi>=1.5,<1.6",
+    "PyYAML>=6.0.2,<6.1",
+    "pyproj>=3.6,<3.7",
+    "python-xlib>=0.33,<0.34",
+    "colorama>=0.4.6,<0.5",
+    "pynput>=1.7,<1.8",
+    "pyautogui>=0.9,<0.10",
+    "markdown>=3.6,<3.7",
+    "tkhtmlview>=0.2.0,<0.3",
+]
+algorithmic = [
+    "numpy>=1.26,<2.0",
+    "scipy>=1.11,<1.13",
+    "matplotlib>=3.8,<3.9",
+    "Pillow>=10.4,<10.5",
+    "requests>=2.31,<3.0",
+    "beautifulsoup4>=4.12,<5.0",
+    "yt-dlp>=2024.7.1",
+]
+visual = [
+    "Pillow>=10.4,<10.5",
+    "matplotlib>=3.8,<3.9",
+    "imageio>=2.34,<2.35",
+    "plotly>=5.22,<5.23",
+    "colour-science>=0.4,<0.5",
+    "vpython>=7.6,<7.7",
+    "opencv-python>=4.10,<5.0",
+]
+audio = [
+    "numpy>=1.26,<2.0",
+    "scipy>=1.11,<1.13",
+    "librosa>=0.10,<0.11",
+    "soundfile>=0.12,<0.13",
+    "sounddevice>=0.4,<0.5",
+    "mutagen>=1.47,<1.48",
+]
+games = [
+    "numpy>=1.26,<2.0",
+    "matplotlib>=3.8,<3.9",
+    "pygame>=2.6,<2.7",
+]
+ai = [
+    "numpy>=1.26,<2.0",
+    "scipy>=1.11,<1.13",
+    "scikit-learn>=1.5,<1.6",
+]
+midi = [
+    "mido>=1.3,<1.4",
+    "python-rtmidi>=1.5,<1.6",
+]
+web = [
+    "requests>=2.31,<3.0",
+    "Flask>=3.0,<3.1",
+    "plotly>=5.22,<5.23",
+]
+security = [
+    "cryptography>=42.0,<44.0",
+]
+documents = [
+    "pypdf>=4.3,<4.4",
+]
+markdown = [
+    "markdown>=3.6,<3.7",
+    "tkhtmlview>=0.2.0,<0.3",
+]
+desktop = [
+    "python-xlib>=0.33,<0.34",
+    "colorama>=0.4.6,<0.5",
+    "pynput>=1.7,<1.8",
+    "pyautogui>=0.9,<0.10",
+]
+geo = [
+    "pyproj>=3.6,<3.7",
+    "PyYAML>=6.0.2,<6.1",
+]
+media = [
+    "imageio>=2.34,<2.35",
+    "yt-dlp>=2024.7.1",
+]
+developer = [
+    "pytest>=8.3,<8.4",
+    "ruff>=0.5,<0.6",
+    "mypy>=1.11,<1.12",
+]
+all = [
+    "numpy>=1.26,<2.0",
+    "pandas>=2.2,<2.3",
+    "requests>=2.31,<3.0",
+    "Flask>=3.0,<3.1",
+    "pypdf>=4.3,<4.4",
+    "mutagen>=1.47,<1.48",
+    "cryptography>=42.0,<44.0",
+    "tqdm>=4.66,<4.67",
+    "boto3>=1.34,<1.35",
+    "scipy>=1.11,<1.13",
+    "opencv-python>=4.10,<5.0",
+    "Pillow>=10.4,<10.5",
+    "plotly>=5.22,<5.23",
+    "imageio>=2.34,<2.35",
+    "pygame>=2.6,<2.7",
+    "librosa>=0.10,<0.11",
+    "soundfile>=0.12,<0.13",
+    "sounddevice>=0.4,<0.5",
+    "mido>=1.3,<1.4",
+    "python-rtmidi>=1.5,<1.6",
+    "PyYAML>=6.0.2,<6.1",
+    "pyproj>=3.6,<3.7",
+    "python-xlib>=0.33,<0.34",
+    "colorama>=0.4.6,<0.5",
+    "pynput>=1.7,<1.8",
+    "pyautogui>=0.9,<0.10",
+    "matplotlib>=3.8,<3.9",
+    "beautifulsoup4>=4.12,<5.0",
+    "yt-dlp>=2024.7.1",
+    "colour-science>=0.4,<0.5",
+    "vpython>=7.6,<7.7",
+    "scikit-learn>=1.5,<1.6",
+    "markdown>=3.6,<3.7",
+    "tkhtmlview>=0.2.0,<0.3",
+    "pytest>=8.3,<8.4",
+    "ruff>=0.5,<0.6",
+    "mypy>=1.11,<1.12",
+]
+
+[project.urls]
+Homepage = "https://github.com/saintwithataint/Pro-g-rammingChallenges4"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,43 +1,5 @@
-# Root consolidated dependencies for the entire Pro-g-rammingChallenges4 repository
-# Strategy: keep one canonical pin per library aligned with actual imports.
-# Optional stacks are marked for forthcoming pyproject extras so base installs stay minimal.
-
-#############################
-# Base / cross-project core
-#############################
-numpy>=1.26,<2.0              # Arrays and math (Algorithmic/, Emulation/, Practical audio tools) – planned extra: core
-Pillow>=10.4,<10.5            # Image handling (Algorithmic steganography, Emulation palette helpers) – planned extra: imaging
-pandas>=2.2,<2.3              # Data analytics (Practical/IP Tracking dashboard) – planned extra: data
-requests>=2.31,<3.0           # HTTP client (Practical/IP Tracking, Algorithmic web scraping) – planned extra: web
-Flask>=3.0,<3.1               # Imageboard web app (Practical/Imageboard) – planned extra: web
-pypdf>=4.3,<4.4               # PDF metadata editing (Practical/PDF Tagger) – planned extra: documents
-mutagen>=1.47,<1.48           # Audio metadata parsing (Practical/ID3 Reader) – planned extra: audio
-cryptography>=42.0,<44.0      # AES-GCM vaults (Practical/Password Manager, Encrypted Upload) – planned extra: security
-
-#############################
-# Optional extras (install on demand; will move to pyproject extras)
-#############################
-matplotlib>=3.8,<3.9          # Plotting (Algorithmic visualizations, Games/shuffle) – planned extra: visualization
-scipy>=1.11,<1.13             # Signal processing (Practical Shazam clone, WAV Equalizer) – planned extra: audio
-pygame>=2.6,<2.7              # Retro demos & Simon audio (Practical/Old School, Games/Simon) – planned extra: games
-imageio>=2.34,<2.35           # GIF export (Practical retro demo capture) – planned extra: visualization
-opencv-python>=4.10,<5.0      # Seam carving & palette ops (Practical/Seam Carving, Emulation palette) – planned extra: imaging
-scikit-learn>=1.5,<1.6        # KMeans palettes (Emulation/5 color scheme) – planned extra: ml
-colour-science>=0.4,<0.5      # Advanced color math (Emulation color experiments) – planned extra: visualization
-librosa>=0.10,<0.11           # Audio STFT helper (Practical Shazam clone) – planned extra: audio
-soundfile>=0.12,<0.13         # Audio file backend (Practical Shazam clone) – planned extra: audio
-sounddevice>=0.4,<0.5         # Live audio I/O (Practical WAV Equalizer, Synth performer) – planned extra: audio
-plotly>=5.22,<5.23            # Interactive geo plots (Practical IP Tracking) – planned extra: visualization
-tqdm>=4.66,<4.67              # CLI progress bars (Practical IP Tracking) – planned extra: cli
-vpython>=7.6,<7.7             # 3D spinny cube (Emulation/SpinnyCube) – planned extra: visualization
-mido>=1.3,<1.4                # MIDI utilities (Practical synth tools) – planned extra: midi
-python-rtmidi>=1.5,<1.6       # RtMidi backend (Practical synth tools) – planned extra: midi
-boto3>=1.34,<1.35             # S3 uploads (Practical/Encrypted Upload) – planned extra: cloud
-pytest>=8.3,<8.4              # Testing harness (repo wide) – planned extra: dev
-ruff>=0.5,<0.6                # Linting (repo tooling) – planned extra: dev
-mypy>=1.11,<1.12              # Static type checking (repo tooling) – planned extra: dev
-
-# NOTES:
-# 1. For folder-specific work, prefer the scoped requirements files.
-# 2. Once pyproject extras land, the "planned extra" labels will map directly to optional dependency groups.
-# 3. Start with numpy + Pillow + Flask for the lightest educational install, then layer extras as needed.
+# Dependency management moved to pyproject.toml.
+# Use extras to install the stacks you need, for example:
+#   python -m pip install -e .[practical]
+#   python -m pip install -e .[algorithmic]
+# See the README "Using pyproject.toml" section for more combinations and details.

--- a/src/pro_challenges/__init__.py
+++ b/src/pro_challenges/__init__.py
@@ -1,0 +1,15 @@
+"""Utility namespace for packaging the Pro-g-rammingChallenges4 examples.
+
+The individual challenge folders in this repository are intentionally kept
+self-contained.  This lightweight package simply exposes repository metadata
+so that `pip install -e .` provides an importable module.
+"""
+
+from importlib import metadata as _metadata
+
+try:  # pragma: no cover - convenience helper for interactive use
+    __version__ = _metadata.version("pro-g-rammingchallenges4")
+except _metadata.PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.dev0"
+
+__all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- add a repository-wide `pyproject.toml` with optional dependency extras aligned to challenge domains and expose a minimal `src/pro_challenges` package for editable installs
- convert legacy `requirements.txt` files into pointers to the new extras and refresh category READMEs with virtualenv and `pip install .[...]` instructions
- document the extras mapping in the root README so contributors know how to combine stacks for specific projects

## Testing
- pytest *(fails: missing optional dependencies such as boto3 and GUI modules when run without extras)*

------
https://chatgpt.com/codex/tasks/task_b_68d6d4e717c88329be257a08223761fa