### PR TITLE
Add native producer/consumer build automation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,3 +42,29 @@ jobs:
             git commit -m "style: super-linter auto-fixes"
             git push
           fi
+
+  native-build:
+    name: Native smoke tests (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: linux-gcc-gpp-openjdk
+            java-version: "17"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install native toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential openjdk-${{ matrix.java-version }}-jdk
+
+      - name: Display toolchain versions
+        run: |
+          gcc --version
+          g++ --version
+          javac -version
+
+      - name: Run native build script
+        run: python tools/build_native.py --base "Practical/Producer Consumer" --ci

--- a/Practical/Producer Consumer/README.md
+++ b/Practical/Producer Consumer/README.md
@@ -1,0 +1,40 @@
+# Producer/Consumer Native Implementations
+
+This folder contains reference implementations of the bounded-buffer producer/consumer
+problem in C, C++, and Java. The table below lists the source files that participate
+in the shared native build, along with the compilers/VMs that are expected.
+
+| Project ID   | Source file | Language | Required toolchain | Notes |
+| ------------ | ----------- | -------- | ------------------ | ----- |
+| `pc-c`       | `pc.c`      | C (POSIX threads) | GCC or any C11 compiler with pthreads support | CLI supports `-h/--help` for usage. |
+| `pc-cpp`     | `pc.cpp`    | C++17     | G++/Clang with C++17 and pthreads | Recommended flags: `-std=c++17 -pthread`. |
+| `pcLL-java`  | `pcLL.java` | Java 11+  | OpenJDK (javac/java) | Uses intrinsic locks with optional verbose logging. |
+| `pcSem-java` | `pcSem.java`| Java 11+  | OpenJDK (javac/java) | Semaphore-based variant with similar CLI. |
+
+All implementations only depend on the standard libraries provided by the selected
+compiler or JVM.
+
+## Shared build script
+
+For repeatable local builds the repository provides a shared driver at
+`tools/build_native.py`. The script discovers the native projects in this folder,
+compiles them into a temporary build directory, and performs a lightweight
+functional smoke-test for each artifact.
+
+Typical usage from the repository root:
+
+```bash
+python tools/build_native.py --base "Practical/Producer Consumer"
+```
+
+Useful options:
+
+- `--list` — Show the discovered projects and exit.
+- `--only pc-cpp` — Limit the build to a specific project (repeatable flag).
+- `--keep-build` — Preserve the temporary build directory at `build/native/` for
+  debugging the compiled artifacts.
+
+When running the script locally ensure that `gcc`, `g++`, and an OpenJDK runtime
+(javac/java) are available on your `PATH`. The CI workflow installs these
+prerequisites automatically and executes the same smoke tests for every project
+via the `native-build` GitHub Actions job.

--- a/tools/build_native.py
+++ b/tools/build_native.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Build and smoke-test native Producer/Consumer demos."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+BASE_DEFAULT = Path("Practical/Producer Consumer")
+
+
+@dataclass(frozen=True)
+class Project:
+    name: str
+    source: Path
+    language: str
+    run_args: Sequence[str]
+    main_class: str | None = None
+    skip_ci: bool = False
+
+    @property
+    def id(self) -> str:
+        return self.name
+
+
+PROJECT_CATALOGUE: List[Project] = [
+    Project(
+        name="pc-c",
+        source=BASE_DEFAULT / "pc.c",
+        language="c",
+        run_args=["-h"],
+    ),
+    Project(
+        name="pc-cpp",
+        source=BASE_DEFAULT / "pc.cpp",
+        language="c++",
+        run_args=["-n", "1", "-P", "1", "-C", "1", "-p", "0", "-q", "0", "-c", "2"],
+    ),
+    Project(
+        name="pcLL-java",
+        source=BASE_DEFAULT / "pcLL.java",
+        language="java",
+        run_args=[
+            "quiet=true",
+            "timestamps=false",
+            "itemsPerProducer=1",
+            "producers=1",
+            "consumers=1",
+            "prodDelayMs=0",
+            "consDelayMs=0",
+        ],
+        main_class="pcLL",
+    ),
+    Project(
+        name="pcSem-java",
+        source=BASE_DEFAULT / "pcSem.java",
+        language="java",
+        run_args=[
+            "quiet=true",
+            "timestamps=false",
+            "itemsPerProducer=1",
+            "producers=1",
+            "consumers=1",
+            "prodDelayMs=0",
+            "consDelayMs=0",
+        ],
+        main_class="pcSem",
+    ),
+]
+
+
+def discover_projects(base: Path) -> List[Project]:
+    projects: List[Project] = []
+    for project in PROJECT_CATALOGUE:
+        candidate = base / project.source.name
+        if candidate.exists():
+            projects.append(
+                Project(
+                    name=project.name,
+                    source=candidate,
+                    language=project.language,
+                    run_args=project.run_args,
+                    main_class=project.main_class,
+                    skip_ci=project.skip_ci,
+                )
+            )
+    return projects
+
+
+def run(cmd: Sequence[str], *, cwd: Path | None = None) -> None:
+    print(f"$ {' '.join(cmd)}")
+    subprocess.run(cmd, check=True, cwd=str(cwd) if cwd else None)
+
+
+def compile_c(project: Project, build_dir: Path) -> Path:
+    output = build_dir / project.source.stem
+    run(
+        [
+            "gcc",
+            "-O2",
+            "-Wall",
+            "-Wextra",
+            "-pthread",
+            str(project.source),
+            "-o",
+            str(output),
+        ]
+    )
+    return output
+
+
+def compile_cpp(project: Project, build_dir: Path) -> Path:
+    output = build_dir / project.source.stem
+    run(
+        [
+            "g++",
+            "-std=c++17",
+            "-O2",
+            "-Wall",
+            "-Wextra",
+            "-pthread",
+            str(project.source),
+            "-o",
+            str(output),
+        ]
+    )
+    return output
+
+
+def compile_java(project: Project, build_dir: Path) -> Path:
+    classes_dir = build_dir / "classes"
+    classes_dir.mkdir(parents=True, exist_ok=True)
+    run(["javac", "-d", str(classes_dir), str(project.source)])
+    # Return the directory containing classes; the runner will know how to use it.
+    return classes_dir
+
+
+def smoke_test(project: Project, artifact: Path) -> None:
+    if project.language in {"c", "c++"}:
+        cmd = [str(artifact), *project.run_args]
+    elif project.language == "java":
+        if not project.main_class:
+            raise RuntimeError(f"Java project {project.name} is missing main_class metadata")
+        cmd = [
+            "java",
+            "-cp",
+            str(artifact),
+            project.main_class,
+            *project.run_args,
+        ]
+    else:
+        raise ValueError(f"Unsupported language for project {project.name}: {project.language}")
+    run(cmd)
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        type=Path,
+        default=BASE_DEFAULT,
+        help="Root directory that contains the native projects",
+    )
+    parser.add_argument(
+        "--only",
+        nargs="*",
+        help="Limit the run to the given project identifiers",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List discovered projects and exit",
+    )
+    parser.add_argument(
+        "--keep-build",
+        action="store_true",
+        help="Keep the temporary build directory instead of deleting it",
+    )
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="Enable CI mode (skips projects flagged as incompatible)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    base = args.base
+    projects = discover_projects(base)
+    if args.only:
+        whitelist = set(args.only)
+        projects = [p for p in projects if p.name in whitelist]
+    if not projects:
+        print(f"No native projects found under {base}")
+        return 0
+    if args.list:
+        print("Discovered native projects:")
+        for project in projects:
+            print(f"- {project.name}: {project.source} [{project.language}]")
+        return 0
+
+    temp_dir_manager: tempfile.TemporaryDirectory[str] | None = None
+    try:
+        if args.keep_build:
+            build_root = Path("build/native")
+            build_root.mkdir(parents=True, exist_ok=True)
+        else:
+            temp_dir_manager = tempfile.TemporaryDirectory(prefix="native-build-")
+            build_root = Path(temp_dir_manager.name)
+
+        print(f"Using build root: {build_root}")
+
+        for project in projects:
+            if args.ci and project.skip_ci:
+                print(f"Skipping {project.name} (marked as unsupported on CI)")
+                continue
+            print(f"\n=== Building {project.name} ({project.language}) ===")
+            project_build_dir = build_root / project.name
+            project_build_dir.mkdir(parents=True, exist_ok=True)
+
+            if project.language == "c":
+                artifact = compile_c(project, project_build_dir)
+            elif project.language == "c++":
+                artifact = compile_cpp(project, project_build_dir)
+            elif project.language == "java":
+                artifact = compile_java(project, project_build_dir)
+            else:
+                raise ValueError(f"Unsupported language: {project.language}")
+
+            print(f"--- Running smoke test for {project.name} ---")
+            smoke_test(project, artifact)
+        print("\nAll native projects built and tested successfully.")
+        return 0
+    finally:
+        if temp_dir_manager is not None:
+            temp_dir_manager.cleanup()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- document the compiler and JVM expectations for the producer/consumer native demos and describe the shared build entrypoint
- add tools/build_native.py to compile and smoke-test the C, C++, and Java variants
- extend the main workflow with a native-build matrix job that provisions gcc/g++/OpenJDK and runs the shared script on Linux

## Testing
- python tools/build_native.py

------
https://chatgpt.com/codex/tasks/task_b_68de34f9dc548323b55b915a771150a3