### PR TITLE
Fix Black workflow permissions for push events

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   black-format:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -26,6 +28,7 @@ jobs:
         run: black .
 
       - name: Commit changes if any
+        if: github.event_name == 'push'
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- grant the Black workflow contents write permission for push authentication
- skip committing formatting changes during pull request runs where pushes are unavailable

## Testing
- black --check .

------
https://chatgpt.com/codex/tasks/task_b_68de3a3c0fa083238f1aeafe2a8bb4e9