### PR TITLE
Update autodocs workflow permissions

### DIFF
--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -5,10 +5,11 @@ on:
     branches:
       - main
       - master
-  pull_request:
 
 jobs:
   markdown-autodocs:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- grant the markdown-autodocs job permission to push documentation updates
- limit the workflow to push events so it does not attempt commits on pull requests

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68de3a42b5b8832383c5cde42e5328a4