### PR TITLE
Add modular chess implementation with UI and tests

### DIFF
--- a/Games/Chess/README.md
+++ b/Games/Chess/README.md
@@ -1,0 +1,69 @@
+# Chess
+
+A feature-complete chess implementation written in Python with modular board
+logic, PGN support, an optional minimax AI, and both Pygame and CLI
+interfaces.
+
+## Features
+
+- Full legal move generation including castling, en passant, promotions, and
+  check/checkmate detection.
+- Pure-Python board module that can be reused or tested independently.
+- PGN import/export helpers for sharing games.
+- Optional minimax AI opponent with a material-based heuristic.
+- Two front-ends: a headless CLI and a graphical Pygame board.
+- Automated pytest suite covering tricky move rules.
+
+## Installation
+
+Install the repository in editable mode with the `games` extra to pull in
+Pygame:
+
+```bash
+python -m pip install -e .[games]
+```
+
+For development (tests, linting) you may also want the `developer` extra:
+
+```bash
+python -m pip install -e .[games,developer]
+```
+
+## Running the CLI
+
+```
+python -m Games.Chess.cli [--ai white|black|both] [--depth N] [--pgn game.pgn]
+```
+
+> Tip: If you `cd Games` first, run `python -m Chess.cli` instead of prefixing
+> with `Games.`
+
+Commands available while playing:
+
+- Enter moves in SAN (e.g. `Nf3`) or UCI (`g1f3`).
+- Type `moves` to see all legal moves.
+- `save output.pgn` exports the move history.
+- `load input.pgn` replaces the current position with moves from the given PGN.
+- `quit` ends the session.
+
+## Running the Pygame UI
+
+```
+python -m Games.Chess.pygame_ui [ai]
+```
+
+> From inside `Games/`, launch with `python -m Chess.pygame_ui`.
+
+Click on a piece to see its legal moves and click a highlighted square to move.
+Pass `ai` as `w`, `b`, or `wb` to let the AI play a side.
+
+## Tests
+
+Run the automated tests for chess with:
+
+```
+pytest Games/Chess/tests
+```
+
+This exercises key move legality scenarios (castling, en passant, check
+handling) to ensure the engine stays correct.

--- a/Games/Chess/__init__.py
+++ b/Games/Chess/__init__.py
@@ -1,0 +1,6 @@
+"""Chess game implementation with board logic, move validation, and UIs."""
+
+from .board import Board
+from .move import Move
+
+__all__ = ["Board", "Move"]

--- a/Games/Chess/__main__.py
+++ b/Games/Chess/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for ``python -m Games.Chess``."""
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/Games/Chess/ai.py
+++ b/Games/Chess/ai.py
@@ -1,0 +1,81 @@
+"""Simple minimax AI opponent for chess."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+from .board import BLACK, WHITE, Board
+from .move import Move
+
+
+@dataclass
+class SearchResult:
+    move: Optional[Move]
+    score: int
+    nodes: int = 0
+
+
+def evaluate(board: Board) -> int:
+    """Material-only evaluation from white's perspective."""
+
+    return board.material_balance()
+
+
+def minimax(
+    board: Board,
+    depth: int,
+    maximizing: bool,
+    alpha: int = -10_000_000,
+    beta: int = 10_000_000,
+    eval_fn: Callable[[Board], int] = evaluate,
+) -> SearchResult:
+    """Perform a minimax search with alpha-beta pruning."""
+
+    legal_moves = board.legal_moves()
+    if depth == 0 or not legal_moves:
+        base_score = eval_fn(board)
+        if not legal_moves:
+            if board.is_in_check(board.turn):
+                # Mate is bad for side to move
+                base_score = -10_000 if maximizing else 10_000
+            else:
+                base_score = 0
+        return SearchResult(move=None, score=base_score, nodes=1)
+
+    best_move: Optional[Move] = None
+    nodes = 0
+    if maximizing:
+        value = -10_000_000
+        for move in legal_moves:
+            child = board.make_move(move)
+            result = minimax(child, depth - 1, False, alpha, beta, eval_fn)
+            nodes += result.nodes
+            if result.score > value:
+                value = result.score
+                best_move = move
+            alpha = max(alpha, value)
+            if alpha >= beta:
+                break
+        return SearchResult(move=best_move, score=value, nodes=nodes)
+    value = 10_000_000
+    for move in legal_moves:
+        child = board.make_move(move)
+        result = minimax(child, depth - 1, True, alpha, beta, eval_fn)
+        nodes += result.nodes
+        if result.score < value:
+            value = result.score
+            best_move = move
+        beta = min(beta, value)
+        if beta <= alpha:
+            break
+    return SearchResult(move=best_move, score=value, nodes=nodes)
+
+
+def choose_move(board: Board, depth: int = 2, eval_fn: Callable[[Board], int] = evaluate) -> Move:
+    """Choose a move for the side to move on ``board``."""
+
+    maximizing = board.turn == WHITE
+    result = minimax(board, depth, maximizing, eval_fn=eval_fn)
+    if result.move is None:
+        raise ValueError("No legal moves available")
+    return result.move

--- a/Games/Chess/board.py
+++ b/Games/Chess/board.py
@@ -1,0 +1,494 @@
+"""Core board model and move generation for the chess game."""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from .move import Move, Square
+
+WHITE = "w"
+BLACK = "b"
+FILES = "abcdefgh"
+RANKS = "12345678"
+
+PIECE_VALUES = {
+    "P": 100,
+    "N": 320,
+    "B": 330,
+    "R": 500,
+    "Q": 900,
+    "K": 20000,
+}
+
+
+@dataclass(frozen=True)
+class Board:
+    """Immutable chess board state."""
+
+    board: Tuple[Tuple[Optional[str], ...], ...]
+    turn: str = WHITE
+    castling: str = "KQkq"
+    en_passant: Optional[Square] = None
+    halfmove_clock: int = 0
+    fullmove_number: int = 1
+
+    @staticmethod
+    def starting_position() -> "Board":
+        """Return the standard chess initial setup."""
+
+        layout = (
+            tuple("rnbqkbnr"),
+            tuple("pppppppp"),
+            tuple([None] * 8),
+            tuple([None] * 8),
+            tuple([None] * 8),
+            tuple([None] * 8),
+            tuple("PPPPPPPP"),
+            tuple("RNBQKBNR"),
+        )
+        return Board(layout)
+
+    def piece_at(self, square: Square) -> Optional[str]:
+        return self.board[square[0]][square[1]]
+
+    def set_piece(self, square: Square, piece: Optional[str]) -> "Board":
+        rows = [list(row) for row in self.board]
+        rows[square[0]][square[1]] = piece
+        return replace(self, board=tuple(tuple(row) for row in rows))
+
+    def switch_turn(self) -> "Board":
+        return replace(self, turn=WHITE if self.turn == BLACK else BLACK)
+
+    # Utility conversions -------------------------------------------------
+    @staticmethod
+    def square_name(square: Square) -> str:
+        return FILES[square[1]] + str(8 - square[0])
+
+    @staticmethod
+    def parse_square(name: str) -> Square:
+        file = FILES.index(name[0])
+        rank = 8 - int(name[1])
+        return rank, file
+
+    # Iterators -----------------------------------------------------------
+    def pieces(self, color: Optional[str] = None) -> Iterable[Tuple[Square, str]]:
+        for r in range(8):
+            for c in range(8):
+                piece = self.board[r][c]
+                if piece is None:
+                    continue
+                if color and self.color_of(piece) != color:
+                    continue
+                yield (r, c), piece
+
+    @staticmethod
+    def color_of(piece: str) -> str:
+        return WHITE if piece.isupper() else BLACK
+
+    # Move generation -----------------------------------------------------
+    def legal_moves(self) -> List[Move]:
+        moves: List[Move] = []
+        for move in self.pseudo_legal_moves(self.turn):
+            if not self._leaves_king_in_check(move):
+                moves.append(move)
+        return moves
+
+    def pseudo_legal_moves(self, color: str) -> Iterable[Move]:
+        for square, piece in self.pieces(color):
+            piece_type = piece.upper()
+            if piece_type == "P":
+                yield from self._pawn_moves(square, color)
+            elif piece_type == "N":
+                yield from self._knight_moves(square, color)
+            elif piece_type == "B":
+                yield from self._slider_moves(square, color, [(-1, -1), (-1, 1), (1, -1), (1, 1)])
+            elif piece_type == "R":
+                yield from self._slider_moves(square, color, [(-1, 0), (1, 0), (0, -1), (0, 1)])
+            elif piece_type == "Q":
+                yield from self._slider_moves(
+                    square,
+                    color,
+                    [(-1, -1), (-1, 1), (1, -1), (1, 1), (-1, 0), (1, 0), (0, -1), (0, 1)],
+                )
+            elif piece_type == "K":
+                yield from self._king_moves(square, color)
+
+    def _pawn_moves(self, square: Square, color: str) -> Iterable[Move]:
+        direction = -1 if color == WHITE else 1
+        start_row = 6 if color == WHITE else 1
+        promotion_row = 0 if color == WHITE else 7
+        r, c = square
+
+        one_forward = (r + direction, c)
+        if self._on_board(one_forward) and self.piece_at(one_forward) is None:
+            if one_forward[0] == promotion_row:
+                for promo in "QRBN":
+                    yield Move(square, one_forward, promotion=promo)
+            else:
+                yield Move(square, one_forward)
+            two_forward = (r + 2 * direction, c)
+            if r == start_row and self.piece_at(two_forward) is None:
+                yield Move(square, two_forward)
+
+        for dc in (-1, 1):
+            target = (r + direction, c + dc)
+            if not self._on_board(target):
+                continue
+            captured = self.piece_at(target)
+            if captured and self.color_of(captured) != color:
+                if target[0] == promotion_row:
+                    for promo in "QRBN":
+                        yield Move(square, target, promotion=promo)
+                else:
+                    yield Move(square, target)
+            elif self.en_passant and target == self.en_passant:
+                yield Move(square, target, is_en_passant=True)
+
+    def _knight_moves(self, square: Square, color: str) -> Iterable[Move]:
+        r, c = square
+        for dr, dc in [(-2, -1), (-2, 1), (-1, -2), (-1, 2), (1, -2), (1, 2), (2, -1), (2, 1)]:
+            target = (r + dr, c + dc)
+            if not self._on_board(target):
+                continue
+            piece = self.piece_at(target)
+            if piece is None or self.color_of(piece) != color:
+                yield Move(square, target)
+
+    def _slider_moves(
+        self, square: Square, color: str, directions: Iterable[Tuple[int, int]]
+    ) -> Iterable[Move]:
+        r, c = square
+        for dr, dc in directions:
+            nr, nc = r + dr, c + dc
+            while self._on_board((nr, nc)):
+                piece = self.piece_at((nr, nc))
+                if piece is None:
+                    yield Move(square, (nr, nc))
+                else:
+                    if self.color_of(piece) != color:
+                        yield Move(square, (nr, nc))
+                    break
+                nr += dr
+                nc += dc
+
+    def _king_moves(self, square: Square, color: str) -> Iterable[Move]:
+        r, c = square
+        for dr in (-1, 0, 1):
+            for dc in (-1, 0, 1):
+                if dr == 0 and dc == 0:
+                    continue
+                target = (r + dr, c + dc)
+                if not self._on_board(target):
+                    continue
+                piece = self.piece_at(target)
+                if piece is None or self.color_of(piece) != color:
+                    yield Move(square, target)
+
+        if color == self.turn:
+            yield from self._castling_moves(square, color)
+
+    def _castling_moves(self, square: Square, color: str) -> Iterable[Move]:
+        if color == WHITE:
+            rights = self.castling
+            back_rank = 7
+            king_side = "K"
+            queen_side = "Q"
+        else:
+            rights = self.castling
+            back_rank = 0
+            king_side = "k"
+            queen_side = "q"
+
+        if king_side in rights:
+            if self._can_castle_through(back_rank, 4, 6, color):
+                yield Move(square, (back_rank, 6), is_castling=True)
+        if queen_side in rights:
+            if self._can_castle_through(back_rank, 4, 2, color, queen_side=True):
+                yield Move(square, (back_rank, 2), is_castling=True)
+
+    def _can_castle_through(
+        self,
+        rank: int,
+        king_start: int,
+        king_end: int,
+        color: str,
+        queen_side: bool = False,
+    ) -> bool:
+        step = 1 if king_end > king_start else -1
+        rook_col = 0 if queen_side else 7
+        rook_square = (rank, rook_col)
+        rook = self.piece_at(rook_square)
+        if rook is None or rook.upper() != "R" or self.color_of(rook) != color:
+            return False
+
+        for col in range(min(king_start, rook_col) + 1, max(king_start, rook_col)):
+            if self.piece_at((rank, col)) is not None:
+                return False
+
+        for col in range(king_start, king_end + step, step):
+            if self.square_attacked((rank, col), WHITE if color == BLACK else BLACK):
+                return False
+        return True
+
+    def _on_board(self, square: Square) -> bool:
+        return 0 <= square[0] < 8 and 0 <= square[1] < 8
+
+    def _leaves_king_in_check(self, move: Move) -> bool:
+        new_board = self.make_move(move)
+        return new_board.is_in_check(self.turn)
+
+    def square_attacked(self, square: Square, by_color: str) -> bool:
+        for move in self.pseudo_legal_moves(by_color):
+            if move.end == square:
+                return True
+        return False
+
+    def king_square(self, color: str) -> Square:
+        for square, piece in self.pieces(color):
+            if piece.upper() == "K":
+                return square
+        raise ValueError("King missing from board")
+
+    def is_in_check(self, color: str) -> bool:
+        king_sq = self.king_square(color)
+        opponent = WHITE if color == BLACK else BLACK
+        return self.square_attacked(king_sq, opponent)
+
+    # Move application ----------------------------------------------------
+    def make_move(self, move: Move) -> "Board":
+        start_piece = self.piece_at(move.start)
+        if start_piece is None:
+            raise ValueError("No piece on the starting square")
+        color = self.color_of(start_piece)
+        target_piece = self.piece_at(move.end)
+        rows = [list(row) for row in self.board]
+
+        # Handle en passant capture removal
+        if move.is_en_passant:
+            ep_rank = move.start[0]
+            rows[ep_rank][move.end[1]] = None
+
+        rows[move.start[0]][move.start[1]] = None
+
+        if move.is_castling:
+            if move.end[1] == 6:
+                # king side
+                rows[move.end[0]][5] = rows[move.end[0]][7]
+                rows[move.end[0]][7] = None
+            else:
+                rows[move.end[0]][3] = rows[move.end[0]][0]
+                rows[move.end[0]][0] = None
+
+        # Promotion or normal move
+        piece_to_place = start_piece
+        if move.promotion:
+            piece_to_place = move.promotion if color == WHITE else move.promotion.lower()
+        rows[move.end[0]][move.end[1]] = piece_to_place
+
+        new_board = replace(self, board=tuple(tuple(row) for row in rows))
+
+        # Update castling rights
+        castling = new_board.castling
+        if start_piece.upper() == "K":
+            castling = castling.replace("K", "").replace("Q", "") if color == WHITE else castling
+            castling = castling.replace("k", "").replace("q", "") if color == BLACK else castling
+        if start_piece.upper() == "R":
+            if move.start == (7, 0):
+                castling = castling.replace("Q", "")
+            elif move.start == (7, 7):
+                castling = castling.replace("K", "")
+            elif move.start == (0, 0):
+                castling = castling.replace("q", "")
+            elif move.start == (0, 7):
+                castling = castling.replace("k", "")
+        if move.end == (7, 0):
+            castling = castling.replace("Q", "")
+        elif move.end == (7, 7):
+            castling = castling.replace("K", "")
+        elif move.end == (0, 0):
+            castling = castling.replace("q", "")
+        elif move.end == (0, 7):
+            castling = castling.replace("k", "")
+
+        en_passant: Optional[Square] = None
+        if start_piece.upper() == "P" and abs(move.start[0] - move.end[0]) == 2:
+            en_passant = ((move.start[0] + move.end[0]) // 2, move.start[1])
+
+        halfmove = 0 if start_piece.upper() == "P" or target_piece else self.halfmove_clock + 1
+        fullmove = self.fullmove_number + (1 if self.turn == BLACK else 0)
+
+        new_board = replace(
+            new_board,
+            castling=castling,
+            en_passant=en_passant,
+            halfmove_clock=halfmove,
+            fullmove_number=fullmove,
+            turn=WHITE if self.turn == BLACK else BLACK,
+        )
+        return new_board
+
+    # Evaluation helpers --------------------------------------------------
+    def material_balance(self) -> int:
+        score = 0
+        for _, piece in self.pieces():
+            value = PIECE_VALUES[piece.upper()]
+            score += value if piece.isupper() else -value
+        return score
+
+    # SAN notation --------------------------------------------------------
+    def san(self, move: Move) -> str:
+        """Return the algebraic notation for a legal move."""
+
+        if move.is_castling:
+            return "O-O" if move.end[1] == 6 else "O-O-O"
+
+        piece = self.piece_at(move.start)
+        if piece is None:
+            raise ValueError("Cannot format SAN for move without piece")
+        color = self.color_of(piece)
+        board_after = self.make_move(move)
+        opponent = WHITE if color == BLACK else BLACK
+        capture = self.piece_at(move.end) is not None or move.is_en_passant
+
+        disambiguation = ""
+        if piece.upper() != "P":
+            same_piece_moves = [
+                m
+                for m in self.pseudo_legal_moves(color)
+                if m.end == move.end and m != move and not self._leaves_king_in_check(m)
+                and self.piece_at(m.start).upper() == piece.upper()
+            ]
+            if same_piece_moves:
+                same_files = {m.start[1] for m in same_piece_moves}
+                same_ranks = {m.start[0] for m in same_piece_moves}
+                file_char = FILES[move.start[1]]
+                rank_char = str(8 - move.start[0])
+                if move.start[1] not in same_files:
+                    disambiguation = file_char
+                elif move.start[0] not in same_ranks:
+                    disambiguation = rank_char
+                else:
+                    disambiguation = file_char + rank_char
+
+        piece_char = "" if piece.upper() == "P" else piece.upper()
+        capture_indicator = "x" if capture else ""
+        target_square = self.square_name(move.end)
+        promotion = f"={move.promotion.upper()}" if move.promotion else ""
+        check = "+" if board_after.is_in_check(opponent) else ""
+
+        if not board_after.legal_moves() and board_after.is_in_check(opponent):
+            check = "#"
+        elif not board_after.legal_moves():
+            check = ""
+
+        if piece.upper() == "P" and capture:
+            piece_char = FILES[move.start[1]]
+        return f"{piece_char}{disambiguation}{capture_indicator}{target_square}{promotion}{check}"
+
+    # Parsing --------------------------------------------------------------
+    def parse_san(self, san: str) -> Move:
+        """Parse SAN notation into a Move instance."""
+
+        san = san.strip()
+        if san in {"O-O", "0-0"}:
+            king_rank = 7 if self.turn == WHITE else 0
+            return Move((king_rank, 4), (king_rank, 6), is_castling=True)
+        if san in {"O-O-O", "0-0-0"}:
+            king_rank = 7 if self.turn == WHITE else 0
+            return Move((king_rank, 4), (king_rank, 2), is_castling=True)
+
+        san = san.replace("+", "").replace("#", "")
+        promotion = None
+        if "=" in san:
+            san, promotion = san.split("=")
+            promotion = promotion.upper()
+
+        capture = "x" in san
+        san = san.replace("x", "")
+        piece_char = san[0] if san[0].isupper() and san[0] in "RNBQKP" else "P"
+        if piece_char != "P" and san[0].isupper():
+            san = san[1:]
+
+        file_hint = None
+        rank_hint = None
+        while san and san[0] in FILES:
+            if len(san) == 2:
+                break
+            file_hint = san[0]
+            san = san[1:]
+        while san and san[0] in RANKS and len(san) > 2:
+            rank_hint = san[0]
+            san = san[1:]
+
+        target = self.parse_square(san[-2:])
+
+        candidates = []
+        for move in self.legal_moves():
+            if move.end != target:
+                continue
+            start_piece = self.piece_at(move.start)
+            if start_piece is None or start_piece.upper() != piece_char:
+                continue
+            if promotion and move.promotion != promotion:
+                continue
+            if file_hint and FILES[move.start[1]] != file_hint:
+                continue
+            if rank_hint and str(8 - move.start[0]) != rank_hint:
+                continue
+            if capture and self.piece_at(move.end) is None and not move.is_en_passant:
+                continue
+            candidates.append(move)
+
+        if len(candidates) != 1:
+            raise ValueError(f"Ambiguous SAN move: {san}")
+        return candidates[0]
+
+    # FEN helpers ----------------------------------------------------------
+    def to_fen(self) -> str:
+        rows = []
+        for r in range(8):
+            empty = 0
+            fen_row = ""
+            for c in range(8):
+                piece = self.board[r][c]
+                if piece is None:
+                    empty += 1
+                else:
+                    if empty:
+                        fen_row += str(empty)
+                        empty = 0
+                    fen_row += piece
+            if empty:
+                fen_row += str(empty)
+            rows.append(fen_row)
+        castling = self.castling or "-"
+        ep = self.square_name(self.en_passant) if self.en_passant else "-"
+        return " ".join(
+            ["/".join(rows), self.turn, castling, ep, str(self.halfmove_clock), str(self.fullmove_number)]
+        )
+
+    @staticmethod
+    def from_fen(value: str) -> "Board":
+        parts = value.strip().split()
+        if len(parts) != 6:
+            raise ValueError("Invalid FEN")
+        rows = []
+        for row in parts[0].split("/"):
+            expanded: List[Optional[str]] = []
+            for ch in row:
+                if ch.isdigit():
+                    expanded.extend([None] * int(ch))
+                else:
+                    expanded.append(ch)
+            rows.append(tuple(expanded))
+        board = tuple(rows)
+        en_passant = None if parts[3] == "-" else Board.parse_square(parts[3])
+        return Board(
+            board,
+            turn=parts[1],
+            castling=parts[2] if parts[2] != "-" else "",
+            en_passant=en_passant,
+            halfmove_clock=int(parts[4]),
+            fullmove_number=int(parts[5]),
+        )
+

--- a/Games/Chess/cli.py
+++ b/Games/Chess/cli.py
@@ -1,0 +1,171 @@
+"""Command line interface for the chess game."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from . import Board
+from .ai import choose_move
+from .move import Move
+from .pgn import export_pgn, import_pgn
+
+PIECE_SYMBOLS = {
+    "P": "♙",
+    "N": "♘",
+    "B": "♗",
+    "R": "♖",
+    "Q": "♕",
+    "K": "♔",
+    "p": "♟",
+    "n": "♞",
+    "b": "♝",
+    "r": "♜",
+    "q": "♛",
+    "k": "♚",
+}
+
+
+def render_board(board: Board, use_unicode: bool = True) -> str:
+    """Return an ASCII or unicode representation of the board."""
+
+    lines: List[str] = []
+    for r in range(8):
+        row = [str(8 - r)]
+        for c in range(8):
+            piece = board.board[r][c]
+            if piece is None:
+                row.append("." if not use_unicode else "·")
+            elif use_unicode:
+                row.append(PIECE_SYMBOLS[piece])
+            else:
+                row.append(piece)
+        lines.append(" ".join(row))
+    lines.append("  a b c d e f g h")
+    return "\n".join(lines)
+
+
+def parse_move(board: Board, raw: str) -> Move:
+    raw = raw.strip()
+    if not raw:
+        raise ValueError("Empty move")
+    legal = board.legal_moves()
+    try:
+        tentative = Move.from_uci(raw)
+        for move in legal:
+            if move.start == tentative.start and move.end == tentative.end:
+                if (move.promotion or "") == (tentative.promotion or ""):
+                    return move
+        raise ValueError("UCI move does not match a legal move")
+    except Exception:
+        return board.parse_san(raw)
+
+
+def play_cli(
+    initial_board: Optional[Board] = None,
+    ai: Optional[str] = None,
+    depth: int = 2,
+    use_unicode: bool = True,
+    history: Optional[List[Move]] = None,
+) -> None:
+    board = initial_board or Board.starting_position()
+    history = list(history or [])
+
+    print(render_board(board, use_unicode=use_unicode))
+    while True:
+        legal = board.legal_moves()
+        if not legal:
+            if board.is_in_check(board.turn):
+                winner = "Black" if board.turn == "w" else "White"
+                print(f"Checkmate! {winner} wins.")
+            else:
+                print("Stalemate.")
+            break
+
+        if board.turn == "w":
+            turn_name = "White"
+        else:
+            turn_name = "Black"
+        ai_turn = ai and board.turn in ai
+
+        if ai_turn:
+            move = choose_move(board, depth)
+            print(f"AI plays {board.san(move)} ({move.to_uci()})")
+        else:
+            prompt = f"{turn_name} to move (enter SAN or UCI, 'moves', 'save <file>', 'load <file>', 'quit'): "
+            raw = input(prompt).strip()
+            if raw.lower() in {"quit", "exit"}:
+                print("Game aborted.")
+                break
+            if raw.lower() == "moves":
+                san_moves = [board.san(m) for m in legal]
+                print("Available moves:", ", ".join(sorted(san_moves)))
+                continue
+            if raw.lower().startswith("save "):
+                path = Path(raw.split(maxsplit=1)[1])
+                pgn = export_pgn(Board.starting_position(), history, "*")
+                path.write_text(pgn, encoding="utf-8")
+                print(f"Saved PGN to {path}")
+                continue
+            if raw.lower().startswith("load "):
+                path = Path(raw.split(maxsplit=1)[1])
+                moves = import_pgn(path.read_text(encoding="utf-8"))
+                board = Board.starting_position()
+                history = []
+                for mv in moves:
+                    board = board.make_move(mv)
+                    history.append(mv)
+                print("Loaded PGN.")
+                print(render_board(board, use_unicode=use_unicode))
+                continue
+            try:
+                move = parse_move(board, raw)
+            except ValueError as exc:  # pragma: no cover - defensive
+                print(f"Invalid move: {exc}")
+                continue
+            if move not in legal:
+                print("Move is not legal from this position.")
+                continue
+        board = board.make_move(move)
+        history.append(move)
+        print(render_board(board, use_unicode=use_unicode))
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Play chess from the command line.")
+    parser.add_argument("--ai", choices=["white", "black", "both"], help="Enable an AI for a side.")
+    parser.add_argument("--depth", type=int, default=2, help="Search depth for the AI.")
+    parser.add_argument("--pgn", type=Path, help="Load moves from a PGN file before starting.")
+    parser.add_argument("--ascii", action="store_true", help="Render the board using ASCII characters.")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    board = Board.starting_position()
+    history: List[Move] = []
+    if args.pgn:
+        text = args.pgn.read_text(encoding="utf-8")
+        moves = import_pgn(text, board)
+        for mv in moves:
+            board = board.make_move(mv)
+            history.append(mv)
+        print(f"Loaded {len(history)} moves from {args.pgn}.")
+
+    ai_setting = None
+    if args.ai:
+        if args.ai == "both":
+            ai_setting = "wb"
+        elif args.ai == "white":
+            ai_setting = "w"
+        else:
+            ai_setting = "b"
+
+    play_cli(
+        board,
+        ai_setting,
+        depth=args.depth,
+        use_unicode=not args.ascii,
+        history=history,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/Games/Chess/move.py
+++ b/Games/Chess/move.py
@@ -1,0 +1,50 @@
+"""Data structures describing chess moves."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+Square = Tuple[int, int]
+
+
+@dataclass(frozen=True)
+class Move:
+    """Represents a single chess move.
+
+    Attributes:
+        start: (row, column) tuple in 0-indexed board coordinates.
+        end: Destination square in 0-indexed board coordinates.
+        promotion: Optional promoted piece character (``Q``, ``R``, ``B``, ``N``).
+        is_castling: Whether the move is a castling move.
+        is_en_passant: Whether the move captures en passant.
+    """
+
+    start: Square
+    end: Square
+    promotion: Optional[str] = None
+    is_castling: bool = False
+    is_en_passant: bool = False
+
+    def to_uci(self) -> str:
+        """Return the move in UCI coordinate notation."""
+
+        return f"{self._square_to_str(self.start)}{self._square_to_str(self.end)}" + (
+            (self.promotion or "").lower()
+        )
+
+    @staticmethod
+    def _square_to_str(square: Square) -> str:
+        file = chr(ord("a") + square[1])
+        rank = str(8 - square[0])
+        return f"{file}{rank}"
+
+    @staticmethod
+    def from_uci(value: str) -> "Move":
+        """Parse a UCI move (e.g. ``e2e4`` or ``e7e8q``)."""
+
+        if len(value) not in {4, 5}:
+            raise ValueError(f"Invalid UCI move: {value}")
+        start = (8 - int(value[1]), ord(value[0]) - ord("a"))
+        end = (8 - int(value[3]), ord(value[2]) - ord("a"))
+        promotion = value[4].upper() if len(value) == 5 else None
+        return Move(start, end, promotion=promotion)

--- a/Games/Chess/pgn.py
+++ b/Games/Chess/pgn.py
@@ -1,0 +1,63 @@
+"""PGN import and export helpers."""
+from __future__ import annotations
+
+import re
+from typing import List, Sequence
+
+from .board import Board
+from .move import Move
+
+MOVE_TEXT_RE = re.compile(r"(\d+\.+)|([\w+#=O-]+)")
+
+
+DEFAULT_TAGS = {
+    "Event": "Casual Game",
+    "Site": "Local",
+    "Date": "????.??.??",
+    "Round": "-",
+    "White": "Human",
+    "Black": "Human",
+    "Result": "*",
+}
+
+
+def export_pgn(board: Board, moves: Sequence[Move], result: str = "*") -> str:
+    """Return a PGN string representing the game."""
+
+    tags = dict(DEFAULT_TAGS)
+    tags["Result"] = result
+    header = [f"[{key} \"{value}\"]" for key, value in tags.items()]
+
+    move_text_parts: List[str] = []
+    state = board
+    for index, move in enumerate(moves):
+        if index % 2 == 0:
+            move_text_parts.append(f"{index // 2 + 1}.")
+        move_text_parts.append(state.san(move))
+        state = state.make_move(move)
+    move_text = " ".join(move_text_parts)
+    if result != "*":
+        move_text = f"{move_text} {result}".strip()
+
+    return "\n".join(header + ["", move_text])
+
+
+def import_pgn(text: str, board: Board | None = None) -> List[Move]:
+    """Parse a PGN string and return the move list."""
+
+    board = board or Board.starting_position()
+    moves: List[Move] = []
+    for line in text.strip().splitlines():
+        line = line.strip()
+        if not line or line.startswith("["):
+            continue
+        for token in MOVE_TEXT_RE.findall(line):
+            word = next(filter(None, token))
+            if word.endswith("."):
+                continue
+            if word in {"1-0", "0-1", "1/2-1/2", "*"}:
+                break
+            move = board.parse_san(word)
+            moves.append(move)
+            board = board.make_move(move)
+    return moves

--- a/Games/Chess/pygame_ui.py
+++ b/Games/Chess/pygame_ui.py
@@ -1,0 +1,199 @@
+"""Pygame interface for the chess game."""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple, Union
+
+import pygame
+
+from .ai import choose_move
+from .board import WHITE, Board
+from .move import Move
+
+SQUARE_SIZE = 80
+BOARD_SIZE = SQUARE_SIZE * 8
+MARGIN = 20
+WINDOW_SIZE = BOARD_SIZE + 2 * MARGIN
+
+LIGHT = (240, 217, 181)
+DARK = (181, 136, 99)
+HIGHLIGHT = (246, 246, 105)
+SELECTED = (186, 202, 68)
+TEXT_COLOR = (20, 20, 20)
+FONT_NAME = "freesansbold.ttf"
+
+PIECE_TEXT = {
+    "P": "♙",
+    "N": "♘",
+    "B": "♗",
+    "R": "♖",
+    "Q": "♕",
+    "K": "♔",
+    "p": "♟",
+    "n": "♞",
+    "b": "♝",
+    "r": "♜",
+    "q": "♛",
+    "k": "♚",
+}
+
+
+@dataclass
+class GameState:
+    board: Board
+    selected: Optional[Tuple[int, int]] = None
+    legal_moves: Dict[Tuple[int, int], List[Move]] | None = None
+    history: Tuple[Move, ...] = ()
+
+
+def draw_board(screen: pygame.Surface, font: pygame.font.Font, state: GameState) -> None:
+    screen.fill((30, 30, 30))
+    board = state.board
+    for row in range(8):
+        for col in range(8):
+            color = LIGHT if (row + col) % 2 == 0 else DARK
+            rect = pygame.Rect(MARGIN + col * SQUARE_SIZE, MARGIN + row * SQUARE_SIZE, SQUARE_SIZE, SQUARE_SIZE)
+            if state.selected == (row, col):
+                pygame.draw.rect(screen, SELECTED, rect)
+            elif state.legal_moves and (row, col) in state.legal_moves:
+                pygame.draw.rect(screen, HIGHLIGHT, rect)
+            else:
+                pygame.draw.rect(screen, color, rect)
+            piece = board.board[row][col]
+            if piece:
+                text = font.render(PIECE_TEXT[piece], True, TEXT_COLOR)
+                text_rect = text.get_rect(center=rect.center)
+                screen.blit(text, text_rect)
+
+    info_font = pygame.font.Font(FONT_NAME, 20)
+    turn_text = "White to move" if board.turn == WHITE else "Black to move"
+    surface = info_font.render(turn_text, True, (230, 230, 230))
+    screen.blit(surface, (MARGIN, WINDOW_SIZE - MARGIN + 4))
+
+
+def handle_click(state: GameState, pos: Tuple[int, int]) -> Union[None, Move, List[Move]]:
+    board = state.board
+    col = (pos[0] - MARGIN) // SQUARE_SIZE
+    row = (pos[1] - MARGIN) // SQUARE_SIZE
+    if not (0 <= row < 8 and 0 <= col < 8):
+        state.selected = None
+        state.legal_moves = None
+        return None
+
+    square = (row, col)
+    if state.selected is None:
+        piece = board.piece_at(square)
+        if piece and board.color_of(piece) == board.turn:
+            moves: Dict[Tuple[int, int], List[Move]] = {}
+            for move in board.legal_moves():
+                if move.start == square:
+                    moves.setdefault(move.end, []).append(move)
+            if moves:
+                state.selected = square
+                state.legal_moves = moves
+        return None
+
+    if state.legal_moves and square in state.legal_moves:
+        options = state.legal_moves[square]
+        state.selected = None
+        state.legal_moves = None
+        if len(options) == 1:
+            return options[0]
+        return options
+
+    state.selected = None
+    state.legal_moves = None
+    return None
+
+
+def ai_move(state: GameState, depth: int) -> Optional[Move]:
+    try:
+        return choose_move(state.board, depth)
+    except ValueError:
+        return None
+
+def prompt_promotion(
+    screen: pygame.Surface, font: pygame.font.Font, state: GameState, options: List[Move]
+) -> Optional[Move]:
+    option_font = pygame.font.Font(FONT_NAME, 28)
+    prompt_font = pygame.font.Font(FONT_NAME, 24)
+    mapping = {move.promotion or "Q": move for move in options}
+    while True:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return None
+            if event.type == pygame.KEYDOWN:
+                key = event.unicode.upper()
+                if key in mapping:
+                    return mapping[key]
+            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                x, y = event.pos
+                buttons = list(mapping.items())
+                for index, (promo, move) in enumerate(buttons):
+                    rect = pygame.Rect(
+                        MARGIN + index * 120,
+                        WINDOW_SIZE // 2 - 40,
+                        100,
+                        80,
+                    )
+                    if rect.collidepoint(x, y):
+                        return move
+
+        draw_board(screen, font, state)
+        overlay = pygame.Surface((WINDOW_SIZE, WINDOW_SIZE), pygame.SRCALPHA)
+        overlay.fill((0, 0, 0, 160))
+        screen.blit(overlay, (0, 0))
+        title = prompt_font.render("Choose promotion (click or press key)", True, (255, 255, 255))
+        screen.blit(title, (MARGIN, WINDOW_SIZE // 2 - 80))
+        for index, (promo, move) in enumerate(mapping.items()):
+            rect = pygame.Rect(MARGIN + index * 120, WINDOW_SIZE // 2 - 40, 100, 80)
+            pygame.draw.rect(screen, (220, 220, 220), rect)
+            label = option_font.render(promo, True, (20, 20, 20))
+            label_rect = label.get_rect(center=rect.center)
+            screen.blit(label, label_rect)
+        pygame.display.flip()
+
+
+def run_pygame(ai: Optional[str] = None, depth: int = 2) -> None:
+    pygame.init()
+    screen = pygame.display.set_mode((WINDOW_SIZE, WINDOW_SIZE + 40))
+    pygame.display.set_caption("Chess")
+    font = pygame.font.Font(FONT_NAME, 48)
+
+    state = GameState(board=Board.starting_position())
+    clock = pygame.time.Clock()
+
+    running = True
+    while running:
+        clock.tick(30)
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                if ai and state.board.turn in ai:
+                    continue
+                move = handle_click(state, event.pos)
+                if isinstance(move, Move):
+                    state.board = state.board.make_move(move)
+                elif isinstance(move, list) and move:
+                    choice = prompt_promotion(screen, font, state, move)
+                    if choice:
+                        state.board = state.board.make_move(choice)
+        if ai and state.board.turn in ai:
+            move = ai_move(state, depth)
+            if move:
+                state.board = state.board.make_move(move)
+
+        draw_board(screen, font, state)
+        pygame.display.flip()
+
+    pygame.quit()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    depth = 2
+    ai = None
+    if len(sys.argv) > 1:
+        ai = sys.argv[1]
+    run_pygame(ai=ai, depth=depth)

--- a/Games/Chess/tests/test_moves.py
+++ b/Games/Chess/tests/test_moves.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from Games.Chess.board import Board
+
+
+def test_starting_position_has_twenty_moves():
+    board = Board.starting_position()
+    moves = board.legal_moves()
+    assert len(moves) == 20
+
+
+def test_simple_opening_sequence():
+    board = Board.starting_position()
+    move = next(m for m in board.legal_moves() if m.to_uci() == "e2e4")
+    board = board.make_move(move)
+    assert board.turn == "b"
+    assert board.piece_at(Board.parse_square("e4")) == "P"
+
+    reply = next(m for m in board.legal_moves() if m.to_uci() == "e7e5")
+    board = board.make_move(reply)
+
+    knight_move = next(m for m in board.legal_moves() if m.to_uci() == "g1f3")
+    board = board.make_move(knight_move)
+    assert board.piece_at(Board.parse_square("f3")) == "N"
+
+
+def test_castling_detection():
+    board = Board.from_fen("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1")
+    legal = {m.to_uci(): m for m in board.legal_moves()}
+    assert "e1g1" in legal
+    assert legal["e1g1"].is_castling
+    assert "e1c1" in legal
+
+
+def test_en_passant_capture():
+    board = Board.from_fen("4k3/8/8/3pP3/8/8/8/4K3 w - d6 0 1")
+    move = next(m for m in board.legal_moves() if m.to_uci() == "e5d6")
+    assert move.is_en_passant
+    board = board.make_move(move)
+    assert board.piece_at(Board.parse_square("d6")) == "P"
+    assert board.piece_at(Board.parse_square("d5")) is None
+
+
+def test_check_detection():
+    board = Board.from_fen("r3k2r/8/8/4Q3/8/8/8/R3K2R b KQkq - 0 1")
+    assert board.is_in_check("b")
+    legal = [m.to_uci() for m in board.legal_moves()]
+    assert "e8d7" in legal

--- a/Games/README.md
+++ b/Games/README.md
@@ -76,7 +76,7 @@ Authoritative status board for challenges #104–#132. Entry points list the mai
 | 122 | Design a Game Engine in Unity | Backlog | Unity (planned) | — |
 | 123 | Yahtzee | Solved | Python 3 (CLI), Java | `Yahtzee/yahtzee.py`, `Yahtzee/yahtzee.java` |
 | 124 | Oil Panic | Backlog | TBD | — |
-| 125 | Chess | Backlog | TBD | — |
+| 125 | Chess | Solved | Python 3 (CLI + Pygame) | `python -m Games.Chess.cli`, `python -m Games.Chess.pygame_ui` |
 | 126 | Go (No AI necessary) | Backlog | TBD | — |
 | 127 | Connect Four | Solved | Python 3 + pygame + numpy, Java | `Connect4/connect4.py`, `Connect4/connect4.java` |
 | 128 | Mastermind | Backlog | TBD | — |
@@ -118,9 +118,10 @@ python "Yahtzee/yahtzee.py"     # CLI edition
 python "Snake/snake.py"         # Turtle graphics, ensure tkinter is available
 python "Knight Tour/knight.py"  # CLI solver visualises via stdout
 python "RPS/rpsls.py"           # CLI (supports Lizard/Spock variant)
+python -m Chess.cli              # CLI chess with optional AI
 ```
 
-Per-game documentation: [Connect Four](Connect4/README.md), [Minesweeper](Minesweeper/README.md), [Simon](Simon/README.md), [Sudoku](Sudoku/README.md), [Shuffle](Shuffle/README.md), [Yahtzee](Yahtzee/README.md), [Snake](Snake/README.md), [Knight's Tour]("Knight Tour"/README.md), [Rock Paper Scissors](RPS/README.md).
+Per-game documentation: [Connect Four](Connect4/README.md), [Minesweeper](Minesweeper/README.md), [Simon](Simon/README.md), [Sudoku](Sudoku/README.md), [Shuffle](Shuffle/README.md), [Yahtzee](Yahtzee/README.md), [Snake](Snake/README.md), [Knight's Tour]("Knight Tour"/README.md), [Rock Paper Scissors](RPS/README.md), [Chess](Chess/README.md).
 
 Assets are co-located inside each project (e.g., `Simon/Assets/Audio`). Keep relative paths intact when running outside the repo root.
 

--- a/Games/__init__.py
+++ b/Games/__init__.py
@@ -1,0 +1,1 @@
+"""Namespace package for the Games collection."""

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The repository includes a GitHub Actions workflow at `.github/workflows/keep-str
 | 122 | Design a Game Engine in Unity | Not Yet |
 | 123 | Yahtzee | [View Solution](./Games/Yahtzee/) |
 | 124 | Oil Panic | Not Yet |
-| 125 | Chess | Not Yet |
+| 125 | Chess | [View Solution](./Games/Chess/) |
 | 126 | Go (No AI Necessary) | Not Yet |
 | 127 | Connect Four | [View Solution](./Games/Connect4/) |
 | 128 | Mastermind | Not Yet |


### PR DESCRIPTION
## Summary
- implement a reusable chess engine with legal move generation, PGN helpers, and minimax AI
- add CLI and Pygame interfaces plus documentation for running the new game
- cover key rules with pytest-based move legality tests and link the game from existing README indexes

## Testing
- pytest Games/Chess/tests

------
https://chatgpt.com/codex/tasks/task_b_68d7322d99dc8329a23b79cbe4b604f7