### PR TITLE
docs: revamp Games README and add per-game guides

### DIFF
--- a/Games/Connect4/README.md
+++ b/Games/Connect4/README.md
@@ -1,0 +1,32 @@
+# Connect Four
+
+- **Challenge:** #127 — Connect Four
+- **Languages:** Python, Java
+
+## Overview
+Two-player Connect Four with both a desktop GUI (pygame) and a Java console mode. The Python version renders a 7×6 grid with mouse-driven piece drops; the Java build mirrors the classic rules in a text-based interface.
+
+## Dependencies
+- **Python:** `pip install -e .[games]` (pulls `pygame` and `numpy`).
+- **Java:** JDK 11+ (uses standard library only).
+
+## Run
+### Python (pygame board)
+```bash
+python connect4.py
+```
+Controls: move the mouse to select a column, click to drop your checker.
+
+### Java (console mode)
+```bash
+javac connect4.java
+java -cp . connect4
+```
+Controls: follow the on-screen prompts to choose columns (0-indexed).
+
+## Assets
+No external assets; colours and layout are generated procedurally.
+
+## Notes
+- The Python game depends on `pygame.mixer` for sound cues; ensure audio devices are available.
+- To tweak board size or winning length, adjust the constants near the top of `connect4.py`.

--- a/Games/Knight Tour/README.md
+++ b/Games/Knight Tour/README.md
@@ -1,0 +1,22 @@
+# Knight's Tour Solver
+
+- **Challenge:** #104 — Knight's Tour
+- **Language:** Python
+
+## Overview
+Command-line backtracking solver that searches for a full knight's tour on an `n × n` board. Prints the move sequence and board layout directly to stdout.
+
+## Dependencies
+No third-party packages. Python 3.10+ is sufficient.
+
+## Run
+```bash
+python knight.py --size 8 --start 0 0
+```
+Arguments:
+- `--size`: board dimension (default 8).
+- `--start`: starting coordinates as `row col` (default `0 0`).
+
+## Notes
+- The solver uses Warnsdorff ordering for speed; adjust heuristics in `next_moves` if you want to experiment.
+- For very large boards expect longer runtimes.

--- a/Games/Minesweeper/README.md
+++ b/Games/Minesweeper/README.md
@@ -1,0 +1,23 @@
+# Minesweeper
+
+- **Challenge:** #117 — Minesweeper
+- **Language:** Python (tkinter)
+
+## Overview
+Graphical Minesweeper clone with adjustable board size and mine density. Uses tkinter buttons for cells and message boxes for win/loss states.
+
+## Dependencies
+- Python standard library + `tkinter` (ships with most desktop Python builds).
+- Optional: `pip install -e .[games]` to align with repo-wide tooling.
+
+## Run
+```bash
+python mine.py --rows 10 --cols 10 --mines 15
+```
+Arguments:
+- `--rows` / `--cols`: board dimensions (defaults: 10×10).
+- `--mines`: number of mines (default: 10).
+
+## Notes
+- On Linux ensure `python3-tk` is installed if tkinter is missing.
+- The GUI auto-resizes based on the board; adjust the constants at the top for custom styling.

--- a/Games/README.md
+++ b/Games/README.md
@@ -1,95 +1,180 @@
-# Games Collection
+# Games Challenge Hub
 
-Welcome to the **Games** folder of the Pro-g-rammingChallenges4 repository! This directory contains a diverse set of classic and algorithmic games implemented in various programming languages, including Python, Java, C++, JavaScript, and HTML/CSS. Each game is designed to be educational, beginner-friendly, and a fun way to explore programming concepts.
+A curated playground of `/g/` games implemented across Python, Java, C++, and web stacks. The `Games/` tree mixes fully playable titles with backlog design notes so you can explore existing builds or claim an open challenge.
 
-## Contents
+This README mirrors the structure of the Practical suite guide: start with a quick environment spin-up, consult the index, and drill into per-language playbooks or contribution patterns when you are ready to extend the catalogue.
 
-- **Connect4** (`Connect4.java`, `connect4.py`): Play the classic Connect Four game in Java or Python.
+---
 
+## 1. Quick Start
 
-- **Knight Tour** (`knight.py`): Solve the Knight's Tour puzzle using Python.
-- **Minesweeper** (`mine.py`): A simple command-line Minesweeper game in Python.
-- **RPS** (Rock Paper Scissors):
-  - `rps.cpp`, `Rps.java`, `rps.js`, `rps.html`, `rps.css`, `rpsls.py`
-  - Play Rock Paper Scissors (and RPSLS) in your favorite language, with both CLI and web versions. SVG assets included.
-- **Shuffle** (`cards.py`): Simulate card shuffling and visualization in Python (uses matplotlib).
-- **Simon** (`simon.py`): The classic Simon memory game with sound and graphics (Python, tkinter, pygame). Assets included.
-- **Snake** (`snake.py`, `snake.js`, `snake.html`, `snake.css`): Play Snake in Python (tkinter) or in your browser (JS/HTML/CSS).
-- **Sudoku** (`sudoku.py`): Sudoku puzzle generator and solver in Python (uses numpy).
-- **Yahtzee** (`Yahtzee.java`, `yahtzee.py`): Play Yahtzee in Java or Python.
+### 1.1. Clone and scope to the games
 
+```bash
+git clone https://github.com/saintwithataint/Pro-g-rammingChallenges4.git
+cd Pro-g-rammingChallenges4/Games
+```
 
-## Using pyproject.toml
+> Working from the repository root? Swap the final line for `cd Pro-g-rammingChallenges4` and prefix game paths with `Games/` in the commands below.
 
-Create a virtual environment, then install the extras for the games you want to run:
+### 1.2. Create a virtual environment (recommended)
 
 ```bash
 python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\Activate.ps1
-python -m pip install -e .[games]
-# Optional helpers
-python -m pip install -e .[visual]  # matplotlib-based scoreboards
-python -m pip install -e .[audio]   # shared sound backends (pygame, sounddevice)
+source .venv/bin/activate  # Windows PowerShell: .venv\Scripts\Activate.ps1
 ```
 
-Editable installs keep your local changes immediately playable.
+### 1.3. Install pyproject extras for games
 
-## How to Run
+Use the editable extras defined in the root [`pyproject.toml`](../pyproject.toml) and cross-referenced in the [repository README](../README.md#using-pyprojecttoml):
 
-### Python Games
+```bash
+python -m pip install -e .[games]
+# Optional add-ons
+python -m pip install -e .[visual]  # matplotlib-powered visualisers (Shuffle)
+python -m pip install -e .[audio]   # pygame audio backends (Simon, Connect 4)
+```
 
-- Make sure you have Python 3.8+ installed.
-- Install dependencies via pyproject extras:
+Extras keep Python dependencies lightweight and consistent with the root extras table.
 
-  ```sh
-  python -m pip install -e .[games]
-  # Add .[visual] for matplotlib stats or .[audio] for richer sound
-  ```
+### 1.4. Launch your first build
 
-- Run the desired game:
+```bash
+python "Snake/snake.py"          # Turtle graphics Snake
+python "Simon/simon.py"          # Pygame Simon (loads local assets)
+python "Shuffle/cards.py"        # Matplotlib card shuffler
+```
 
-  ```sh
-  python <game>.py
-  ```
+Prefer Java or C++? Check the run matrix in [Section 4](#4-run-guides-by-language).
 
-- Some games (e.g., Simon, Snake) require `tkinter` and/or `pygame` for GUI and sound.
+---
 
-### Java Games
+## 2. Challenge Index (solved + backlog)
 
-- Compile and run with:
+Authoritative status board for challenges #104–#132. Entry points list the main script or launcher; multi-language games expose multiple commands.
 
-  ```sh
-  javac <Game>.java
-  java <Game>
-  ```
+| #   | Challenge | Status  | Primary Tech Stack | Entry Points |
+|-----|-----------|---------|--------------------|--------------|
+| 104 | Knight's Tour | Solved | Python 3 (CLI, backtracking) | `Knight Tour/knight.py` |
+| 105 | Monster Raising/Breeding Simulator | Backlog | TBD | — |
+| 106 | Tetris | Backlog | TBD | — |
+| 107 | Snake | Solved | Python 3 (turtle), JavaScript + HTML Canvas | `Snake/snake.py`, `Snake/snake.html` |
+| 108 | Pipe Dreams | Backlog | TBD | — |
+| 109 | Pac-Man (behavioural ghosts) | Backlog | TBD | — |
+| 110 | Dragon Quest / Basic RPG Engine | Backlog | TBD | — |
+| 111 | Rock Paper Scissors (+Lizard Spock) | Solved | Python 3 (CLI), C++, Java, JavaScript/Web | `RPS/rpsls.py`, `RPS/rps.cpp`, `RPS/rps.java`, `RPS/rps.html` |
+| 112 | First-Person Engine (OpenGL) | Backlog | Planned OpenGL / C++ | — |
+| 113 | Shuffle a Deck (with visualisation) | Solved | Python 3 + matplotlib | `Shuffle/cards.py` |
+| 114 | Multi-agent Tag Simulation | Backlog | TBD | — |
+| 115 | Wolfenstein Clone | Backlog | Planned raycaster | — |
+| 116 | Scorched Earth Clone | Backlog | TBD | — |
+| 117 | Minesweeper | Solved | Python 3 + tkinter | `Minesweeper/mine.py` |
+| 118 | 64KB Audio/Visual Demo | Backlog | TBD | — |
+| 119 | Sudoku | Solved | Python 3 + tkinter + numpy | `Sudoku/sudoku.py` |
+| 120 | Danmaku (Bullet Hell) Engine | Backlog | TBD | — |
+| 121 | Roguelike Engine / Dungeon Generator | Backlog | TBD | — |
+| 122 | Design a Game Engine in Unity | Backlog | Unity (planned) | — |
+| 123 | Yahtzee | Solved | Python 3 (CLI), Java | `Yahtzee/yahtzee.py`, `Yahtzee/yahtzee.java` |
+| 124 | Oil Panic | Backlog | TBD | — |
+| 125 | Chess | Backlog | TBD | — |
+| 126 | Go (No AI necessary) | Backlog | TBD | — |
+| 127 | Connect Four | Solved | Python 3 + pygame + numpy, Java | `Connect4/connect4.py`, `Connect4/connect4.java` |
+| 128 | Mastermind | Backlog | TBD | — |
+| 129 | Missile Command | Backlog | TBD | — |
+| 130 | Tron | Backlog | TBD | — |
+| 131 | Breakout | Backlog | TBD | — |
+| 132 | Simon | Solved | Python 3 + pygame (audio assets) | `Simon/simon.py` |
 
-### C++ Games
+> When you create a new implementation, update this table with the tech stack and primary launch command so the backlog remains actionable.
 
-- Compile and run with:
+---
 
-  ```sh
-  g++ rps.cpp -o rps
-  ./rps
-  ```
+## 3. Selective Installs (Games-focused extras)
 
-### JavaScript/HTML/CSS Games
+| Focus | Extras | Notes |
+|-------|--------|-------|
+| All Python games | `games` | Installs numpy, matplotlib, and pygame used throughout the solved titles. |
+| Visual analytics (Shuffle stats, future dashboards) | `games,visual` | Adds plotting + rendering helpers beyond the base game set. |
+| Audio-heavy builds (Simon patterns, future rhythm games) | `games,audio` | Pulls in sounddevice/librosa alongside pygame mixers. |
+| Development + linting | `games,developer` | Extends with pytest, ruff, mypy for automated checks. |
 
-- Open the `.html` file in your web browser (e.g., `rps.html`, `snake.html`).
+Need another stack? Refer to the [root extras table](../README.md#using-pyprojecttoml) to combine categories (e.g., `.[games,web]` for multiplayer dashboards).
 
-## Assets
+---
 
-- Some games include assets (images, audio, fonts) in their respective subfolders. No additional downloads are required.
+## 4. Run Guides by Language
 
-## Educational Focus
+Each language links to the dedicated game README for deeper context (rules, controls, screenshots, and assets). Commands assume you are inside `Games/` with the virtual environment activated.
 
-- All code is written with clarity and learning in mind. Each file is well-documented and commented to help new developers understand the logic and structure.
-- Explore different programming paradigms and languages by comparing implementations of the same game.
+### 4.1. Python
 
-## Contributing
+```bash
+python "Connect4/connect4.py"   # Requires pygame + numpy
+python "Minesweeper/mine.py"    # tkinter GUI (bundled with most Python installs)
+python "Simon/simon.py"         # Loads Assets/Audio and Assets/Images
+python "Sudoku/sudoku.py"       # Needs numpy + tkinter
+python "Shuffle/cards.py"       # matplotlib visualiser
+python "Yahtzee/yahtzee.py"     # CLI edition
+python "Snake/snake.py"         # Turtle graphics, ensure tkinter is available
+python "Knight Tour/knight.py"  # CLI solver visualises via stdout
+python "RPS/rpsls.py"           # CLI (supports Lizard/Spock variant)
+```
 
-- Contributions are welcome! Feel free to add new games, improve documentation, or refactor existing code for clarity and performance.
-- Please follow the style and documentation conventions used throughout the repository.
+Per-game documentation: [Connect Four](Connect4/README.md), [Minesweeper](Minesweeper/README.md), [Simon](Simon/README.md), [Sudoku](Sudoku/README.md), [Shuffle](Shuffle/README.md), [Yahtzee](Yahtzee/README.md), [Snake](Snake/README.md), [Knight's Tour]("Knight Tour"/README.md), [Rock Paper Scissors](RPS/README.md).
 
-## License
+Assets are co-located inside each project (e.g., `Simon/Assets/Audio`). Keep relative paths intact when running outside the repo root.
 
-This project is licensed under the MIT License. See the root `LICENSE` file for details.
+### 4.2. Java
+
+```bash
+javac Connect4/connect4.java && java -cp Connect4 connect4
+javac Yahtzee/yahtzee.java && java -cp Yahtzee Yahtzee
+javac RPS/rps.java && java -cp RPS rps
+```
+
+Ensure `javac`/`java` are on your `PATH`. See the linked READMEs for gameplay controls and optional CLI arguments: [Connect Four](Connect4/README.md), [Yahtzee](Yahtzee/README.md), [Rock Paper Scissors](RPS/README.md).
+
+### 4.3. C++
+
+```bash
+g++ RPS/rps.cpp -o RPS/rps
+./RPS/rps
+```
+
+The C++ build uses only the standard library; no external packages required. Details live in [Rock Paper Scissors](RPS/README.md).
+
+### 4.4. JavaScript / Web
+
+1. Open the HTML file directly in a browser:
+   - `Snake/snake.html`
+   - `RPS/rps.html`
+2. For asset-backed games, keep the accompanying `.js`, `.css`, and `assets/` folders in the same directory.
+3. Optional: use a static server for clean module loading (`python -m http.server` from within the game folder).
+
+See [Snake](Snake/README.md) and [Rock Paper Scissors](RPS/README.md) for control schemes and asset notes.
+
+---
+
+## 5. Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `ModuleNotFoundError: pygame` or `numpy` | Install extras with `python -m pip install -e .[games]` (virtual env recommended). |
+| Python GUI fails with `No module named '_tkinter'` | Install a system package that provides Tk (macOS: `brew install python-tk`; Ubuntu: `sudo apt-get install python3-tk`). Turtle and tkinter-based games (Snake, Minesweeper, Sudoku) depend on it. |
+| Pygame window opens without sound | Ensure `pygame.mixer` can access audio devices. On Linux, install SDL dependencies (`sudo apt-get install libsdl2-mixer-2.0-0`). Assets live under `Simon/Assets`. |
+| Java commands fail with `class not found` | Compile within the game folder and include it on the classpath (`-cp`). Follow the exact commands in [Section 4.2](#42-java). |
+| Browser games cannot load assets when served remotely | Serve via a static server that preserves folder structure (`python -m http.server`) to avoid cross-origin or relative path issues. |
+
+If issues persist, open an issue referencing the challenge number and include OS + dependency versions.
+
+---
+
+## 6. Contribution Guidelines (Games-specific)
+
+1. **Coding style**: Match existing Python conventions (type hints, docstrings, classes for game state) and follow language idioms for Java/C++ (camelCase methods, header comments). Keep logic modules importable so they can be unit-tested.
+2. **Asset handling**: Place media under `<Game>/Assets/` with subfolders (`Audio/`, `Images/`, etc.). Document licensing in the game README and prefer original or CC0/GPL-compatible assets.
+3. **README expectations**: Every playable game must ship a `README.md` containing: challenge number, summary, dependency checklist, run commands for each language variant, and asset notes. Use the new READMEs in this directory as templates.
+4. **Extras alignment**: When introducing new dependencies, extend `pyproject.toml` extras thoughtfully and update the [root extras table](../README.md#using-pyprojecttoml) plus the table in [Section 3](#3-selective-installs-games-focused-extras).
+5. **Testing & linting**: Prefer running `python -m pytest` and `ruff check` (via the `developer` extra) for shared modules. GUI-heavy games should include a CLI-friendly smoke test where feasible.
+
+Ready to contribute? Fork the repo, branch per challenge (`feature/game-<name>`), follow the quick start above, and submit a PR summarising gameplay, assets, and controls.

--- a/Games/RPS/README.md
+++ b/Games/RPS/README.md
@@ -1,0 +1,46 @@
+# Rock Paper Scissors Suite
+
+- **Challenge:** #111 — Rock Paper Scissors (with Lizard & Spock variant)
+- **Languages:** Python, C++, Java, JavaScript/Web
+
+## Overview
+Multi-language implementations of classic Rock Paper Scissors plus a Python bonus mode supporting the Lizard/Spock expansion. Includes a browser UI with theming assets.
+
+## Dependencies
+- **Python:** `pip install -e .[games]` (standard library only, but keeps environments consistent).
+- **C++:** GCC/Clang with C++17 support.
+- **Java:** JDK 11+.
+- **Web:** Any modern browser; assets under `assets/` for icons and sounds.
+
+## Run
+### Python (CLI + Lizard/Spock)
+```bash
+python rpsls.py --mode classic
+python rpsls.py --mode lizardspock
+```
+
+### C++
+```bash
+g++ rps.cpp -std=c++17 -o rps
+./rps
+```
+
+### Java
+```bash
+javac rps.java
+java -cp . rps
+```
+
+### Web
+Open `rps.html` in a browser. For local development you can launch a static server:
+```bash
+python -m http.server 8000
+# Navigate to http://localhost:8000/Games/RPS/rps.html
+```
+
+## Assets
+SVG icons and CSS live in `assets/`, `rps.css`, and `rps.js`. Keep the folder structure intact when serving the page.
+
+## Notes
+- Python CLI supports score tracking and an autoplay demo (`--autoplay`).
+- Update move sets or translations in `rps.js` / `rpsls.py` to localise.

--- a/Games/Shuffle/README.md
+++ b/Games/Shuffle/README.md
@@ -1,0 +1,22 @@
+# Deck Shuffle Visualiser
+
+- **Challenge:** #113 — Shuffle a Deck of Cards (with visualisation)
+- **Language:** Python
+
+## Overview
+Interactive matplotlib application that displays a deck of cards and lets you shuffle via GUI buttons. Ideal for demonstrating randomness and shuffle statistics.
+
+## Dependencies
+- `pip install -e .[games,visual]` (requires `matplotlib`).
+
+## Run
+```bash
+python cards.py
+```
+Controls:
+- **Shuffle Deck:** randomises the current order.
+- **Reset Deck:** restores sorted order.
+
+## Notes
+- Requires a display server (matplotlib interactive backend).
+- Modify colours, fonts, or animation speed in the constants at the top of `cards.py`.

--- a/Games/Simon/README.md
+++ b/Games/Simon/README.md
@@ -1,0 +1,27 @@
+# Simon Memory Game
+
+- **Challenge:** #132 — Simon
+- **Language:** Python (pygame)
+
+## Overview
+Colour-and-sound-based Simon clone built with pygame. Features menu, increasing difficulty, score tracking, and audio/visual feedback using bundled assets.
+
+## Dependencies
+- `pip install -e .[games,audio]` (ensures `pygame` plus audio helpers).
+
+## Run
+```bash
+python simon.py
+```
+Controls:
+- Click the coloured panels or press arrow keys to repeat the pattern.
+- Press `Esc` to quit.
+
+## Assets
+- Audio cues: `Assets/Audio/*.wav`
+- Button art: `Assets/Images/*.png`
+Keep the `Assets/` folder beside `simon.py`.
+
+## Notes
+- On Linux, install SDL mixer packages if audio fails to initialise.
+- Screen size and colour palette are configurable in the constants at the top of the script.

--- a/Games/Snake/README.md
+++ b/Games/Snake/README.md
@@ -1,0 +1,30 @@
+# Snake
+
+- **Challenge:** #107 — Snake
+- **Languages:** Python, JavaScript/Web
+
+## Overview
+Classic Snake implemented twice: a Python turtle graphics version and a browser-based canvas edition. Both support adjustable speed and track the current score.
+
+## Dependencies
+- **Python:** Standard library `turtle` (requires `tkinter`). Install `pip install -e .[games]` to stay aligned with repo tooling.
+- **Web:** Modern browser (Chrome, Firefox, Edge). Optional CSS/JS customisation via the included files.
+
+## Run
+### Python (turtle)
+```bash
+python snake.py
+```
+Controls: Arrow keys to move. Game resets after collision.
+
+### Web (Canvas)
+Open `snake.html` in a browser, or serve locally:
+```bash
+python -m http.server 8000
+# Visit http://localhost:8000/Games/Snake/snake.html
+```
+Controls: Arrow keys or WASD.
+
+## Notes
+- Ensure tkinter is installed on Linux (`sudo apt-get install python3-tk`).
+- Canvas assets are pure CSS/JS—no external images required.

--- a/Games/Sudoku/README.md
+++ b/Games/Sudoku/README.md
@@ -1,0 +1,23 @@
+# Sudoku Generator & Solver
+
+- **Challenge:** #119 — Sudoku
+- **Language:** Python (tkinter + numpy)
+
+## Overview
+Tkinter GUI that generates Sudoku puzzles, validates input, and solves boards using backtracking. Includes difficulty presets and automatic board highlighting.
+
+## Dependencies
+- `pip install -e .[games]` (provides `numpy` and `pygame`; pygame is unused but bundled via the games extra).
+- Ensure tkinter is available (install `python3-tk` on Linux if required).
+
+## Run
+```bash
+python sudoku.py
+```
+Controls:
+- Click a cell and type digits 1–9.
+- Use the buttons to generate puzzles, solve, or clear entries.
+
+## Notes
+- Board logic lives in `SudokuLogic`; you can import it for CLI experiments or testing.
+- Difficulty weights can be tuned in the `SudokuGame` class.

--- a/Games/Yahtzee/README.md
+++ b/Games/Yahtzee/README.md
@@ -1,0 +1,28 @@
+# Yahtzee
+
+- **Challenge:** #123 — Yahtzee
+- **Languages:** Python, Java
+
+## Overview
+Dice game implementation with score evaluation, rerolls, and combination detection. The Python version is CLI-based; the Java edition mirrors gameplay for JVM users.
+
+## Dependencies
+- **Python:** Standard library only (`random`, `collections`). Install `pip install -e .[games]` to stay consistent with repo tooling.
+- **Java:** JDK 11+ (standard library).
+
+## Run
+### Python
+```bash
+python yahtzee.py
+```
+Follow the prompts to reroll dice and record scores.
+
+### Java
+```bash
+javac yahtzee.java
+java -cp . yahtzee
+```
+
+## Notes
+- Python version exposes helper classes (`Hand`, `ScoreCard`) for testing; import them if you want to script simulations.
+- Consider adding a GUI by building on these core logic classes.


### PR DESCRIPTION
## Summary
- restructure `Games/README.md` to mirror the Practical template with quick start, dependency, run, troubleshooting, and contribution sections
- publish a complete challenge index including statuses, tech stacks, and entry points for solved and backlog items
- add per-game READMEs for current implementations with run commands, dependency notes, and asset guidance

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68d730e2904c832998c7512094ac35be