### PR TITLE
Add pytest configuration and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[developer,practical]
+
+      - name: Run test suite
+        env:
+          IMAGEBOARD_DATA_DIR: ${{ runner.temp }}/imageboard-data
+          IMAGEBOARD_SECRET_KEY: testing-secret
+          IMAGEBOARD_ADMIN_PASSWORD: letmein
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -426,7 +426,34 @@ PY
 | GUI window invisible | Running headless | Use CLI version or run locally |
 | `OSError: [Errno ...] image file truncated` | Corrupt input image | Re-download / validate file |
 
-### 8. Next Steps / Improvements
+### 8. Running Tests Locally
+
+To mirror the automated checks:
+
+1. Install the developer and practical extras in editable mode so intra-repo imports work the same way as CI:
+
+   ```bash
+   python -m pip install --upgrade pip
+   python -m pip install -e .[developer,practical]
+   ```
+
+2. From the repository root, run the full test suite:
+
+   ```bash
+   pytest
+   ```
+
+   The included `pytest.ini` sets `PYTHONPATH=.` so tests in `Practical/Imageboard/tests` and `Algorithmic/MBR` resolve local modules without extra flags.
+
+3. If you need to replicate the imageboard tests manually, export the environment variables they expect before invoking the app or running individual tests:
+
+   ```bash
+   export IMAGEBOARD_DATA_DIR=$(mktemp -d)
+   export IMAGEBOARD_SECRET_KEY=testing-secret
+   export IMAGEBOARD_ADMIN_PASSWORD=letmein
+   ```
+
+### 9. Next Steps / Improvements
 
 * Introduce `pyproject.toml` with extras: `imageboard`, `visual`, `ml`, `geo`.
 * Add `pytest` smoke tests (import + `--help` execution) to CI.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
## Summary
- add a root pytest.ini so intra-repo imports resolve when running pytest
- configure a GitHub Actions workflow that installs developer/practical extras, sets imageboard env vars, and runs pytest
- extend the repository usage guide with instructions for running pytest locally and mirroring CI variables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68de34ff7f7c832380cfd6ff35817645