### PR TITLE
Add Streamlit hub for Practical tools and unify render hooks

### DIFF
--- a/Practical/Graphing Calculator/streamlit_app.py
+++ b/Practical/Graphing Calculator/streamlit_app.py
@@ -101,4 +101,8 @@ def render() -> None:
         st.warning("\n".join(result.errors))
 
 
-render()
+__all__ = ["render"]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    render()

--- a/Practical/HSV color wheel/streamlit_app.py
+++ b/Practical/HSV color wheel/streamlit_app.py
@@ -23,104 +23,118 @@ except ImportError:  # pragma: no cover
     Image = None  # type: ignore[misc, assignment]
 
 
-st.set_page_config(page_title="HSV Colour Wheel", page_icon="🎨", layout="wide")
-st.title("HSV Colour Wheel")
+def render() -> None:
+    """Render the HSV colour wheel application."""
 
-if not COLOUR_SCIENCE_AVAILABLE:
-    st.info(COLOUR_SCIENCE_GUIDANCE)
+    st.set_page_config(page_title="HSV Colour Wheel", page_icon="🎨", layout="wide")
+    st.title("HSV Colour Wheel")
 
-st.markdown(
-    "Generate HSV colour wheels interactively. Adjust the parameters on the left and "
-    "use the download buttons to export the PNG image or JSON metadata."
-)
+    if not COLOUR_SCIENCE_AVAILABLE:
+        st.info(COLOUR_SCIENCE_GUIDANCE)
 
-with st.sidebar:
-    st.header("Configuration")
-    samples = st.slider("Samples", min_value=64, max_value=4096, value=512, step=32)
-    clip_circle = st.toggle("Clip to circle", value=True)
-    orientation_label = st.selectbox(
-        "Orientation",
-        options=[orientation.value for orientation in Orientation],
-        index=0,
+    st.markdown(
+        "Generate HSV colour wheels interactively. Adjust the parameters on the left and "
+        "use the download buttons to export the PNG image or JSON metadata."
     )
-    orientation = Orientation(orientation_label)
-    feather = st.slider(
-        "Feather (px)",
-        min_value=0,
-        max_value=max(0, samples // 2),
-        value=0,
-        step=1,
-    )
-    dpi = st.slider("DPI for downloads", min_value=72, max_value=600, value=150, step=6)
 
-config = Config(
-    samples=samples,
-    clip_circle=clip_circle,
-    method=orientation,
-    feather=feather,
-    dpi=dpi,
-    show=False,
-)
-
-try:
-    config.validate()
-except ValueError as exc:
-    st.error(f"Configuration error: {exc}")
-    st.stop()
-
-wheel = generate_colour_wheel(config)
-
-st.subheader("Preview")
-st.image(
-    wheel,
-    caption=(
-        f"{config.samples}×{config.samples} | {config.method.value} | "
-        f"Clipped: {config.clip_circle} | Feather: {config.feather}px"
-    ),
-    clamp=True,
-)
-
-metadata: dict[str, Any] = {
-    "samples": config.samples,
-    "clip_circle": config.clip_circle,
-    "orientation": config.method.value,
-    "feather": config.feather,
-    "dpi": config.dpi,
-    "dtype": str(wheel.dtype),
-    "min": float(np.min(wheel)),
-    "max": float(np.max(wheel)),
-    "colour_science_available": COLOUR_SCIENCE_AVAILABLE,
-}
-
-col_png, col_json = st.columns(2)
-
-with col_png:
-    st.subheader("Image export")
-    if Image is None:
-        st.warning(
-            "PNG export requires the optional Pillow dependency. Install it with "
-            "`pip install pillow` to enable image downloads."
+    with st.sidebar:
+        st.header("Configuration")
+        samples = st.slider("Samples", min_value=64, max_value=4096, value=512, step=32)
+        clip_circle = st.toggle("Clip to circle", value=True)
+        orientation_label = st.selectbox(
+            "Orientation",
+            options=[orientation.value for orientation in Orientation],
+            index=0,
         )
-    else:
-        arr8 = np.clip(wheel * 255.0, 0, 255).astype(np.uint8)
-        png_buffer = BytesIO()
-        Image.fromarray(arr8, mode="RGBA").save(png_buffer, format="PNG", dpi=(config.dpi, config.dpi))
-        png_name = f"colour-wheel-{config.samples}px-{config.method.value.lower()}.png"
+        orientation = Orientation(orientation_label)
+        feather = st.slider(
+            "Feather (px)",
+            min_value=0,
+            max_value=max(0, samples // 2),
+            value=0,
+            step=1,
+        )
+        dpi = st.slider("DPI for downloads", min_value=72, max_value=600, value=150, step=6)
+
+    config = Config(
+        samples=samples,
+        clip_circle=clip_circle,
+        method=orientation,
+        feather=feather,
+        dpi=dpi,
+        show=False,
+    )
+
+    try:
+        config.validate()
+    except ValueError as exc:
+        st.error(f"Configuration error: {exc}")
+        st.stop()
+
+    wheel = generate_colour_wheel(config)
+
+    st.subheader("Preview")
+    st.image(
+        wheel,
+        caption=(
+            f"{config.samples}×{config.samples} | {config.method.value} | "
+            f"Clipped: {config.clip_circle} | Feather: {config.feather}px"
+        ),
+        clamp=True,
+    )
+
+    metadata: dict[str, Any] = {
+        "samples": config.samples,
+        "clip_circle": config.clip_circle,
+        "orientation": config.method.value,
+        "feather": config.feather,
+        "dpi": config.dpi,
+        "dtype": str(wheel.dtype),
+        "min": float(np.min(wheel)),
+        "max": float(np.max(wheel)),
+        "colour_science_available": COLOUR_SCIENCE_AVAILABLE,
+    }
+
+    col_png, col_json = st.columns(2)
+
+    with col_png:
+        st.subheader("Image export")
+        if Image is None:
+            st.warning(
+                "PNG export requires the optional Pillow dependency. Install it with "
+                "`pip install pillow` to enable image downloads."
+            )
+        else:
+            arr8 = np.clip(wheel * 255.0, 0, 255).astype(np.uint8)
+            png_buffer = BytesIO()
+            Image.fromarray(arr8, mode="RGBA").save(
+                png_buffer,
+                format="PNG",
+                dpi=(config.dpi, config.dpi),
+            )
+            png_name = f"colour-wheel-{config.samples}px-{config.method.value.lower()}.png"
+            st.download_button(
+                "Download PNG",
+                data=png_buffer.getvalue(),
+                file_name=png_name,
+                mime="image/png",
+            )
+
+    with col_json:
+        st.subheader("Metadata")
+        meta_buffer = BytesIO(json.dumps(metadata, indent=2).encode("utf-8"))
+        json_name = Path("colour-wheel-metadata.json").name
         st.download_button(
-            "Download PNG",
-            data=png_buffer.getvalue(),
-            file_name=png_name,
-            mime="image/png",
+            "Download JSON",
+            data=meta_buffer.getvalue(),
+            file_name=json_name,
+            mime="application/json",
         )
+        st.json(metadata)
 
-with col_json:
-    st.subheader("Metadata")
-    meta_buffer = BytesIO(json.dumps(metadata, indent=2).encode("utf-8"))
-    json_name = Path("colour-wheel-metadata.json").name
-    st.download_button(
-        "Download JSON",
-        data=meta_buffer.getvalue(),
-        file_name=json_name,
-        mime="application/json",
-    )
-    st.json(metadata)
+
+__all__ = ["render"]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    render()

--- a/Practical/IP Tracking visualization/streamlit_app.py
+++ b/Practical/IP Tracking visualization/streamlit_app.py
@@ -81,7 +81,7 @@ def _render_summary(meta: dict[str, object]) -> None:
     st.write(f"**Elapsed:** {meta.get('elapsed_sec', 0)} seconds")
 
 
-def main() -> None:
+def render() -> None:
     st.set_page_config(page_title="IP Tracking Visualization", layout="wide")
     st.title("IP Tracking Visualization")
     st.write(
@@ -167,5 +167,8 @@ def main() -> None:
         )
 
 
+__all__ = ["render"]
+
+
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    render()

--- a/Practical/IP URL Obscurifier/streamlit_app.py
+++ b/Practical/IP URL Obscurifier/streamlit_app.py
@@ -26,12 +26,159 @@ from obscurifier import (  # noqa: E402  # pylint: disable=wrong-import-position
 )
 
 
-st.set_page_config(page_title="IP URL Obscurifier", layout="wide")
-st.title("IP URL Obscurifier")
+def render() -> None:
+    """Render the IP/URL obscurifier interface."""
 
-module_doc = obscurifier.__doc__ or ""
-if module_doc:
-    st.warning(module_doc.strip())
+    st.set_page_config(page_title="IP URL Obscurifier", layout="wide")
+    st.title("IP URL Obscurifier")
+
+    module_doc = obscurifier.__doc__ or ""
+    if module_doc:
+        st.warning(module_doc.strip())
+
+    tab_encode_ip, tab_decode_ip, tab_encode_url, tab_decode_url = st.tabs(
+        [
+            "Generate IPv4 disguises",
+            "Decode IPv4 value",
+            "Encode URL",
+            "Decode URL",
+        ]
+    )
+
+    with tab_encode_ip:
+        st.subheader("Generate IPv4 disguises")
+        ip_value = st.text_input("IPv4 address", value="192.168.0.1")
+        custom_mix_input = st.text_input(
+            "Custom mixed bases (comma separated)",
+            help="Example: hex,decimal,octal,binary",
+        )
+        selected_patterns = _collect_mix_patterns("encode-ip")
+
+        if st.button("Generate variants", key="generate-ip") and ip_value:
+            try:
+                custom_mix = [part.strip() for part in custom_mix_input.split(",") if part.strip()] or None
+                bundle = generate_ipv4_variants(
+                    ip_value,
+                    custom_mix=custom_mix,
+                    default_mix_patterns=selected_patterns,
+                )
+            except ObscurifierError as exc:  # pragma: no cover - UI feedback
+                st.error(str(exc))
+            else:
+                st.success(f"Canonical IPv4: {bundle.canonical}")
+                st.dataframe(_bundle_to_table(bundle), use_container_width=True)
+                payload = {
+                    "canonical": bundle.canonical,
+                    "integers": bundle.integers,
+                    "dotted": bundle.dotted,
+                    "mixed": bundle.mixed,
+                }
+                st.download_button(
+                    "Download IPv4 JSON",
+                    data=json.dumps(payload, indent=2),
+                    file_name="ipv4_variants.json",
+                    mime="application/json",
+                )
+
+    with tab_decode_ip:
+        st.subheader("Decode IPv4 value")
+        decode_value = st.text_input("IPv4 string or integer", value="0xC0A80001")
+        if st.button("Decode IPv4", key="decode-ip") and decode_value:
+            try:
+                canonical, breakdown = decode_ipv4(decode_value)
+            except ObscurifierError as exc:  # pragma: no cover - UI feedback
+                st.error(str(exc))
+            else:
+                st.success(f"Canonical IPv4: {canonical}")
+                st.dataframe(_breakdown_table(breakdown), use_container_width=True)
+                payload = {
+                    "canonical": canonical,
+                    "breakdown": [
+                        {"component": component, "base": base, "value": value}
+                        for component, base, value in breakdown
+                    ],
+                }
+                st.download_button(
+                    "Download decode JSON",
+                    data=json.dumps(payload, indent=2),
+                    file_name="ipv4_decode.json",
+                    mime="application/json",
+                )
+
+    with tab_encode_url:
+        st.subheader("Encode URL")
+        url_value = st.text_input("URL", value="http://192.168.0.1/admin")
+        credential_value = st.text_input(
+            "Credentials (user:password)",
+            help="Optional credentials to inject into the rewritten URLs.",
+        )
+        url_custom_mix = st.text_input(
+            "Custom mixed bases for URL hosts",
+            key="url-custom-mix",
+            help="Comma separated list.",
+        )
+        url_patterns = _collect_mix_patterns("encode-url")
+
+        if st.button("Rewrite URL", key="encode-url") and url_value:
+            try:
+                custom_mix = [part.strip() for part in url_custom_mix.split(",") if part.strip()] or None
+                bundle, variants = encode_url(
+                    url_value,
+                    credentials=credential_value or None,
+                    custom_mix=custom_mix,
+                    default_mix_patterns=url_patterns,
+                )
+            except ObscurifierError as exc:  # pragma: no cover - UI feedback
+                st.error(str(exc))
+            else:
+                st.success(f"Canonical host: {bundle.canonical}")
+                variant_table = pd.DataFrame(
+                    [{"label": label, "url": value} for label, value in variants]
+                )
+                st.dataframe(variant_table, use_container_width=True)
+                payload = {
+                    "canonical_host": bundle.canonical,
+                    "variants": variants,
+                }
+                st.download_button(
+                    "Download URL variants JSON",
+                    data=json.dumps(payload, indent=2),
+                    file_name="url_variants.json",
+                    mime="application/json",
+                )
+
+    with tab_decode_url:
+        st.subheader("Decode URL")
+        decode_url_value = st.text_input("URL to decode", value="http://0xC0A80001/login")
+        if st.button("Inspect URL", key="decode-url") and decode_url_value:
+            try:
+                data = decode_url(decode_url_value)
+            except ObscurifierError as exc:  # pragma: no cover - UI feedback
+                st.error(str(exc))
+            else:
+                st.success(f"Canonical URL: {data['canonical_url']}")
+                summary_table = pd.DataFrame(
+                    [
+                        {"property": "original", "value": data["original"]},
+                        {"property": "canonical_host", "value": data["canonical_host"]},
+                        {"property": "canonical_url", "value": data["canonical_url"]},
+                        {
+                            "property": "credentials",
+                            "value": "yes" if data["has_credentials"] else "no",
+                        },
+                    ]
+                )
+                st.dataframe(summary_table, use_container_width=True)
+                breakdown = data.get("host_breakdown", [])
+                if breakdown:
+                    st.markdown("### Host breakdown")
+                    st.dataframe(_breakdown_table(breakdown), use_container_width=True)
+                st.download_button(
+                    "Download URL decode JSON",
+                    data=json.dumps(data, indent=2),
+                    file_name="url_decode.json",
+                    mime="application/json",
+                )
 
 
 def _collect_mix_patterns(label_prefix: str) -> Sequence[Tuple[str, Sequence[str]]]:
@@ -76,144 +223,10 @@ def _breakdown_table(breakdown: Iterable[Tuple[str, str, int]]) -> pd.DataFrame:
     )
 
 
-tab_encode_ip, tab_decode_ip, tab_encode_url, tab_decode_url = st.tabs(
-    [
-        "Generate IPv4 disguises",
-        "Decode IPv4 value",
-        "Encode URL",
-        "Decode URL",
-    ]
-)
 
-with tab_encode_ip:
-    st.subheader("Generate IPv4 disguises")
-    ip_value = st.text_input("IPv4 address", value="192.168.0.1")
-    custom_mix_input = st.text_input(
-        "Custom mixed bases (comma separated)",
-        help="Example: hex,decimal,octal,binary",
-    )
-    selected_patterns = _collect_mix_patterns("encode-ip")
 
-    if st.button("Generate variants", key="generate-ip") and ip_value:
-        try:
-            custom_mix = [part.strip() for part in custom_mix_input.split(",") if part.strip()] or None
-            bundle = generate_ipv4_variants(
-                ip_value,
-                custom_mix=custom_mix,
-                default_mix_patterns=selected_patterns,
-            )
-        except ObscurifierError as exc:  # pragma: no cover - UI feedback
-            st.error(str(exc))
-        else:
-            st.success(f"Canonical IPv4: {bundle.canonical}")
-            st.dataframe(_bundle_to_table(bundle), use_container_width=True)
-            payload = {
-                "canonical": bundle.canonical,
-                "integers": bundle.integers,
-                "dotted": bundle.dotted,
-                "mixed": bundle.mixed,
-            }
-            st.download_button(
-                "Download IPv4 JSON",
-                data=json.dumps(payload, indent=2),
-                file_name="ipv4_variants.json",
-                mime="application/json",
-            )
+__all__ = ["render"]
 
-with tab_decode_ip:
-    st.subheader("Decode IPv4 value")
-    decode_value = st.text_input("IPv4 string or integer", value="0xC0A80001")
-    if st.button("Decode IPv4", key="decode-ip") and decode_value:
-        try:
-            canonical, breakdown = decode_ipv4(decode_value)
-        except ObscurifierError as exc:  # pragma: no cover - UI feedback
-            st.error(str(exc))
-        else:
-            st.success(f"Canonical IPv4: {canonical}")
-            st.dataframe(_breakdown_table(breakdown), use_container_width=True)
-            payload = {
-                "canonical": canonical,
-                "breakdown": [
-                    {"component": component, "base": base, "value": value}
-                    for component, base, value in breakdown
-                ],
-            }
-            st.download_button(
-                "Download decode JSON",
-                data=json.dumps(payload, indent=2),
-                file_name="ipv4_decode.json",
-                mime="application/json",
-            )
 
-with tab_encode_url:
-    st.subheader("Encode URL")
-    url_value = st.text_input("URL", value="http://192.168.0.1/admin")
-    credential_value = st.text_input(
-        "Credentials (user:password)",
-        help="Optional credentials to inject into the rewritten URLs.",
-    )
-    url_custom_mix = st.text_input(
-        "Custom mixed bases for URL hosts", key="url-custom-mix", help="Comma separated list."
-    )
-    url_patterns = _collect_mix_patterns("encode-url")
-
-    if st.button("Rewrite URL", key="encode-url") and url_value:
-        try:
-            custom_mix = [part.strip() for part in url_custom_mix.split(",") if part.strip()] or None
-            bundle, variants = encode_url(
-                url_value,
-                credentials=credential_value or None,
-                custom_mix=custom_mix,
-                default_mix_patterns=url_patterns,
-            )
-        except ObscurifierError as exc:  # pragma: no cover - UI feedback
-            st.error(str(exc))
-        else:
-            st.success(f"Canonical host: {bundle.canonical}")
-            variant_table = pd.DataFrame(
-                [{"label": label, "url": value} for label, value in variants]
-            )
-            st.dataframe(variant_table, use_container_width=True)
-            payload = {
-                "canonical_host": bundle.canonical,
-                "variants": variants,
-            }
-            st.download_button(
-                "Download URL variants JSON",
-                data=json.dumps(payload, indent=2),
-                file_name="url_variants.json",
-                mime="application/json",
-            )
-
-with tab_decode_url:
-    st.subheader("Decode URL")
-    decode_url_value = st.text_input("URL to decode", value="http://0xC0A80001/login")
-    if st.button("Inspect URL", key="decode-url") and decode_url_value:
-        try:
-            data = decode_url(decode_url_value)
-        except ObscurifierError as exc:  # pragma: no cover - UI feedback
-            st.error(str(exc))
-        else:
-            st.success(f"Canonical URL: {data['canonical_url']}")
-            summary_table = pd.DataFrame(
-                [
-                    {"property": "original", "value": data["original"]},
-                    {"property": "canonical_host", "value": data["canonical_host"]},
-                    {"property": "canonical_url", "value": data["canonical_url"]},
-                    {
-                        "property": "credentials",
-                        "value": "yes" if data["has_credentials"] else "no",
-                    },
-                ]
-            )
-            st.dataframe(summary_table, use_container_width=True)
-            breakdown = data.get("host_breakdown", [])
-            if breakdown:
-                st.markdown("### Host breakdown")
-                st.dataframe(_breakdown_table(breakdown), use_container_width=True)
-            st.download_button(
-                "Download URL decode JSON",
-                data=json.dumps(data, indent=2),
-                file_name="url_decode.json",
-                mime="application/json",
-            )
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    render()

--- a/Practical/Image Converter/streamlit_app.py
+++ b/Practical/Image Converter/streamlit_app.py
@@ -53,7 +53,7 @@ def _build_resize_spec(width_text: str, height_text: str) -> Optional[ResizeSpec
     return ResizeSpec(width=width_value, height=height_value)
 
 
-def main() -> None:
+def render() -> None:
     st.set_page_config(page_title="Image Converter", page_icon="🖼️")
     st.title("Image Converter")
     st.write(
@@ -175,5 +175,10 @@ def main() -> None:
             file_name=item["converted_name"],
             mime=mime,
         )
+
+
+__all__ = ["render"]
+
+
 if __name__ == "__main__":
-    main()
+    render()

--- a/Practical/ImgToASCII/streamlit_app.py
+++ b/Practical/ImgToASCII/streamlit_app.py
@@ -40,7 +40,7 @@ def _render_ascii(ascii_art: str) -> None:
     )
 
 
-def main() -> None:
+def render() -> None:
     st.set_page_config(page_title="Image to ASCII", layout="wide")
     st.title("Image to ASCII Converter")
 
@@ -110,6 +110,9 @@ def main() -> None:
     )
 
 
+__all__ = ["render"]
+
+
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    render()
 

--- a/Practical/Old School cringe/streamlit_app.py
+++ b/Practical/Old School cringe/streamlit_app.py
@@ -140,9 +140,8 @@ def render() -> None:
     st.caption("Data sourced from retro_demo.py's timeline configuration.")
 
 
-def main() -> None:
-    render()
+__all__ = ["render"]
 
 
 if __name__ == "__main__":
-    main()
+    render()

--- a/Practical/Paint/streamlit_app.py
+++ b/Practical/Paint/streamlit_app.py
@@ -28,7 +28,7 @@ def _prepare_download(image_array: np.ndarray) -> bytes:
     return buffer.getvalue()
 
 
-def main() -> None:
+def render() -> None:
     st.set_page_config(page_title="Paint Clone (Streamlit)", layout="wide")
     st.title("🖌️ Paint Clone — Streamlit Edition")
     st.write(
@@ -77,5 +77,8 @@ def main() -> None:
         st.info("Start drawing on the canvas to enable PNG downloads.")
 
 
+__all__ = ["render"]
+
+
 if __name__ == "__main__":
-    main()
+    render()

--- a/Practical/README.md
+++ b/Practical/README.md
@@ -52,6 +52,16 @@ python "Seam Carving/resize.py" --help
 python "ToDoList-CLI/todo.py" add "Ship awesome README"
 ```
 
+### 1.5. Launch the Streamlit hub
+
+Spin up the browser-based tools (Paint clone, HSV colour wheel, matrix playgrounds, etc.) from one place:
+
+```pwsh
+streamlit run app.py
+```
+
+The app opens a sidebar selector with descriptions for every Streamlit-powered project. Pick a tool to load its dedicated UI and swap between them without restarting Streamlit.
+
 ## Using pyproject.toml
 
 All Practical projects share the repo-wide optional extras defined in `pyproject.toml`. Install `.[practical]` for the full toolkit or combine targeted extras (audio, web, desktop, markdown, geo, midi) depending on what you plan to explore. Editable installs (`pip install -e .[extra]`) keep your changes instantly runnable. See the table below for combinations and the [root extras table](../README.md#using-pyprojecttoml) for cross-category options.

--- a/Practical/Radix Base Converter/streamlit_app.py
+++ b/Practical/Radix Base Converter/streamlit_app.py
@@ -58,7 +58,7 @@ def _build_batch_downloads(rows: list[dict[str, str | int]]) -> tuple[bytes, byt
     return csv_bytes, text_bytes
 
 
-def main() -> None:
+def render() -> None:
     st.set_page_config(page_title="Radix Base Converter", page_icon="🔢", layout="centered")
     st.title("🔢 Radix Base Converter")
     st.write(
@@ -162,5 +162,8 @@ def main() -> None:
                     )
 
 
+__all__ = ["render"]
+
+
 if __name__ == "__main__":
-    main()
+    render()

--- a/Practical/Vector Product/streamlit_app.py
+++ b/Practical/Vector Product/streamlit_app.py
@@ -69,9 +69,8 @@ def render() -> None:
         plt.close(fig)
 
 
-def main() -> None:
-    render()
+__all__ = ["render"]
 
 
 if __name__ == "__main__":
-    main()
+    render()

--- a/Practical/Verlet Cloth/streamlit_app.py
+++ b/Practical/Verlet Cloth/streamlit_app.py
@@ -13,26 +13,114 @@ import streamlit as st
 from cloth import simulate_cloth
 
 
-st.set_page_config(page_title="Verlet Cloth Playground", page_icon="🧵", layout="wide")
-st.title("Verlet Cloth Playground")
-st.markdown(
-    """
-Experiment with the cloth simulation parameters and preview the resulting
-animation directly in the browser.  You can also download the generated frames
-for offline processing or visualisation.
-"""
-)
+def render() -> None:
+    """Render the interactive cloth simulation controls."""
 
-with st.sidebar:
-    st.header("Simulation Parameters")
-    num_x = st.slider("Grid columns", min_value=4, max_value=60, value=30)
-    num_y = st.slider("Grid rows", min_value=4, max_value=60, value=20)
-    gravity_strength = st.slider("Gravity (m/s²)", min_value=0.0, max_value=25.0, value=9.81)
-    constraint_iterations = st.slider("Constraint iterations", min_value=1, max_value=20, value=5)
-    steps = st.slider("Simulation steps", min_value=1, max_value=300, value=120)
-    timestep = st.slider("Timestep (dt)", min_value=0.005, max_value=0.05, value=0.016, step=0.001)
-    pinned_rows = st.slider("Pinned rows", min_value=0, max_value=num_y - 1, value=1)
-    st.markdown("Use the controls above to tailor the simulation to your needs.")
+    st.set_page_config(page_title="Verlet Cloth Playground", page_icon="🧵", layout="wide")
+    st.title("Verlet Cloth Playground")
+    st.markdown(
+        """
+    Experiment with the cloth simulation parameters and preview the resulting
+    animation directly in the browser.  You can also download the generated frames
+    for offline processing or visualisation.
+    """
+    )
+
+    with st.sidebar:
+        st.header("Simulation Parameters")
+        num_x = st.slider("Grid columns", min_value=4, max_value=60, value=30)
+        num_y = st.slider("Grid rows", min_value=4, max_value=60, value=20)
+        gravity_strength = st.slider("Gravity (m/s²)", min_value=0.0, max_value=25.0, value=9.81)
+        constraint_iterations = st.slider("Constraint iterations", min_value=1, max_value=20, value=5)
+        steps = st.slider("Simulation steps", min_value=1, max_value=300, value=120)
+        timestep = st.slider("Timestep (dt)", min_value=0.005, max_value=0.05, value=0.016, step=0.001)
+        pinned_rows = st.slider("Pinned rows", min_value=0, max_value=num_y - 1, value=1)
+        st.markdown("Use the controls above to tailor the simulation to your needs.")
+
+    frames = run_simulation(
+        num_x=num_x,
+        num_y=num_y,
+        gravity_strength=gravity_strength,
+        constraint_iterations=constraint_iterations,
+        steps=steps,
+        timestep=timestep,
+        pinned_rows=pinned_rows,
+    )
+
+    frame_index = st.slider("Frame to display", min_value=0, max_value=len(frames) - 1, value=0)
+    current_frame = frames[frame_index]
+    positions = np.array(current_frame.get("positions", []))
+    segments = np.array(current_frame.get("segments", []))
+
+    line_x: List[float] = []
+    line_y: List[float] = []
+    for segment in segments:
+        line_x.extend([segment[0, 0], segment[1, 0], None])
+        line_y.extend([segment[0, 1], segment[1, 1], None])
+
+    fig = go.Figure()
+    if line_x:
+        fig.add_trace(
+            go.Scatter(
+                x=line_x,
+                y=line_y,
+                mode="lines",
+                line=dict(color="#424242", width=1),
+                name="Constraints",
+                hoverinfo="skip",
+            )
+        )
+
+    if len(positions) > 0:
+        fig.add_trace(
+            go.Scatter(
+                x=positions[:, 0],
+                y=positions[:, 1],
+                mode="markers",
+                marker=dict(color="#1976d2", size=6),
+                name="Particles",
+            )
+        )
+
+    fig.update_layout(
+        width=None,
+        height=650,
+        showlegend=False,
+        margin=dict(l=10, r=10, t=30, b=10),
+    )
+    fig.update_xaxes(title_text="X position", showgrid=False, zeroline=False)
+    fig.update_yaxes(
+        title_text="Y position",
+        showgrid=False,
+        zeroline=False,
+        scaleanchor="x",
+        scaleratio=1,
+    )
+
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.markdown(
+        f"Showing frame **{frame_index}** / **{len(frames) - 1}** — time = ``{current_frame['time']:.3f}s``"
+    )
+
+    json_bytes = serialise_frames_to_json(frames)
+    gif_bytes = frames_to_gif(frames)
+
+    col_json, col_gif = st.columns(2)
+    with col_json:
+        st.download_button(
+            label="Download frames as JSON",
+            data=json_bytes,
+            file_name="verlet_cloth_frames.json",
+            mime="application/json",
+        )
+    with col_gif:
+        st.download_button(
+            label="Download animation as GIF",
+            data=gif_bytes,
+            file_name="verlet_cloth_animation.gif",
+            mime="image/gif",
+        )
 
 
 @st.cache_data(show_spinner=False)
@@ -62,67 +150,6 @@ def run_simulation(
         constraint_iterations=constraint_iterations,
     )
     return frames
-
-
-frames = run_simulation(
-    num_x=num_x,
-    num_y=num_y,
-    gravity_strength=gravity_strength,
-    constraint_iterations=constraint_iterations,
-    steps=steps,
-    timestep=timestep,
-    pinned_rows=pinned_rows,
-)
-
-frame_index = st.slider("Frame to display", min_value=0, max_value=len(frames) - 1, value=0)
-current_frame = frames[frame_index]
-positions = np.array(current_frame.get("positions", []))
-segments = np.array(current_frame.get("segments", []))
-
-line_x: List[float] = []
-line_y: List[float] = []
-for segment in segments:
-    line_x.extend([segment[0, 0], segment[1, 0], None])
-    line_y.extend([segment[0, 1], segment[1, 1], None])
-
-fig = go.Figure()
-if line_x:
-    fig.add_trace(
-        go.Scatter(
-            x=line_x,
-            y=line_y,
-            mode="lines",
-            line=dict(color="#424242", width=1),
-            name="Constraints",
-            hoverinfo="skip",
-        )
-    )
-
-if len(positions) > 0:
-    fig.add_trace(
-        go.Scatter(
-            x=positions[:, 0],
-            y=positions[:, 1],
-            mode="markers",
-            marker=dict(color="#1976d2", size=6),
-            name="Particles",
-        )
-    )
-
-fig.update_layout(
-    width=None,
-    height=650,
-    showlegend=False,
-    margin=dict(l=10, r=10, t=30, b=10),
-)
-fig.update_xaxes(title_text="X position", showgrid=False, zeroline=False)
-fig.update_yaxes(title_text="Y position", showgrid=False, zeroline=False, scaleanchor="x", scaleratio=1)
-
-st.plotly_chart(fig, use_container_width=True)
-
-st.markdown(
-    f"Showing frame **{frame_index}** / **{len(frames) - 1}** — time = ``{current_frame['time']:.3f}s``"
-)
 
 
 def serialise_frames_to_json(frames: List[dict]) -> bytes:
@@ -184,21 +211,8 @@ def frames_to_gif(frames: List[dict], duration: float = 0.08) -> bytes:
     return output.read()
 
 
-json_bytes = serialise_frames_to_json(frames)
-gif_bytes = frames_to_gif(frames)
+__all__ = ["render"]
 
-col_json, col_gif = st.columns(2)
-with col_json:
-    st.download_button(
-        label="Download frames as JSON",
-        data=json_bytes,
-        file_name="verlet_cloth_frames.json",
-        mime="application/json",
-    )
-with col_gif:
-    st.download_button(
-        label="Download animation as GIF",
-        data=gif_bytes,
-        file_name="verlet_cloth_animation.gif",
-        mime="image/gif",
-    )
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    render()

--- a/Practical/app.py
+++ b/Practical/app.py
@@ -1,0 +1,181 @@
+"""Unified Streamlit entry point for the Practical project suite."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from types import ModuleType
+from typing import Callable, Dict, List
+
+import streamlit as st
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Metadata describing a Streamlit tool and how to load it."""
+
+    key: str
+    title: str
+    path: Path
+    description: str
+
+
+TOOLS: List[ToolSpec] = [
+    ToolSpec(
+        key="bellman-ford",
+        title="Bellman–Ford Simulation",
+        path=BASE_DIR / "Bellman Ford Simulation" / "streamlit_app.py",
+        description="Step through the Bellman–Ford shortest path algorithm with visualised relaxation steps.",
+    ),
+    ToolSpec(
+        key="bismuth-fractal",
+        title="Bismuth Fractal",
+        path=BASE_DIR / "Bismuth Fractal" / "streamlit_app.py",
+        description="Generate colourful recursive bismuth fractal art and download the rendered image.",
+    ),
+    ToolSpec(
+        key="graphing-calculator",
+        title="Graphing Calculator",
+        path=BASE_DIR / "Graphing Calculator" / "streamlit_app.py",
+        description="Plot one or more mathematical functions (with optional derivatives) over configurable domains.",
+    ),
+    ToolSpec(
+        key="hsv-wheel",
+        title="HSV Colour Wheel",
+        path=BASE_DIR / "HSV color wheel" / "streamlit_app.py",
+        description="Create HSV colour wheel images, inspect metadata, and export PNG/JSON assets.",
+    ),
+    ToolSpec(
+        key="ip-tracking",
+        title="IP Tracking Visualisation",
+        path=BASE_DIR / "IP Tracking visualization" / "streamlit_app.py",
+        description="Fetch geolocation data for IP addresses and explore the results on an interactive map.",
+    ),
+    ToolSpec(
+        key="ip-url-obscurifier",
+        title="IP URL Obscurifier",
+        path=BASE_DIR / "IP URL Obscurifier" / "streamlit_app.py",
+        description="Encode or decode IPv4 values and URLs into mixed-base disguises with downloadable outputs.",
+    ),
+    ToolSpec(
+        key="image-converter",
+        title="Image Converter",
+        path=BASE_DIR / "Image Converter" / "streamlit_app.py",
+        description="Convert, resize, and download images in common formats while preserving metadata when possible.",
+    ),
+    ToolSpec(
+        key="img-to-ascii",
+        title="Image → ASCII",
+        path=BASE_DIR / "ImgToASCII" / "streamlit_app.py",
+        description="Transform uploaded images into ASCII art with tunable character sets and metadata exports.",
+    ),
+    ToolSpec(
+        key="markdown-editor",
+        title="Markdown Editor",
+        path=BASE_DIR / "Markdown Editor" / "streamlit_app.py",
+        description="Author Markdown content with HTML templates, live preview, and optional session autosave.",
+    ),
+    ToolSpec(
+        key="matrix-arithmetic",
+        title="Matrix Arithmetic",
+        path=BASE_DIR / "Matrix Arithmetic" / "streamlit_app.py",
+        description="Compute matrix operations (add, multiply, determinant, inverse) with step-by-step explanations.",
+    ),
+    ToolSpec(
+        key="old-school-demo",
+        title="Old School Demo Timeline",
+        path=BASE_DIR / "Old School cringe" / "streamlit_app.py",
+        description="Browse the demoscene-inspired effect timeline powering the retro multi-effect demo.",
+    ),
+    ToolSpec(
+        key="paint-clone",
+        title="Paint Clone",
+        path=BASE_DIR / "Paint" / "streamlit_app.py",
+        description="Sketch directly in the browser using familiar Paint tools and export your drawing as a PNG.",
+    ),
+    ToolSpec(
+        key="radix-converter",
+        title="Radix Base Converter",
+        path=BASE_DIR / "Radix Base Converter" / "streamlit_app.py",
+        description="Convert values between bases, build batch conversion tables, and export CSV/text reports.",
+    ),
+    ToolSpec(
+        key="vector-product",
+        title="Vector Product Explorer",
+        path=BASE_DIR / "Vector Product" / "streamlit_app.py",
+        description="Experiment with dot and cross products, inspect magnitudes, and view plots of the inputs.",
+    ),
+    ToolSpec(
+        key="verlet-cloth",
+        title="Verlet Cloth Playground",
+        path=BASE_DIR / "Verlet Cloth" / "streamlit_app.py",
+        description="Simulate a cloth mesh, preview frames, and download JSON/GIF exports of the animation.",
+    ),
+]
+
+TOOLS_BY_KEY: Dict[str, ToolSpec] = {tool.key: tool for tool in TOOLS}
+_IMPORTED_MODULES: Dict[str, ModuleType] = {}
+_SYS_PATH_CACHE: set[str] = set()
+
+
+def _ensure_import(tool: ToolSpec) -> ModuleType:
+    module = _IMPORTED_MODULES.get(tool.key)
+    if module is not None:
+        return module
+
+    module_name = f"practical_streamlit_{tool.key.replace('-', '_')}"
+    spec = importlib.util.spec_from_file_location(module_name, tool.path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load module spec for {tool.path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+
+    parent_dir = str(tool.path.parent.resolve())
+    if parent_dir not in _SYS_PATH_CACHE:
+        sys.path.insert(0, parent_dir)
+        _SYS_PATH_CACHE.add(parent_dir)
+
+    spec.loader.exec_module(module)
+    _IMPORTED_MODULES[tool.key] = module
+    return module
+
+
+@lru_cache(maxsize=None)
+def _resolve_render(tool_key: str) -> Callable[[], None]:
+    tool = TOOLS_BY_KEY[tool_key]
+    module = _ensure_import(tool)
+    render = getattr(module, "render", None)
+    if not callable(render):  # pragma: no cover - defensive guard for unexpected modules
+        raise AttributeError(f"Module {tool.path} does not expose a callable render()")
+    return render
+
+
+def main() -> None:
+    st.sidebar.title("Practical Streamlit Hub")
+    st.sidebar.write("Select a tool to launch its Streamlit interface.")
+
+    options = [tool.key for tool in TOOLS]
+    selected_key = st.sidebar.radio(
+        "Available tools",
+        options=options,
+        format_func=lambda key: TOOLS_BY_KEY[key].title,
+    )
+    selected_tool = TOOLS_BY_KEY[selected_key]
+
+    st.sidebar.markdown(f"_{selected_tool.description}_")
+    st.sidebar.divider()
+    st.sidebar.caption("Switch between tools using the radio buttons above.")
+
+    render = _resolve_render(selected_key)
+    render()
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit entry point
+    main()
+


### PR DESCRIPTION
## Summary
- add a central `app.py` in Practical that lazily loads each Streamlit tool with descriptions in a sidebar selector
- standardise every Streamlit sub-app to expose a `render()` entry point and avoid auto-execution on import
- document the new Streamlit hub entry point and usage in the Practical README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d7244b5a908329b06c1168e01f345e