### PR TITLE
Restrict auto-commit step to push workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: true
 
       - name: Commit & Push changes if any
+        if: github.event_name == 'push'
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- guard the Commit & Push step so it runs only on push-triggered workflows

## Testing
- not run (CI workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68de3a3ffed483239617c8b2689ed873