### PR TITLE
Add Streamlit interface for IP URL Obscurifier

### DIFF
--- a/Practical/IP URL Obscurifier/__init__.py
+++ b/Practical/IP URL Obscurifier/__init__.py
@@ -1,0 +1,40 @@
+"""Convenience re-exports for the IP URL Obscurifier helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+if __package__:
+    from .obscurifier import (  # type: ignore[import-not-found]
+        DEFAULT_MIX_PATTERNS,
+        IPv4VariantBundle,
+        ObscurifierError,
+        decode_ipv4,
+        decode_url,
+        encode_url,
+        generate_ipv4_variants,
+    )
+else:  # pragma: no cover - import convenience for direct execution
+    _PACKAGE_ROOT = Path(__file__).resolve().parent
+    if str(_PACKAGE_ROOT) not in sys.path:
+        sys.path.insert(0, str(_PACKAGE_ROOT))
+    from obscurifier import (  # type: ignore[import-not-found]
+        DEFAULT_MIX_PATTERNS,
+        IPv4VariantBundle,
+        ObscurifierError,
+        decode_ipv4,
+        decode_url,
+        encode_url,
+        generate_ipv4_variants,
+    )
+
+__all__ = [
+    "DEFAULT_MIX_PATTERNS",
+    "IPv4VariantBundle",
+    "ObscurifierError",
+    "decode_ipv4",
+    "decode_url",
+    "encode_url",
+    "generate_ipv4_variants",
+]

--- a/Practical/IP URL Obscurifier/obscurifier.py
+++ b/Practical/IP URL Obscurifier/obscurifier.py
@@ -7,6 +7,11 @@ canonical dotted-decimal string.
 
 The tool is intentionally educational—showing how easy it is to disguise a
 network destination—and should be used ethically.
+
+The public helpers are designed to be imported by other tools or notebooks.
+They expose structured return types and raise :class:`ObscurifierError`
+instead of terminating the process so callers can provide their own error
+handling and presentation layers.
 """
 
 from __future__ import annotations
@@ -20,7 +25,7 @@ from dataclasses import dataclass
 from typing import Dict, Iterable, List, Sequence, Tuple
 from urllib.parse import ParseResult, urlparse, urlunparse
 
-DEFAULT_MIX_PATTERNS: List[Tuple[str, Tuple[str, str, str, str]]] = [
+DEFAULT_MIX_PATTERNS: List["MixPattern"] = [
     ("hex-lead", ("hex", "hex", "decimal", "decimal")),
     ("binary-tail", ("decimal", "decimal", "binary", "binary")),
     ("octal-sandwich", ("octal", "decimal", "octal", "hex")),
@@ -29,12 +34,39 @@ DEFAULT_MIX_PATTERNS: List[Tuple[str, Tuple[str, str, str, str]]] = [
 
 @dataclass
 class IPv4VariantBundle:
-    """Container for IPv4 obfuscation variants."""
+    """Container for IPv4 obfuscation variants.
+
+    Attributes
+    ----------
+    canonical:
+        Canonical dotted-decimal representation of the IPv4 address.
+    integers:
+        Mapping of style name to single-integer disguises.
+    dotted:
+        Mapping of style name to dotted representations using a single base
+        per octet.
+    mixed:
+        Sequence of ``(label, dotted_value)`` pairs describing mixed-base
+        dotted representations.
+    """
 
     canonical: str
     integers: Dict[str, str]
     dotted: Dict[str, str]
     mixed: List[Tuple[str, str]]
+
+
+__all__ = [
+    "DEFAULT_MIX_PATTERNS",
+    "IPv4VariantBundle",
+    "ObscurifierError",
+    "generate_ipv4_variants",
+    "decode_ipv4",
+    "encode_url",
+    "decode_url",
+    "build_parser",
+    "main",
+]
 
 
 _BASE_FORMATTERS = {
@@ -66,14 +98,49 @@ def _validate_mix_sequence(sequence: Sequence[str]) -> Tuple[str, str, str, str]
     return tuple(normalised)  # type: ignore[return-value]
 
 
+MixPattern = Tuple[str, Tuple[str, str, str, str]]
+MixPatternInput = Sequence[Tuple[str, Sequence[str]]]
+
+
 def generate_ipv4_variants(
     ip: str,
     *,
     custom_mix: Sequence[str] | None = None,
     include_default_mixes: bool = True,
     mix_limit: int | None = None,
+    default_mix_patterns: MixPatternInput | None = None,
 ) -> IPv4VariantBundle:
-    """Produce dotted and integer IPv4 disguises."""
+    """Produce dotted and integer IPv4 disguises.
+
+    Parameters
+    ----------
+    ip:
+        IPv4 address in dotted-decimal notation.
+    custom_mix:
+        Optional sequence of base labels (``decimal``, ``hex``, ``octal``,
+        ``binary``, ``zero-padded``) that will be used to generate a single
+        mixed dotted representation.
+    include_default_mixes:
+        When ``True`` the default mix patterns (or the ones supplied via
+        ``default_mix_patterns``) are included in the bundle.
+    mix_limit:
+        Optional cap on the number of default mix patterns returned.
+    default_mix_patterns:
+        Override for the default mix pattern catalogue. Each entry should be
+        a ``(label, pattern)`` tuple where ``pattern`` contains four base
+        names.
+
+    Returns
+    -------
+    IPv4VariantBundle
+        Structured collection containing canonical, integer and dotted
+        variants.
+
+    Raises
+    ------
+    ObscurifierError
+        If the IPv4 address is invalid or a mix pattern is malformed.
+    """
 
     try:
         addr = ipaddress.IPv4Address(ip)
@@ -102,11 +169,14 @@ def generate_ipv4_variants(
     mixed: List[Tuple[str, str]] = []
 
     if include_default_mixes:
-        patterns = DEFAULT_MIX_PATTERNS
+        patterns_source: Sequence[Tuple[str, Sequence[str]]]
+        patterns_source = default_mix_patterns if default_mix_patterns is not None else DEFAULT_MIX_PATTERNS
+        patterns_list = list(patterns_source)
         if mix_limit is not None:
-            patterns = patterns[:mix_limit]
-        for label, pattern in patterns:
-            mixed.append((label, _format_dotted(octets, pattern)))
+            patterns_list = patterns_list[:mix_limit]
+        for label, pattern in patterns_list:
+            normalised = _validate_mix_sequence(pattern)
+            mixed.append((label, _format_dotted(octets, normalised)))
 
     if custom_mix:
         pattern = _validate_mix_sequence(custom_mix)
@@ -153,7 +223,25 @@ def _detect_base(token: str) -> Tuple[int, str]:
 
 
 def decode_ipv4(value: str) -> Tuple[str, List[Tuple[str, str, int]]]:
-    """Return canonical IPv4 along with detected component bases."""
+    """Normalise an IPv4 string back to dotted decimal form.
+
+    Parameters
+    ----------
+    value:
+        String containing either a dotted representation or an integer form
+        of the IPv4 address.
+
+    Returns
+    -------
+    tuple[str, list[tuple[str, str, int]]]
+        A tuple of the canonical dotted-decimal IPv4 string and a breakdown
+        of the detected bases for each component.
+
+    Raises
+    ------
+    ObscurifierError
+        If the input cannot be interpreted as a valid IPv4 address.
+    """
 
     stripped = value.strip()
     if not stripped:
@@ -223,7 +311,32 @@ def encode_url(
     custom_mix: Sequence[str] | None = None,
     include_default_mixes: bool = True,
     mix_limit: int | None = None,
+    default_mix_patterns: MixPatternInput | None = None,
 ) -> Tuple[IPv4VariantBundle, List[Tuple[str, str]]]:
+    """Rewrite a URL with hosts disguised via IPv4 variants.
+
+    Parameters
+    ----------
+    url:
+        Input URL whose host component should be obfuscated.
+    credentials:
+        Optional ``user:password`` string to inject if the URL does not
+        already provide credentials.
+    custom_mix, include_default_mixes, mix_limit, default_mix_patterns:
+        Passed through to :func:`generate_ipv4_variants` to control the host
+        disguise catalogue.
+
+    Returns
+    -------
+    tuple[IPv4VariantBundle, list[tuple[str, str]]]
+        ``IPv4VariantBundle`` describing the host and a list of
+        ``(label, url)`` pairs for each rewritten URL.
+
+    Raises
+    ------
+    ObscurifierError
+        If the URL or credentials are malformed.
+    """
     parsed = _parse_url(url)
     host = parsed.hostname
     if host is None:
@@ -235,6 +348,7 @@ def encode_url(
         custom_mix=custom_mix,
         include_default_mixes=include_default_mixes,
         mix_limit=mix_limit,
+        default_mix_patterns=default_mix_patterns,
     )
 
     user, password = _parse_credentials(credentials)
@@ -278,6 +392,24 @@ def _iter_url_hosts(bundle: IPv4VariantBundle) -> Iterable[Tuple[str, str]]:
 
 
 def decode_url(url: str) -> Dict[str, object]:
+    """Inspect a URL and surface canonical addressing information.
+
+    Parameters
+    ----------
+    url:
+        URL whose host may be disguised.
+
+    Returns
+    -------
+    dict[str, object]
+        JSON-serialisable structure mirroring the CLI output, including
+        credentials, host breakdown, and canonical URL.
+
+    Raises
+    ------
+    ObscurifierError
+        If the URL is malformed or the host cannot be decoded.
+    """
     parsed = _parse_url(url)
     host = parsed.hostname
     if host is None:

--- a/Practical/IP URL Obscurifier/streamlit_app.py
+++ b/Practical/IP URL Obscurifier/streamlit_app.py
@@ -1,0 +1,219 @@
+"""Streamlit interface for the IP URL Obscurifier helpers."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence, Tuple
+
+import pandas as pd
+import streamlit as st
+
+PACKAGE_ROOT = Path(__file__).resolve().parent
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))
+
+import obscurifier  # type: ignore  # pylint: disable=import-error
+
+from obscurifier import (  # noqa: E402  # pylint: disable=wrong-import-position
+    DEFAULT_MIX_PATTERNS,
+    ObscurifierError,
+    decode_ipv4,
+    decode_url,
+    encode_url,
+    generate_ipv4_variants,
+)
+
+
+st.set_page_config(page_title="IP URL Obscurifier", layout="wide")
+st.title("IP URL Obscurifier")
+
+module_doc = obscurifier.__doc__ or ""
+if module_doc:
+    st.warning(module_doc.strip())
+
+
+def _collect_mix_patterns(label_prefix: str) -> Sequence[Tuple[str, Sequence[str]]]:
+    """Return the mix patterns selected by the user via toggles."""
+
+    selected: list[Tuple[str, Sequence[str]]] = []
+    for label, pattern in DEFAULT_MIX_PATTERNS:
+        include = st.toggle(
+            f"Include '{label}' pattern",
+            value=True,
+            key=f"{label_prefix}-mix-{label}",
+            help="Toggle whether this default mixed-base pattern is generated.",
+        )
+        if include:
+            selected.append((label, pattern))
+    return selected
+
+
+def _bundle_to_table(bundle: obscurifier.IPv4VariantBundle) -> pd.DataFrame:
+    rows = [{"category": "canonical", "label": "canonical", "value": bundle.canonical}]
+    rows.extend(
+        {"category": "integer", "label": name, "value": value}
+        for name, value in bundle.integers.items()
+    )
+    rows.extend(
+        {"category": "dotted", "label": name, "value": value}
+        for name, value in bundle.dotted.items()
+    )
+    rows.extend(
+        {"category": "mixed", "label": label, "value": value}
+        for label, value in bundle.mixed
+    )
+    return pd.DataFrame(rows)
+
+
+def _breakdown_table(breakdown: Iterable[Tuple[str, str, int]]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {"component": component, "base": base, "value": value}
+            for component, base, value in breakdown
+        ]
+    )
+
+
+tab_encode_ip, tab_decode_ip, tab_encode_url, tab_decode_url = st.tabs(
+    [
+        "Generate IPv4 disguises",
+        "Decode IPv4 value",
+        "Encode URL",
+        "Decode URL",
+    ]
+)
+
+with tab_encode_ip:
+    st.subheader("Generate IPv4 disguises")
+    ip_value = st.text_input("IPv4 address", value="192.168.0.1")
+    custom_mix_input = st.text_input(
+        "Custom mixed bases (comma separated)",
+        help="Example: hex,decimal,octal,binary",
+    )
+    selected_patterns = _collect_mix_patterns("encode-ip")
+
+    if st.button("Generate variants", key="generate-ip") and ip_value:
+        try:
+            custom_mix = [part.strip() for part in custom_mix_input.split(",") if part.strip()] or None
+            bundle = generate_ipv4_variants(
+                ip_value,
+                custom_mix=custom_mix,
+                default_mix_patterns=selected_patterns,
+            )
+        except ObscurifierError as exc:  # pragma: no cover - UI feedback
+            st.error(str(exc))
+        else:
+            st.success(f"Canonical IPv4: {bundle.canonical}")
+            st.dataframe(_bundle_to_table(bundle), use_container_width=True)
+            payload = {
+                "canonical": bundle.canonical,
+                "integers": bundle.integers,
+                "dotted": bundle.dotted,
+                "mixed": bundle.mixed,
+            }
+            st.download_button(
+                "Download IPv4 JSON",
+                data=json.dumps(payload, indent=2),
+                file_name="ipv4_variants.json",
+                mime="application/json",
+            )
+
+with tab_decode_ip:
+    st.subheader("Decode IPv4 value")
+    decode_value = st.text_input("IPv4 string or integer", value="0xC0A80001")
+    if st.button("Decode IPv4", key="decode-ip") and decode_value:
+        try:
+            canonical, breakdown = decode_ipv4(decode_value)
+        except ObscurifierError as exc:  # pragma: no cover - UI feedback
+            st.error(str(exc))
+        else:
+            st.success(f"Canonical IPv4: {canonical}")
+            st.dataframe(_breakdown_table(breakdown), use_container_width=True)
+            payload = {
+                "canonical": canonical,
+                "breakdown": [
+                    {"component": component, "base": base, "value": value}
+                    for component, base, value in breakdown
+                ],
+            }
+            st.download_button(
+                "Download decode JSON",
+                data=json.dumps(payload, indent=2),
+                file_name="ipv4_decode.json",
+                mime="application/json",
+            )
+
+with tab_encode_url:
+    st.subheader("Encode URL")
+    url_value = st.text_input("URL", value="http://192.168.0.1/admin")
+    credential_value = st.text_input(
+        "Credentials (user:password)",
+        help="Optional credentials to inject into the rewritten URLs.",
+    )
+    url_custom_mix = st.text_input(
+        "Custom mixed bases for URL hosts", key="url-custom-mix", help="Comma separated list."
+    )
+    url_patterns = _collect_mix_patterns("encode-url")
+
+    if st.button("Rewrite URL", key="encode-url") and url_value:
+        try:
+            custom_mix = [part.strip() for part in url_custom_mix.split(",") if part.strip()] or None
+            bundle, variants = encode_url(
+                url_value,
+                credentials=credential_value or None,
+                custom_mix=custom_mix,
+                default_mix_patterns=url_patterns,
+            )
+        except ObscurifierError as exc:  # pragma: no cover - UI feedback
+            st.error(str(exc))
+        else:
+            st.success(f"Canonical host: {bundle.canonical}")
+            variant_table = pd.DataFrame(
+                [{"label": label, "url": value} for label, value in variants]
+            )
+            st.dataframe(variant_table, use_container_width=True)
+            payload = {
+                "canonical_host": bundle.canonical,
+                "variants": variants,
+            }
+            st.download_button(
+                "Download URL variants JSON",
+                data=json.dumps(payload, indent=2),
+                file_name="url_variants.json",
+                mime="application/json",
+            )
+
+with tab_decode_url:
+    st.subheader("Decode URL")
+    decode_url_value = st.text_input("URL to decode", value="http://0xC0A80001/login")
+    if st.button("Inspect URL", key="decode-url") and decode_url_value:
+        try:
+            data = decode_url(decode_url_value)
+        except ObscurifierError as exc:  # pragma: no cover - UI feedback
+            st.error(str(exc))
+        else:
+            st.success(f"Canonical URL: {data['canonical_url']}")
+            summary_table = pd.DataFrame(
+                [
+                    {"property": "original", "value": data["original"]},
+                    {"property": "canonical_host", "value": data["canonical_host"]},
+                    {"property": "canonical_url", "value": data["canonical_url"]},
+                    {
+                        "property": "credentials",
+                        "value": "yes" if data["has_credentials"] else "no",
+                    },
+                ]
+            )
+            st.dataframe(summary_table, use_container_width=True)
+            breakdown = data.get("host_breakdown", [])
+            if breakdown:
+                st.markdown("### Host breakdown")
+                st.dataframe(_breakdown_table(breakdown), use_container_width=True)
+            st.download_button(
+                "Download URL decode JSON",
+                data=json.dumps(data, indent=2),
+                file_name="url_decode.json",
+                mime="application/json",
+            )

--- a/Practical/IP URL Obscurifier/tests/test_obscurifier.py
+++ b/Practical/IP URL Obscurifier/tests/test_obscurifier.py
@@ -33,6 +33,15 @@ def test_decode_ipv4_handles_mixed_dotted():
     assert bases == ["octal", "hex", "binary", "zero-padded"]
 
 
+def test_generate_ipv4_variants_custom_default_patterns():
+    custom_defaults = [("only-hex", ("hex", "hex", "hex", "hex"))]
+    bundle = obscurifier.generate_ipv4_variants(
+        "127.0.0.1",
+        default_mix_patterns=custom_defaults,
+    )
+    assert [label for label, _ in bundle.mixed] == ["only-hex"]
+
+
 def test_encode_url_with_credentials():
     bundle, variants = obscurifier.encode_url(
         "http://192.168.0.1/admin",
@@ -52,3 +61,14 @@ def test_decode_url_reveals_credentials():
     assert data["credentials"]["username"] == "user"
     assert data["credentials"]["password"] == "pass"
     assert data["canonical_url"].startswith("http://192.168.0.1")
+
+
+def test_encode_url_supports_custom_mix_patterns():
+    custom_defaults = [("bin-front", ("binary", "decimal", "decimal", "decimal"))]
+    bundle, variants = obscurifier.encode_url(
+        "http://10.0.0.5/",
+        default_mix_patterns=custom_defaults,
+    )
+    assert bundle.canonical == "10.0.0.5"
+    labels = [label for label, _ in variants if label.startswith("mixed-")]
+    assert labels == ["mixed-bin-front"]


### PR DESCRIPTION
## Summary
- document the IPv4 and URL helper APIs and allow callers to override default mix patterns
- expose the helpers through the package __init__ for safer importing
- add a Streamlit UI with mix toggles, tables, and JSON downloads plus tests for the new behaviours

## Testing
- pytest Practical/IP URL Obscurifier/tests/test_obscurifier.py

------
https://chatgpt.com/codex/tasks/task_b_68d71bf4b3d88329b96fa43a1fd6843d