### PR TITLE
Add pygame-based N-body simulator with physics tests

### DIFF
--- a/Emulation/NBodySimulator/README.md
+++ b/Emulation/NBodySimulator/README.md
@@ -1,0 +1,62 @@
+# N-Body Simulator
+
+A 2D gravitational sandbox for the `/g/` challenge #100. Bodies attract
+one another, collide, and merge while conserving momentum. The project
+uses pygame for the interactive front-end and a pure-python physics core
+that is shared with automated tests.
+
+## Features
+
+- Symplectic Euler integration with configurable timestep
+- Softened Newtonian gravity to stabilise close encounters
+- Radius scaling with the cube root of mass (constant density assumption)
+- Elastic merging that conserves total mass and linear momentum
+- Optional particle trails and velocity preview during placement
+- Mouse/keyboard controls for quickly iterating on scenarios
+
+## Controls
+
+| Action | Effect |
+| ------ | ------ |
+| Left click & drag | Create a new body. Drag vector sets the initial velocity. |
+| Mouse wheel / +/- | Increase or decrease the spawn mass. |
+| `[` / `]` | Decrease or increase the simulation timestep. |
+| `T` | Toggle trails on/off. |
+| `Space` | Pause or resume integration. |
+| `C` | Clear all bodies. |
+| `Esc` | Exit the simulator. |
+
+## Running the simulator
+
+```bash
+python "Emulation/NBodySimulator/simulator.py"
+```
+
+The pygame window targets 60 FPS and sub-steps the physics to match the
+requested timestep. Merging behaviour is triggered whenever body centres
+come within the sum of their radii, which are derived from mass assuming
+uniform density.
+
+## Physics notes
+
+- **Gravity**: uses Newton's law with a configurable gravitational
+  constant (`1000` in the GUI) and Plummer softening to avoid singular
+  forces at zero separation.
+- **Integration**: symplectic Euler (semi-implicit) provides better
+  energy stability than naive Euler with minimal overhead.
+- **Collisions**: perfectly inelastic. Masses add together and the new
+  velocity is the momentum-weighted average of the participants.
+- **Radius model**: cube-root scaling maintains constant density and
+  prevents merged bodies from collapsing to a point.
+
+## Dependencies
+
+The simulator relies on `pygame`, which is already part of the repo's
+`visual` extra. Install from the repository root:
+
+```bash
+python -m pip install -e .[visual]
+```
+
+Automated tests cover the gravitational force calculations and verify
+that mass is conserved when bodies merge.

--- a/Emulation/NBodySimulator/simulator.py
+++ b/Emulation/NBodySimulator/simulator.py
@@ -1,0 +1,143 @@
+"""Interactive pygame front-end for the N-body simulator.
+
+Controls
+========
+- **Left click & drag**: place a new body. Drag direction sets initial velocity.
+- **Mouse wheel / +/-**: adjust spawn mass.
+- **[`[`] / [`]`]**: decrease / increase simulation timestep.
+- **T**: toggle particle trails.
+- **Space**: pause / resume integration.
+- **C**: clear all bodies.
+- **Esc / Close button**: exit.
+
+The physics core lives in :mod:`pro_g_rammingchallenges4.nbody` and is
+covered by automated tests.
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Tuple
+
+import pygame
+
+from pro_g_rammingchallenges4.nbody import Body, NBodySimulation
+
+WIDTH, HEIGHT = 1024, 720
+BACKGROUND = (10, 12, 25)
+INFO_COLOR = (200, 200, 210)
+DEFAULT_SPAWN_MASS = 20.0
+MASS_STEP = 1.2
+VELOCITY_SCALE = 0.1
+FONT_PATH = str(Path(pygame.font.get_default_font()))
+
+
+def _draw_body(surface: pygame.Surface, body: Body) -> None:
+    pygame.draw.circle(surface, body.color, (int(body.position[0]), int(body.position[1])), int(body.radius))
+    pygame.draw.circle(surface, (30, 30, 50), (int(body.position[0]), int(body.position[1])), int(body.radius), 1)
+    if body.trail:
+        pygame.draw.lines(surface, body.color, False, [(int(x), int(y)) for x, y in body.trail], 1)
+
+
+def _draw_velocity_vector(surface: pygame.Surface, start: Tuple[int, int], current: Tuple[int, int]) -> None:
+    dx = current[0] - start[0]
+    dy = current[1] - start[1]
+    pygame.draw.line(surface, (120, 180, 255), start, current, 2)
+    length = math.hypot(dx, dy)
+    if length > 0:
+        direction = (dx / length, dy / length)
+        tip = (current[0] + int(direction[0] * 12), current[1] + int(direction[1] * 12))
+        pygame.draw.circle(surface, (120, 180, 255), tip, 3)
+
+
+def _draw_overlay(surface: pygame.Surface, font: pygame.font.Font, sim: NBodySimulation, paused: bool, spawn_mass: float) -> None:
+    lines = [
+        f"Bodies: {len(sim.bodies)} | dt: {sim.timestep:.4f} | Trails: {'on' if sim.trails_enabled else 'off'}",
+        f"Paused: {'yes' if paused else 'no'} | Spawn mass: {spawn_mass:.2f}",
+        "Drag to set velocity. Wheel or +/- to adjust mass. [ and ] tweak dt.",
+    ]
+    y = 12
+    for line in lines:
+        text = font.render(line, True, INFO_COLOR)
+        surface.blit(text, (12, y))
+        y += text.get_height() + 4
+
+
+def main() -> None:
+    pygame.init()
+    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    pygame.display.set_caption("N-Body Simulator")
+    clock = pygame.time.Clock()
+    font = pygame.font.Font(FONT_PATH, 18)
+
+    sim = NBodySimulation(gravitational_constant=1000.0, softening=4.0, max_trail_length=600)
+    sim.timestep = 0.02
+
+    paused = False
+    spawn_mass = DEFAULT_SPAWN_MASS
+    drag_start: Tuple[int, int] | None = None
+
+    running = True
+    while running:
+        real_dt = clock.tick(60) / 1000.0
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_ESCAPE:
+                    running = False
+                elif event.key == pygame.K_SPACE:
+                    paused = not paused
+                elif event.key == pygame.K_LEFTBRACKET:
+                    sim.timestep = max(sim.timestep / 1.3, 1e-4)
+                elif event.key == pygame.K_RIGHTBRACKET:
+                    sim.timestep = min(sim.timestep * 1.3, 1.0)
+                elif event.key in (pygame.K_t,):
+                    sim.toggle_trails()
+                elif event.key in (pygame.K_c,):
+                    sim.reset()
+                elif event.key in (pygame.K_PLUS, pygame.K_EQUALS):
+                    spawn_mass *= MASS_STEP
+                elif event.key == pygame.K_MINUS:
+                    spawn_mass = max(spawn_mass / MASS_STEP, 0.1)
+            elif event.type == pygame.MOUSEBUTTONDOWN:
+                if event.button == 1:
+                    drag_start = event.pos
+                elif event.button == 4:
+                    spawn_mass *= MASS_STEP
+                elif event.button == 5:
+                    spawn_mass = max(spawn_mass / MASS_STEP, 0.1)
+            elif event.type == pygame.MOUSEBUTTONUP:
+                if event.button == 1 and drag_start is not None:
+                    dx = event.pos[0] - drag_start[0]
+                    dy = event.pos[1] - drag_start[1]
+                    sim.add_body(
+                        mass=spawn_mass,
+                        position=drag_start,
+                        velocity=(dx * VELOCITY_SCALE, dy * VELOCITY_SCALE),
+                        color=(255, 210, 140),
+                    )
+                    drag_start = None
+
+        if not paused:
+            # Integrate multiple small steps for stability.
+            accumulate = 0.0
+            while accumulate + sim.timestep <= real_dt:
+                sim.step(sim.timestep)
+                accumulate += sim.timestep
+            if real_dt > accumulate:
+                sim.step(real_dt - accumulate)
+
+        screen.fill(BACKGROUND)
+        for body in sim.bodies:
+            _draw_body(screen, body)
+        if drag_start is not None:
+            _draw_velocity_vector(screen, drag_start, pygame.mouse.get_pos())
+        _draw_overlay(screen, font, sim, paused, spawn_mass)
+        pygame.display.flip()
+
+    pygame.quit()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage only
+    main()

--- a/Emulation/README.md
+++ b/Emulation/README.md
@@ -54,6 +54,7 @@ python -m pip install -e .[ai]            # palette clustering (scikit-learn)
 | CellularTextures | (WIP) Procedural texture generation (C++ prototype). | C++ | — |
 | CompColor | Color space component visualizer & composite manipulator. | numpy, Pillow | — |
 | EulerianPath | Fleury vs Hierholzer algorithm demos (Java/Python/C++). | stdlib (Py) | — |
+| NBodySimulator | 2D gravitational sandbox with merging collisions. | pygame | `visual` extra (pygame) |
 | SpinnyCube | Text-based + optional VPython 3D spinning cube. | stdlib (text mode) | vpython |
 
 > Some folders may contain experimental or WIP code; stable scripts include `5cs.py`, `comp.py`, `hierholzer.py`, `ClockSynced.py`.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ The solutions are organized by category and difficulty, making it easy to naviga
 
 ## Progress
 
-<progress value="99" max="131"></progress>
+<progress value="100" max="131"></progress>
 
-**Overall:** 99 / 131 challenges completed (75.6%).
+**Overall:** 100 / 131 challenges completed (76.3%).
 
 | Category | Completed | Total | Progress |
 | --- | --- | --- | --- |
 | Practical | 53 | 53 | 100% |
 | Algorithmic | 27 | 27 | 100% |
 | Artificial Intelligence | 3 | 8 | 37.5% |
-| Emulation/Modeling | 6 | 14 | 42.9% |
+| Emulation/Modeling | 7 | 14 | 50.0% |
 | Games | 10 | 29 | 34.5% |
 
 _Progress counts are generated from the actual solution folders in the repository (see tables below)._ 
@@ -212,7 +212,7 @@ The repository includes a GitHub Actions workflow at `.github/workflows/keep-str
 | 97 | Generate a 5-Color Scheme from the most dominant tones in any image | [View Solution](./Emulation/5%20color%20scheme/) |
 | 98 | General Lambert's-Problem Solver (At least it's not rocket science... Oh wait it actually is) | Not Yet |
 | 99 | TI-86 Emulator (Bonus: Include the Option to Create Programs) | Not Yet |
-| 100 | N-Body Simulator with particles having a certain mass and radius depending on the mass that merge if they collide (Bonus: Include a GUI where you can place particles) | Not Yet |
+| 100 | N-Body Simulator with particles having a certain mass and radius depending on the mass that merge if they collide (Bonus: Include a GUI where you can place particles) | [View Solution](./Emulation/NBodySimulator/) |
 | 101 | Eulerian Path | [View Solution](./Emulation/EulerianPath/) |
 | 102 | Draw a spinning 3D Cube | [View Solution](./Emulation/SpinnyCube/) |
 | 103 | Cellular Textures | [View Solution](./Emulation/CellularTextures/) |

--- a/src/pro_g_rammingchallenges4/nbody.py
+++ b/src/pro_g_rammingchallenges4/nbody.py
@@ -1,0 +1,191 @@
+"""Core physics model for the N-body simulator challenge.
+
+The module keeps the numerical integration code separate from the
+pygame front-end so unit tests can exercise the physics without a GUI
+context.  Bodies interact gravitationally, merge elastically when they
+collide, and scale their radius with mass assuming constant density.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+from typing import List, Sequence, Tuple
+
+Vector = Tuple[float, float]
+
+
+def radius_from_mass(
+    mass: float,
+    *,
+    reference_mass: float = 1.0,
+    reference_radius: float = 6.0,
+) -> float:
+    """Return a radius that scales with the cube root of the mass.
+
+    The scaling assumes constant density, meaning doubling the mass
+    increases the volume by a factor of two and therefore the radius by
+    :math:`2^{1/3}`.
+    """
+    if mass <= 0:
+        raise ValueError("Bodies must have a positive mass")
+    radius = reference_radius * (mass / reference_mass) ** (1.0 / 3.0)
+    return max(radius, reference_radius * 0.25)
+
+
+@dataclass
+class Body:
+    """A particle in the simulation."""
+
+    mass: float
+    position: List[float]
+    velocity: List[float]
+    color: Tuple[int, int, int] = (255, 200, 120)
+    trail: List[Vector] = field(default_factory=list)
+    radius: float = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.update_radius()
+
+    def update_radius(self) -> None:
+        self.radius = radius_from_mass(self.mass)
+
+    def copy(self) -> "Body":
+        return Body(
+            mass=self.mass,
+            position=list(self.position),
+            velocity=list(self.velocity),
+            color=self.color,
+            trail=list(self.trail),
+        )
+
+
+class NBodySimulation:
+    """Simple 2D gravitational N-body simulation with merging collisions."""
+
+    def __init__(
+        self,
+        *,
+        gravitational_constant: float = 1.0,
+        softening: float = 1e-2,
+        max_trail_length: int = 200,
+    ) -> None:
+        self.gravitational_constant = gravitational_constant
+        self.softening = softening
+        self.max_trail_length = max_trail_length
+        self.bodies: List[Body] = []
+        self.timestep = 0.02
+        self.trails_enabled = True
+
+    def add_body(
+        self,
+        mass: float,
+        position: Sequence[float],
+        velocity: Sequence[float] = (0.0, 0.0),
+        color: Tuple[int, int, int] | None = None,
+    ) -> Body:
+        body = Body(mass=mass, position=list(position), velocity=list(velocity), color=color or (255, 200, 120))
+        self.bodies.append(body)
+        return body
+
+    # Physics helpers -------------------------------------------------
+    def gravitational_force(self, subject: Body, attractor: Body) -> Vector:
+        """Return the gravitational force vector exerted on *subject* by *attractor*."""
+        dx = attractor.position[0] - subject.position[0]
+        dy = attractor.position[1] - subject.position[1]
+        distance_sq = dx * dx + dy * dy + self.softening * self.softening
+        distance = math.sqrt(distance_sq)
+        if distance == 0.0:
+            return (0.0, 0.0)
+        strength = self.gravitational_constant * subject.mass * attractor.mass / (distance_sq * distance)
+        return (strength * dx, strength * dy)
+
+    def _compute_forces(self) -> List[Vector]:
+        forces = [(0.0, 0.0) for _ in self.bodies]
+        for i, body in enumerate(self.bodies):
+            fx = fy = 0.0
+            for j, other in enumerate(self.bodies):
+                if i == j:
+                    continue
+                f = self.gravitational_force(body, other)
+                fx += f[0]
+                fy += f[1]
+            forces[i] = (fx, fy)
+        return forces
+
+    def step(self, dt: float | None = None) -> None:
+        """Advance the simulation by one timestep."""
+        if dt is None:
+            dt = self.timestep
+        if not self.bodies:
+            return
+        forces = self._compute_forces()
+        # Symplectic Euler integration: update velocity then position.
+        for body, (fx, fy) in zip(self.bodies, forces):
+            ax = fx / body.mass
+            ay = fy / body.mass
+            body.velocity[0] += ax * dt
+            body.velocity[1] += ay * dt
+        for body in self.bodies:
+            body.position[0] += body.velocity[0] * dt
+            body.position[1] += body.velocity[1] * dt
+        self._handle_collisions()
+        if self.trails_enabled:
+            for body in self.bodies:
+                body.trail.append((body.position[0], body.position[1]))
+                if len(body.trail) > self.max_trail_length:
+                    del body.trail[0 : len(body.trail) - self.max_trail_length]
+        else:
+            for body in self.bodies:
+                body.trail.clear()
+
+    # Collision handling ---------------------------------------------
+    def _handle_collisions(self) -> None:
+        i = 0
+        while i < len(self.bodies):
+            body = self.bodies[i]
+            j = i + 1
+            while j < len(self.bodies):
+                other = self.bodies[j]
+                dx = other.position[0] - body.position[0]
+                dy = other.position[1] - body.position[1]
+                distance = math.hypot(dx, dy)
+                if distance <= body.radius + other.radius:
+                    body = self._merge_bodies(body, other)
+                    self.bodies[i] = body
+                    self.bodies.pop(j)
+                else:
+                    j += 1
+            i += 1
+
+    def _merge_bodies(self, a: Body, b: Body) -> Body:
+        total_mass = a.mass + b.mass
+        if total_mass <= 0:
+            raise ValueError("Cannot merge bodies with non-positive total mass")
+        position = [
+            (a.position[0] * a.mass + b.position[0] * b.mass) / total_mass,
+            (a.position[1] * a.mass + b.position[1] * b.mass) / total_mass,
+        ]
+        velocity = [
+            (a.velocity[0] * a.mass + b.velocity[0] * b.mass) / total_mass,
+            (a.velocity[1] * a.mass + b.velocity[1] * b.mass) / total_mass,
+        ]
+        color = tuple(
+            int((a.color[idx] * a.mass + b.color[idx] * b.mass) / total_mass)
+            for idx in range(3)
+        )
+        merged = Body(mass=total_mass, position=position, velocity=velocity, color=color)
+        merged.trail = (a.trail + b.trail)[-self.max_trail_length :]
+        return merged
+
+    # Convenience operations -----------------------------------------
+    def reset(self) -> None:
+        self.bodies.clear()
+
+    def toggle_trails(self) -> None:
+        self.trails_enabled = not self.trails_enabled
+        if not self.trails_enabled:
+            for body in self.bodies:
+                body.trail.clear()
+
+
+__all__ = ["Body", "NBodySimulation", "radius_from_mass"]

--- a/tests/test_nbody.py
+++ b/tests/test_nbody.py
@@ -1,0 +1,49 @@
+"""Tests for the N-body simulator physics core."""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from pro_g_rammingchallenges4.nbody import Body, NBodySimulation, radius_from_mass
+
+
+def test_gravitational_force_pair() -> None:
+    sim = NBodySimulation(gravitational_constant=2.0, softening=0.0)
+    body_a = Body(mass=5.0, position=[0.0, 0.0], velocity=[0.0, 0.0])
+    body_b = Body(mass=10.0, position=[3.0, 0.0], velocity=[0.0, 0.0])
+    fx, fy = sim.gravitational_force(body_a, body_b)
+    expected = 2.0 * body_a.mass * body_b.mass / (3.0 ** 2)
+    assert math.isclose(fx, expected, rel_tol=1e-6)
+    assert math.isclose(fy, 0.0, abs_tol=1e-12)
+    fx_b, _ = sim.gravitational_force(body_b, body_a)
+    assert math.isclose(fx_b, -expected, rel_tol=1e-6)
+
+
+def test_collision_merge_conserves_mass_and_momentum() -> None:
+    sim = NBodySimulation(gravitational_constant=0.0, softening=0.0)
+    body_a = Body(mass=4.0, position=[0.0, 0.0], velocity=[1.0, 0.0], color=(255, 0, 0))
+    body_b = Body(mass=6.0, position=[0.0, 0.0], velocity=[-1.0, 0.0], color=(0, 0, 255))
+    sim.bodies.extend([body_a, body_b])
+    sim.step(0.0)
+    assert len(sim.bodies) == 1
+    merged = sim.bodies[0]
+    assert math.isclose(merged.mass, 10.0)
+    expected_velocity = (body_a.velocity[0] * body_a.mass + body_b.velocity[0] * body_b.mass) / 10.0
+    assert math.isclose(merged.velocity[0], expected_velocity)
+    assert math.isclose(merged.velocity[1], 0.0)
+    assert math.isclose(merged.radius, radius_from_mass(merged.mass))
+
+
+def test_radius_from_mass_monotonic() -> None:
+    r1 = radius_from_mass(1.0)
+    r8 = radius_from_mass(8.0)
+    assert r8 == pytest.approx(r1 * 8.0 ** (1 / 3))
+    assert r8 > r1


### PR DESCRIPTION
## Summary
- add a reusable N-body physics core with mass-scaled radii and merging collisions
- provide a pygame UI with placement controls, timestep adjustment, and README documentation
- mark challenge #100 as solved and list the simulator in the Emulation index
- cover gravitational forces and merge behaviour with new pytest tests

## Testing
- pytest tests/test_nbody.py

------
https://chatgpt.com/codex/tasks/task_b_68df52a215788323a54f72df491b7382