### PR TITLE
Add Streamlit keep-alive workflow

### DIFF
--- a/.github/workflows/keep-streamlit-alive.yml
+++ b/.github/workflows/keep-streamlit-alive.yml
@@ -1,0 +1,30 @@
+name: Keep Streamlit deployment alive
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: 'Optional override for the Streamlit app URL to ping.'
+        required: false
+        type: string
+
+jobs:
+  ping:
+    name: Ping Streamlit app
+    runs-on: ubuntu-latest
+    env:
+      TARGET_URL: ${{ github.event.inputs.target_url || secrets.STREAMLIT_PING_URL }}
+    steps:
+      - name: Validate target URL
+        run: |
+          if [ -z "${TARGET_URL}" ]; then
+            echo "The target URL is not configured. Provide it as a workflow input or configure the STREAMLIT_PING_URL secret." >&2
+            exit 1
+          fi
+
+          echo "::add-mask::${TARGET_URL}"
+      - name: Send keep-alive request
+        run: |
+          curl --fail --silent --show-error --max-time 10 "$TARGET_URL"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ The repository now ships a `pyproject.toml` so you can install challenge stacks 
 
 See the category READMEs for per-project suggestions; each now points back to these extras.
 
+## Streamlit deployment keep-alive workflow
+
+The repository includes a GitHub Actions workflow at `.github/workflows/keep-streamlit-alive.yml` that pings the deployed Streamlit app on a schedule. The job runs hourly to keep the hosted instance warm and also supports manual runs so maintainers can verify that the endpoint is still responding.
+
+### Configure the `STREAMLIT_PING_URL` secret
+
+1. In GitHub, open **Settings → Secrets and variables → Actions** for this repository.
+2. Add a new repository secret named `STREAMLIT_PING_URL` that contains the fully qualified URL of the Streamlit deployment (e.g., `https://example.streamlit.app/`).
+3. Save the secret; the workflow will automatically read the value when it runs on its hourly schedule.
+
+### Manually test the keep-alive workflow
+
+1. Navigate to **Actions → Keep Streamlit deployment alive** in GitHub.
+2. Click **Run workflow** to launch it on demand. You may leave the `target_url` field blank to use the `STREAMLIT_PING_URL` secret, or provide a one-off URL for testing.
+3. Review the workflow run logs to ensure the keep-alive request succeeded.
+
 ## Challenges
 
 ### Practical


### PR DESCRIPTION
## Summary
- add a scheduled GitHub Actions workflow that pings the Streamlit deployment using a repository secret
- support manual workflow dispatch with an optional override URL and validation
- document the keep-alive workflow and secret configuration in the README

## Testing
- not run (workflow and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_b_68d727fee644832988df33a2008f3676