### PR TITLE
Add shared graphing core and Streamlit interface

### DIFF
--- a/Practical/Graphing Calculator/plot_core.py
+++ b/Practical/Graphing Calculator/plot_core.py
@@ -1,0 +1,142 @@
+"""Core helpers for evaluating graphing calculator expressions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Sequence
+
+import numpy as np
+import sympy as sp
+
+
+@dataclass(slots=True)
+class PlotSettings:
+    """Configuration used when sampling functions for plotting."""
+
+    x_min: float = -10.0
+    x_max: float = 10.0
+    samples: int = 1000
+    show_derivative: bool = False
+
+    def validate(self) -> None:
+        if self.x_min >= self.x_max:
+            raise ValueError("x-min must be less than x-max")
+        if self.samples < 10 or self.samples > 20000:
+            raise ValueError("samples must be between 10 and 20000")
+
+
+ALLOWED_FUNCS: Dict[str, sp.Function] = {
+    name: getattr(sp, name)
+    for name in [
+        "sin",
+        "cos",
+        "tan",
+        "exp",
+        "log",
+        "sqrt",
+        "abs",
+        "asin",
+        "acos",
+        "atan",
+        "sinh",
+        "cosh",
+        "tanh",
+    ]
+    if hasattr(sp, name)
+}
+ALLOWED_SYMBOLS = {"x": sp.Symbol("x")}
+SAFE_NAMESPACE = {**ALLOWED_FUNCS, **ALLOWED_SYMBOLS, "E": sp.E, "pi": sp.pi}
+
+
+@dataclass(slots=True)
+class PlotLine:
+    label: str
+    values: np.ndarray
+    linestyle: str = "-"
+
+
+@dataclass(slots=True)
+class PlotComputation:
+    x: np.ndarray
+    lines: List[PlotLine]
+    derivative_lines: List[PlotLine]
+    errors: List[str]
+
+
+def parse_functions(raw: str) -> List[str]:
+    """Split raw user input into individual function strings."""
+
+    funcs = [f.strip() for chunk in raw.split("\n") for f in chunk.split(";")]
+    return [f for f in funcs if f]
+
+
+def sympify_expressions(functions: Sequence[str]) -> List[sp.Expr]:
+    """Convert strings to SymPy expressions using a restricted namespace."""
+
+    expressions: List[sp.Expr] = []
+    for expr in functions:
+        try:
+            expressions.append(sp.sympify(expr, locals=SAFE_NAMESPACE))
+        except (sp.SympifyError, TypeError) as exc:  # pragma: no cover - depends on input
+            raise ValueError(f"Cannot parse expression '{expr}': {exc}") from exc
+    return expressions
+
+
+def build_lambda(expression: sp.Expr) -> Callable[[np.ndarray], np.ndarray]:
+    """Generate a NumPy-ready callable for the provided SymPy expression."""
+
+    x = ALLOWED_SYMBOLS["x"]
+    return sp.lambdify(x, expression, modules="numpy")
+
+
+def build_lambdas(expressions: Iterable[sp.Expr]) -> List[Callable[[np.ndarray], np.ndarray]]:
+    return [build_lambda(expr) for expr in expressions]
+
+
+def evaluate_functions(functions: Sequence[str], settings: PlotSettings) -> PlotComputation:
+    """Evaluate the provided function strings over the configured range."""
+
+    if not functions:
+        raise ValueError("No functions provided")
+
+    settings.validate()
+    expressions = sympify_expressions(functions)
+    x_vals = np.linspace(settings.x_min, settings.x_max, settings.samples)
+
+    lines: List[PlotLine] = []
+    derivative_lines: List[PlotLine] = []
+    errors: List[str] = []
+
+    for fn_str, expr in zip(functions, expressions):
+        try:
+            y_vals = _evaluate_expression(expr, x_vals)
+            lines.append(PlotLine(label=f"f(x)={fn_str}", values=y_vals))
+
+            if settings.show_derivative:
+                derivative_expr = sp.diff(expr, ALLOWED_SYMBOLS["x"])
+                derivative_lines.append(
+                    PlotLine(
+                        label=_format_derivative_label(derivative_expr),
+                        values=_evaluate_expression(derivative_expr, x_vals),
+                        linestyle="--",
+                    )
+                )
+        except Exception as exc:  # pragma: no cover - depends on input
+            errors.append(f"Error plotting {fn_str}: {exc}")
+
+    return PlotComputation(x=x_vals, lines=lines, derivative_lines=derivative_lines, errors=errors)
+
+
+def _evaluate_expression(expression: sp.Expr, x_vals: np.ndarray) -> np.ndarray:
+    fn = build_lambda(expression)
+    values = fn(x_vals)
+    if np.iscomplexobj(values):
+        values = np.real(values)
+    values = np.where(np.isfinite(values), values, np.nan)
+    return values
+
+
+def _format_derivative_label(derivative: sp.Expr) -> str:
+    repr_text = sp.srepr(derivative)
+    if len(repr_text) > 30:
+        repr_text = f"{repr_text[:27]}..."
+    return f"f'(x)={repr_text}"

--- a/Practical/Graphing Calculator/streamlit_app.py
+++ b/Practical/Graphing Calculator/streamlit_app.py
@@ -1,0 +1,104 @@
+"""Streamlit front-end for the Graphing Calculator."""
+from __future__ import annotations
+
+import io
+
+import matplotlib.pyplot as plt
+import streamlit as st
+
+from plot_core import PlotSettings, evaluate_functions, parse_functions
+
+
+def render() -> None:
+    """Render the Streamlit interface for plotting functions."""
+
+    st.title("Graphing Calculator")
+    st.write(
+        "Enter one or more functions of `x` (separate with new lines or semicolons)."
+    )
+
+    with st.form("graph-form"):
+        functions_input = st.text_area(
+            "Functions",
+            value="sin(x)\ncos(x)",
+            height=140,
+            help="Example: sin(x); cos(x)",
+        )
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            x_min = st.number_input("x-min", value=-10.0)
+        with col2:
+            x_max = st.number_input("x-max", value=10.0)
+        with col3:
+            samples = st.number_input("Samples", min_value=10, max_value=20000, value=1000)
+
+        show_derivative = st.checkbox("Show derivative", value=False)
+        submitted = st.form_submit_button("Plot")
+
+    if not submitted:
+        st.info("Adjust settings and press Plot to generate a graph.")
+        return
+
+    functions = parse_functions(functions_input)
+    if not functions:
+        st.warning("Please enter at least one function.")
+        return
+
+    settings = PlotSettings(
+        x_min=float(x_min),
+        x_max=float(x_max),
+        samples=int(samples),
+        show_derivative=show_derivative,
+    )
+
+    try:
+        result = evaluate_functions(functions, settings)
+    except ValueError as exc:
+        st.error(str(exc))
+        return
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.grid(True)
+    ax.axhline(0, color="black", linewidth=0.5)
+    ax.axvline(0, color="black", linewidth=0.5)
+
+    for line in result.lines:
+        ax.plot(result.x, line.values, label=line.label, linestyle=line.linestyle)
+
+    for line in result.derivative_lines:
+        ax.plot(result.x, line.values, label=line.label, linestyle=line.linestyle)
+
+    for idx, error in enumerate(result.errors):
+        ax.text(
+            0.02,
+            0.95 - idx * 0.05,
+            error,
+            transform=ax.transAxes,
+            fontsize=8,
+            color="red",
+        )
+
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_title("Graph")
+    if result.lines or result.derivative_lines:
+        ax.legend(loc="upper right", fontsize="small")
+
+    st.pyplot(fig)
+
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png", dpi=150)
+    plt.close(fig)
+    buffer.seek(0)
+    st.download_button(
+        label="Download PNG",
+        data=buffer.getvalue(),
+        file_name="graph.png",
+        mime="image/png",
+    )
+
+    if result.errors:
+        st.warning("\n".join(result.errors))
+
+
+render()


### PR DESCRIPTION
## Summary
- extract reusable plotting helpers into a shared core module
- update the Tkinter graphing calculator to rely on the shared helpers
- add a Streamlit `render()` implementation with plotting controls and PNG export

## Testing
- python -m compileall 'Practical/Graphing Calculator'


------
https://chatgpt.com/codex/tasks/task_b_68d71c046de48329ad1d170ed16a00d2