### PR TITLE
Add Streamlit paint UI with shared settings

### DIFF
--- a/Practical/Paint/README.md
+++ b/Practical/Paint/README.md
@@ -1,0 +1,36 @@
+# Paint Clone
+
+Two front-ends share a common configuration:
+
+- `clone.py` — the original Tkinter desktop paint program with undo/redo and PNG export.
+- `streamlit_app.py` — a web UI powered by Streamlit and `streamlit-drawable-canvas` that mirrors the brush controls.
+
+## Requirements
+
+Install the Practical extras from the project root to grab Pillow and friends:
+
+```bash
+python -m pip install -e .[practical]
+```
+
+For the Streamlit variant you also need the drawing widget:
+
+```bash
+python -m pip install streamlit streamlit-drawable-canvas
+```
+
+## Usage
+
+Desktop app:
+
+```bash
+python clone.py
+```
+
+Streamlit app:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+Both versions share defaults (canvas size, colours, stroke width) via `settings_util.py` so tweaks stay consistent.

--- a/Practical/Paint/clone.py
+++ b/Practical/Paint/clone.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import tempfile
 import tkinter as tk
-from dataclasses import dataclass
 from pathlib import Path
 from tkinter import colorchooser, filedialog, messagebox
 from typing import List, Optional
@@ -34,18 +33,9 @@ except Exception:  # pragma: no cover - absence path
     PIL_AVAILABLE = False
     Image = None  # type: ignore
 
+from settings_util import CanvasSettings as Settings, VALID_SHAPES as SHARED_VALID_SHAPES
+
 # --------------------------- Settings --------------------------- #
-
-
-@dataclass(slots=True)
-class Settings:
-    width: int = 800
-    height: int = 600
-    bg: str = "white"
-    fg: str = "black"
-    stroke_width: int = 3
-    shape: str = "freehand"  # freehand | line | rectangle | oval
-    fill: bool = False
 
 
 # --------------------------- Application --------------------------- #
@@ -54,7 +44,7 @@ class Settings:
 class PaintApp:
     """A lightweight paint-like program with undo, save, and basic shapes."""
 
-    VALID_SHAPES = ("freehand", "line", "rectangle", "oval")
+    VALID_SHAPES = SHARED_VALID_SHAPES
 
     def __init__(self, root: tk.Tk, settings: Optional[Settings] = None):
         self.root = root

--- a/Practical/Paint/settings_util.py
+++ b/Practical/Paint/settings_util.py
@@ -1,0 +1,41 @@
+"""Shared configuration helpers for the Paint apps."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+DEFAULT_CANVAS_WIDTH = 800
+DEFAULT_CANVAS_HEIGHT = 600
+DEFAULT_BACKGROUND_COLOR = "#FFFFFF"
+DEFAULT_FOREGROUND_COLOR = "#000000"
+DEFAULT_STROKE_WIDTH = 3
+DEFAULT_SHAPE = "freehand"
+DEFAULT_FILL = False
+
+VALID_SHAPES: Tuple[str, ...] = ("freehand", "line", "rectangle", "oval")
+
+
+@dataclass(slots=True)
+class CanvasSettings:
+    """Basic dimensions and drawing defaults shared across UIs."""
+
+    width: int = DEFAULT_CANVAS_WIDTH
+    height: int = DEFAULT_CANVAS_HEIGHT
+    bg: str = DEFAULT_BACKGROUND_COLOR
+    fg: str = DEFAULT_FOREGROUND_COLOR
+    stroke_width: int = DEFAULT_STROKE_WIDTH
+    shape: str = DEFAULT_SHAPE
+    fill: bool = DEFAULT_FILL
+
+
+def rgba_from_hex(hex_color: str, alpha: float) -> str:
+    """Convert ``#RRGGBB`` colors to Streamlit-friendly ``rgba()`` strings."""
+
+    hex_color = hex_color.lstrip("#")
+    if len(hex_color) != 6:
+        raise ValueError("Expected a 6-character hex color (e.g. #AABBCC)")
+    r = int(hex_color[0:2], 16)
+    g = int(hex_color[2:4], 16)
+    b = int(hex_color[4:6], 16)
+    alpha = max(0.0, min(alpha, 1.0))
+    return f"rgba({r}, {g}, {b}, {alpha:.2f})"

--- a/Practical/Paint/streamlit_app.py
+++ b/Practical/Paint/streamlit_app.py
@@ -1,0 +1,81 @@
+"""Streamlit front-end for the Paint clone using a drawable canvas widget."""
+from __future__ import annotations
+
+from io import BytesIO
+
+import numpy as np
+import streamlit as st
+from PIL import Image
+from streamlit_drawable_canvas import st_canvas
+
+from settings_util import CanvasSettings, VALID_SHAPES, rgba_from_hex
+
+SHAPE_TO_DRAWING_MODE = {
+    "freehand": "freedraw",
+    "line": "line",
+    "rectangle": "rect",
+    "oval": "circle",
+}
+
+
+def _prepare_download(image_array: np.ndarray) -> bytes:
+    """Convert the canvas numpy array into PNG bytes."""
+
+    image = Image.fromarray(image_array.astype("uint8"), mode="RGBA")
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+def main() -> None:
+    st.set_page_config(page_title="Paint Clone (Streamlit)", layout="wide")
+    st.title("🖌️ Paint Clone — Streamlit Edition")
+    st.write(
+        "Draw with familiar controls from the Tkinter app using an in-browser canvas. "
+        "Use the sidebar to tweak your brush, then download your work as a PNG."
+    )
+
+    defaults = CanvasSettings()
+
+    with st.sidebar:
+        st.header("Brush & Canvas Settings")
+        stroke_color = st.color_picker("Stroke colour", defaults.fg)
+        tool = st.selectbox("Tool", options=VALID_SHAPES, index=VALID_SHAPES.index(defaults.shape))
+        stroke_width = st.slider("Stroke width", min_value=1, max_value=25, value=defaults.stroke_width)
+        fill_enabled = st.checkbox("Fill shapes", value=defaults.fill)
+        background_color = st.color_picker("Canvas background", defaults.bg)
+
+    fill_color = rgba_from_hex(stroke_color, 0.5 if fill_enabled else 0.0)
+    drawing_mode = SHAPE_TO_DRAWING_MODE.get(tool, "freedraw")
+
+    canvas_result = st_canvas(
+        fill_color=fill_color,
+        stroke_width=stroke_width,
+        stroke_color=stroke_color,
+        background_color=background_color,
+        width=defaults.width,
+        height=defaults.height,
+        drawing_mode=drawing_mode,
+        key="paint-canvas",
+        update_streamlit=True,
+        display_toolbar=False,
+    )
+
+    image_data = canvas_result.image_data
+    if image_data is not None:
+        png_bytes = _prepare_download(image_data)
+        st.subheader("Canvas Preview")
+        st.image(image_data, use_column_width=True)
+        st.download_button(
+            label="Download drawing as PNG",
+            data=png_bytes,
+            file_name="paint_clone.png",
+            mime="image/png",
+        )
+    else:
+        st.info("Start drawing on the canvas to enable PNG downloads.")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@
 #   python -m pip install -e .[practical]
 #   python -m pip install -e .[algorithmic]
 # See the README "Using pyproject.toml" section for more combinations and details.
+
+# Additional ad-hoc dependencies referenced by individual tools.
+streamlit>=1.37
+streamlit-drawable-canvas>=0.9.3  # Interactive canvas widget for Practical/Paint/streamlit_app.py


### PR DESCRIPTION
## Summary
- factor shared canvas defaults into `settings_util.py` and update the Tkinter clone to reuse them
- add a Streamlit front-end powered by `streamlit-drawable-canvas` with PNG export support
- document the new dependency in `requirements.txt` and add usage notes for both interfaces

## Testing
- python -m compileall Practical/Paint

------
https://chatgpt.com/codex/tasks/task_b_68d71bfe7a48832994ee857f42b8657a