### PR TITLE
Add TI-86 emulator core and tests

### DIFF
--- a/Emulation/TI86/DEVELOPMENT.md
+++ b/Emulation/TI86/DEVELOPMENT.md
@@ -1,0 +1,56 @@
+# TI-86 emulator architecture notes
+
+## Overview
+
+The emulator is organised as small, composable modules:
+
+| Module | Responsibility |
+| ------ | -------------- |
+| `memory.py` | 64 KiB Z80 address space backed by a ROM page and a flat 32 KiB RAM window. |
+| `cpu.py` | Z80 execution core with single-step tracing and structured register access. |
+| `lcd.py` | 128×64 monochrome framebuffer stored as a 1-D list for easy inspection. |
+| `keypad.py` | Simple row/column matrix that mimics the TI-86 keypad scanning model. |
+| `emulator.py` | High level façade that bundles the CPU, memory, LCD and keypad. |
+| `debugger.py` | Thin breakpoint manager that raises on breakpoints and emits step traces. |
+| `rom.py` | Utility helpers for loading ROM images from files or streams. |
+
+`TI86.create()` wires the components together.  The CPU exposes `step()`,
+`load_state()` and `export_state()` which the debugger and unit tests use to
+control execution deterministically.
+
+## Opcode coverage
+
+The CPU currently implements the commonly used core of the Z80 instruction set:
+
+* 8-bit loads (`LD r,r`, `LD r,n`, `LD (HL),n`, `LD (rr),A`, `LD A,(rr)`).
+* 16-bit loads and stack ops (`LD rr,nn`, `LD (nn),HL`, `LD HL,(nn)`, `PUSH`, `POP`, `LD SP,HL`).
+* Arithmetic and logical instructions (`ADD/ADC/SUB/SBC/AND/OR/XOR/CP` on registers and immediates, `INC/DEC` on registers and `(HL)`, `DAA`, `CPL`, `SCF`, `CCF`).
+* 16-bit arithmetic (`ADD HL,rr`).
+* Control flow (`JR`, conditional `JR`, `JP`, conditional `JP`, `CALL`, `RET`, conditional `RET`, `HALT`).
+* Bit-test prefix `CB` (`BIT b,r`).
+* Rotation helpers (`RLCA`, `RRCA`, `RLA`, `RRA`).
+* Interrupt toggles (`DI`, `EI`) and a stubbed `OUT` instruction for memory-mapped I/O.
+
+Extending the coverage only requires adding a handler to `_build_decoder()` and
+implementing the opcode as a method. The helpers `_read_reg_by_index`,
+`_write_reg_by_index`, `_set_flags_add`, and `_set_flags_sub` encapsulate the
+trickier flag logic.
+
+## Testing strategy
+
+Unit tests in `tests/emulation/test_ti86_cpu.py` load scenarios from
+`opcode_truth.json`. Each scenario records the initial register file, the program
+bytes to execute, and the expected register/memory state after one or more
+instructions. The values mirror the canonical tables from Sean Young's “The Z80
+Instruction Set” documentation and have been simplified for brevity.
+
+Additional tests validate the memory map (ROM writes are ignored, RAM writes
+persist), the breakpoint behaviour, and the integration of the LCD and keypad
+helpers. Run the full suite with:
+
+```bash
+pytest tests/emulation/test_ti86_cpu.py
+```
+
+To instrument new instructions, add a scenario to the JSON table and write a
+focused unit test if hardware integration is required.

--- a/Emulation/TI86/README.md
+++ b/Emulation/TI86/README.md
@@ -1,0 +1,73 @@
+# TI-86 Emulator Core
+
+This directory houses a clean-room TI-86 emulator skeleton written in Python. The
+focus is on clarity, deterministic behaviour, and unit-test-driven development
+rather than cycle-perfect reproduction of the original hardware. The code ships
+with a Z80 CPU core, a simplified memory map, LCD frame buffer, keypad matrix, a
+ROM loader, and hooks that make single-step debugging straightforward.
+
+## Usage
+
+```python
+from pathlib import Path
+
+from pro_g_rammingchallenges4.emulation.ti86 import TI86, load_rom_image
+
+calc = TI86.create()
+load_rom_image(calc.memory, Path("/path/to/ti86.rom"))
+calc.reset()
+
+# Step through the boot ROM
+for _ in range(10):
+    trace = calc.step()
+    print(trace)
+```
+
+### Debugging helpers
+
+```python
+from pro_g_rammingchallenges4.emulation.ti86 import Debugger
+
+dbg = Debugger(calc.cpu)
+dbg.add_breakpoint(0x0045)
+
+def on_step(trace):
+    print(f"{trace.pc:04X}: {trace.mnemonic} ({trace.cycles} cycles)")
+
+dbg.on_step = on_step
+
+# Run until the breakpoint triggers
+try:
+    while True:
+        dbg.step()
+except RuntimeError:
+    print("Reached breakpoint")
+```
+
+## Dependencies
+
+* Python 3.10+
+* `pytest` (only required for running the regression tests)
+
+No external graphics or audio libraries are required; the LCD panel is stored as
+a plain list of pixels so you can integrate your preferred rendering solution.
+
+## Legal notice
+
+The emulator requires a TI-86 ROM image to boot. Texas Instruments retains the
+copyright for the operating system and firmware. Do **not** distribute ROM dumps
+with this repository. Extract the ROM from hardware you own or follow the
+procedures allowed in your jurisdiction.
+
+## Running the tests
+
+The emulator is covered by regression tests that execute representative opcodes
+against a reference table, validate the memory map, and exercise the debugger,
+LCD, and keypad plumbing.
+
+```bash
+python -m pip install -e .[developer]
+pytest tests/emulation/test_ti86_cpu.py
+```
+
+Refer to `DEVELOPMENT.md` for internals and extension guidelines.

--- a/Emulation/TI86/opcode_truth.json
+++ b/Emulation/TI86/opcode_truth.json
@@ -1,0 +1,64 @@
+[
+  {
+    "name": "LD A,n",
+    "program": [62, 66],
+    "initial": {"pc": 0},
+    "expected": {"a": 66, "pc": 2, "f": 0}
+  },
+  {
+    "name": "ADD A,B",
+    "program": [128],
+    "initial": {"a": 15, "b": 1},
+    "expected": {"a": 16, "f": 16}
+  },
+  {
+    "name": "SUB B",
+    "program": [144],
+    "initial": {"a": 16, "b": 16},
+    "expected": {"a": 0, "f": 66}
+  },
+  {
+    "name": "CP B",
+    "program": [184],
+    "initial": {"a": 32, "b": 16},
+    "expected": {"a": 32, "f": 2}
+  },
+  {
+    "name": "JR loop",
+    "program": [24, 254],
+    "expected": {"pc": 0}
+  },
+  {
+    "name": "JR NZ not taken",
+    "program": [32, 2],
+    "initial": {"f": 64},
+    "expected": {"pc": 2, "f": 64}
+  },
+  {
+    "name": "BIT 7,H",
+    "program": [203, 124],
+    "initial": {"h": 128, "f": 1},
+    "expected": {"f": 145}
+  },
+  {
+    "name": "CALL nn",
+    "program": [205, 52, 18],
+    "initial": {"sp": 65534},
+    "expected": {"pc": 4660, "sp": 65532},
+    "post_memory": {"65532": 3, "65533": 0}
+  },
+  {
+    "name": "RET",
+    "program": [201],
+    "initial": {"sp": 65532},
+    "pre_memory": {"65532": 52, "65533": 18},
+    "expected": {"pc": 4660, "sp": 65534}
+  },
+  {
+    "name": "LD (HL),n",
+    "program": [54, 85],
+    "initial": {"h": 128, "l": 0},
+    "expected": {"pc": 2},
+    "post_memory": {"32768": 85}
+  }
+]

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ The solutions are organized by category and difficulty, making it easy to naviga
 
 ## Progress
 
-<progress value="99" max="131"></progress>
+<progress value="100" max="131"></progress>
 
-**Overall:** 99 / 131 challenges completed (75.6%).
+**Overall:** 100 / 131 challenges completed (76.3%).
 
 | Category | Completed | Total | Progress |
 | --- | --- | --- | --- |
 | Practical | 53 | 53 | 100% |
 | Algorithmic | 27 | 27 | 100% |
 | Artificial Intelligence | 3 | 8 | 37.5% |
-| Emulation/Modeling | 6 | 14 | 42.9% |
+| Emulation/Modeling | 7 | 14 | 50% |
 | Games | 10 | 29 | 34.5% |
 
 _Progress counts are generated from the actual solution folders in the repository (see tables below)._ 
@@ -211,7 +211,7 @@ The repository includes a GitHub Actions workflow at `.github/workflows/keep-str
 | 96 | Generate a Complimentary Color from any input color | [View Solution](./Emulation/CompColor/) |
 | 97 | Generate a 5-Color Scheme from the most dominant tones in any image | [View Solution](./Emulation/5%20color%20scheme/) |
 | 98 | General Lambert's-Problem Solver (At least it's not rocket science... Oh wait it actually is) | Not Yet |
-| 99 | TI-86 Emulator (Bonus: Include the Option to Create Programs) | Not Yet |
+| 99 | TI-86 Emulator (Bonus: Include the Option to Create Programs) | [View Solution](./Emulation/TI86/) |
 | 100 | N-Body Simulator with particles having a certain mass and radius depending on the mass that merge if they collide (Bonus: Include a GUI where you can place particles) | Not Yet |
 | 101 | Eulerian Path | [View Solution](./Emulation/EulerianPath/) |
 | 102 | Draw a spinning 3D Cube | [View Solution](./Emulation/SpinnyCube/) |

--- a/src/pro_g_rammingchallenges4/emulation/ti86/__init__.py
+++ b/src/pro_g_rammingchallenges4/emulation/ti86/__init__.py
@@ -1,0 +1,20 @@
+"""TI-86 emulator components."""
+from .cpu import ExecutionTrace, Z80CPU
+from .debugger import Debugger
+from .emulator import TI86
+from .keypad import Keypad
+from .lcd import LCD
+from .memory import Memory
+from .rom import load_rom_image, load_rom_stream
+
+__all__ = [
+    "ExecutionTrace",
+    "Z80CPU",
+    "Debugger",
+    "TI86",
+    "Keypad",
+    "LCD",
+    "Memory",
+    "load_rom_image",
+    "load_rom_stream",
+]

--- a/src/pro_g_rammingchallenges4/emulation/ti86/cpu.py
+++ b/src/pro_g_rammingchallenges4/emulation/ti86/cpu.py
@@ -1,0 +1,941 @@
+"""Z80 CPU core tailored for the TI-86.
+
+The implementation focuses on clarity and debuggability over raw speed.  It implements
+an extensible subset of the Z80 instruction set that is sufficient for the automated
+unit tests in this repository and provides hooks for adding further opcodes as the
+emulator matures.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+from .memory import Memory
+
+
+FLAG_SIGN = 0x80
+FLAG_ZERO = 0x40
+FLAG_HALF_CARRY = 0x10
+FLAG_PARITY = 0x04
+FLAG_SUBTRACT = 0x02
+FLAG_CARRY = 0x01
+
+
+@dataclass
+class ExecutionTrace:
+    """Single instruction execution trace.
+
+    The trace captures enough information to drive a lightweight debugger or to
+    drive unit tests that assert on internal behaviour.
+    """
+
+    pc: int
+    opcode: int
+    mnemonic: str
+    cycles: int
+
+
+@dataclass
+class Registers:
+    """Z80 register file."""
+
+    a: int = 0
+    f: int = 0
+    b: int = 0
+    c: int = 0
+    d: int = 0
+    e: int = 0
+    h: int = 0
+    l: int = 0
+    sp: int = 0xFFFE
+    pc: int = 0
+    ix: int = 0
+    iy: int = 0
+
+    @property
+    def bc(self) -> int:
+        return (self.b << 8) | self.c
+
+    @bc.setter
+    def bc(self, value: int) -> None:
+        self.b = (value >> 8) & 0xFF
+        self.c = value & 0xFF
+
+    @property
+    def de(self) -> int:
+        return (self.d << 8) | self.e
+
+    @de.setter
+    def de(self, value: int) -> None:
+        self.d = (value >> 8) & 0xFF
+        self.e = value & 0xFF
+
+    @property
+    def hl(self) -> int:
+        return (self.h << 8) | self.l
+
+    @hl.setter
+    def hl(self, value: int) -> None:
+        self.h = (value >> 8) & 0xFF
+        self.l = value & 0xFF
+
+    @property
+    def af(self) -> int:
+        return (self.a << 8) | self.f
+
+    @af.setter
+    def af(self, value: int) -> None:
+        self.a = (value >> 8) & 0xFF
+        self.f = value & 0xFF
+
+    def snapshot(self) -> Dict[str, int]:
+        return {
+            "a": self.a,
+            "f": self.f,
+            "b": self.b,
+            "c": self.c,
+            "d": self.d,
+            "e": self.e,
+            "h": self.h,
+            "l": self.l,
+            "sp": self.sp,
+            "pc": self.pc,
+            "ix": self.ix,
+            "iy": self.iy,
+            "bc": self.bc,
+            "de": self.de,
+            "hl": self.hl,
+            "af": self.af,
+        }
+
+
+class Z80CPU:
+    """A pragmatic Z80 CPU core.
+
+    The class exposes helpers such as :meth:`step` and :meth:`set_breakpoint` so the
+    rest of the emulator can offer stepping and debugging experiences without needing
+    to re-implement CPU internals.
+    """
+
+    def __init__(self, memory: Memory) -> None:
+        self.memory = memory
+        self.reg = Registers()
+        self._halted = False
+        self.breakpoints: set[int] = set()
+        self._decoder: Dict[int, Callable[[int], ExecutionTrace]] = {}
+        self._build_decoder()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def halted(self) -> bool:
+        return self._halted
+
+    def reset(self) -> None:
+        self.reg = Registers()
+        self._halted = False
+
+    def set_breakpoint(self, address: int) -> None:
+        self.breakpoints.add(address & 0xFFFF)
+
+    def clear_breakpoint(self, address: int) -> None:
+        self.breakpoints.discard(address & 0xFFFF)
+
+    def clear_breakpoints(self) -> None:
+        self.breakpoints.clear()
+
+    def step(self) -> ExecutionTrace:
+        """Execute a single instruction and return an :class:`ExecutionTrace`."""
+
+        if self._halted:
+            return ExecutionTrace(self.reg.pc, 0x00, "HALT", cycles=4)
+
+        pc = self.reg.pc
+        if pc in self.breakpoints:
+            raise RuntimeError(f"Execution stopped at breakpoint 0x{pc:04X}")
+
+        opcode = self._fetch_byte()
+        handler = self._decoder.get(opcode)
+        if handler is None:
+            raise NotImplementedError(f"Opcode 0x{opcode:02X} not implemented")
+        trace = handler(opcode)
+        return trace
+
+    # ------------------------------------------------------------------
+    # Decoder construction
+    # ------------------------------------------------------------------
+    def _build_decoder(self) -> None:
+        for opcode in range(0x40, 0x80):
+            self._decoder[opcode] = self._op_ld_r_r
+        for opcode in range(0x80, 0x88):
+            self._decoder[opcode] = self._op_add_a_r
+        for opcode in range(0x88, 0x90):
+            self._decoder[opcode] = self._op_adc_a_r
+        for opcode in range(0x90, 0x98):
+            self._decoder[opcode] = self._op_sub_r
+        for opcode in range(0x98, 0xA0):
+            self._decoder[opcode] = self._op_sbc_a_r
+        for opcode in range(0xA0, 0xA8):
+            self._decoder[opcode] = self._op_and_r
+        for opcode in range(0xA8, 0xB0):
+            self._decoder[opcode] = self._op_xor_r
+        for opcode in range(0xB0, 0xB8):
+            self._decoder[opcode] = self._op_or_r
+        for opcode in range(0xB8, 0xC0):
+            self._decoder[opcode] = self._op_cp_r
+
+        special_handlers: Dict[int, Callable[[int], ExecutionTrace]] = {
+            0x00: self._op_nop,
+            0x01: self._op_ld_rr_nn,
+            0x02: self._op_ld_rr_indirect_a,
+            0x03: self._op_inc_rr,
+            0x04: self._op_inc_r,
+            0x05: self._op_dec_r,
+            0x06: self._op_ld_r_n,
+            0x07: self._op_rlca,
+            0x09: self._op_add_hl_rr,
+            0x0A: self._op_ld_a_rr_indirect,
+            0x0B: self._op_dec_rr,
+            0x0C: self._op_inc_r,
+            0x0D: self._op_dec_r,
+            0x0E: self._op_ld_r_n,
+            0x0F: self._op_rrca,
+            0x11: self._op_ld_rr_nn,
+            0x12: self._op_ld_rr_indirect_a,
+            0x13: self._op_inc_rr,
+            0x14: self._op_inc_r,
+            0x15: self._op_dec_r,
+            0x16: self._op_ld_r_n,
+            0x17: self._op_rla,
+            0x18: self._op_jr,
+            0x19: self._op_add_hl_rr,
+            0x1A: self._op_ld_a_rr_indirect,
+            0x1B: self._op_dec_rr,
+            0x1C: self._op_inc_r,
+            0x1D: self._op_dec_r,
+            0x1E: self._op_ld_r_n,
+            0x1F: self._op_rra,
+            0x20: self._op_jr_cond,
+            0x21: self._op_ld_rr_nn,
+            0x22: self._op_ld_indirect_nn_rr,
+            0x23: self._op_inc_rr,
+            0x24: self._op_inc_r,
+            0x25: self._op_dec_r,
+            0x26: self._op_ld_r_n,
+            0x27: self._op_daa,
+            0x28: self._op_jr_cond,
+            0x29: self._op_add_hl_rr,
+            0x2A: self._op_ld_rr_indirect_nn,
+            0x2B: self._op_dec_rr,
+            0x2C: self._op_inc_r,
+            0x2D: self._op_dec_r,
+            0x2E: self._op_ld_r_n,
+            0x2F: self._op_cpl,
+            0x31: self._op_ld_rr_nn,
+            0x32: self._op_ld_indirect_nn_a,
+            0x33: self._op_inc_rr,
+            0x34: self._op_inc_mem_hl,
+            0x35: self._op_dec_mem_hl,
+            0x36: self._op_ld_mem_hl_n,
+            0x37: self._op_scf,
+            0x38: self._op_jr_cond,
+            0x39: self._op_add_hl_rr,
+            0x3A: self._op_ld_a_indirect_nn,
+            0x3B: self._op_dec_rr,
+            0x3C: self._op_inc_r,
+            0x3D: self._op_dec_r,
+            0x3E: self._op_ld_r_n,
+            0x3F: self._op_ccf,
+            0x76: self._op_halt,
+            0xC1: self._op_pop_rr,
+            0xC3: self._op_jp_nn,
+            0xC5: self._op_push_rr,
+            0xC6: self._op_add_a_n,
+            0xC8: self._op_ret_cond,
+            0xC9: self._op_ret,
+            0xCA: self._op_jp_cond,
+            0xCB: self._op_prefix_cb,
+            0xCD: self._op_call_nn,
+            0xCE: self._op_adc_a_n,
+            0xD1: self._op_pop_rr,
+            0xD3: self._op_out,  # TI-86 uses memory mapped IO; keep placeholder.
+            0xD5: self._op_push_rr,
+            0xD6: self._op_sub_n,
+            0xD8: self._op_ret_cond,
+            0xDA: self._op_jp_cond,
+            0xDE: self._op_sbc_a_n,
+            0xE1: self._op_pop_rr,
+            0xE5: self._op_push_rr,
+            0xE6: self._op_and_n,
+            0xE9: self._op_jp_hl,
+            0xEA: self._op_ld_indirect_nn_a,
+            0xEE: self._op_xor_n,
+            0xF1: self._op_pop_rr,
+            0xF3: self._op_di,
+            0xF5: self._op_push_rr,
+            0xF6: self._op_or_n,
+            0xF9: self._op_ld_sp_hl,
+            0xFA: self._op_ld_a_indirect_nn,
+            0xFB: self._op_ei,
+            0xFE: self._op_cp_n,
+        }
+        self._decoder.update(special_handlers)
+
+    # ------------------------------------------------------------------
+    # Instruction helpers
+    # ------------------------------------------------------------------
+    def _fetch_byte(self) -> int:
+        value = self.memory.read_byte(self.reg.pc)
+        self.reg.pc = (self.reg.pc + 1) & 0xFFFF
+        return value
+
+    def _fetch_word(self) -> int:
+        low = self._fetch_byte()
+        high = self._fetch_byte()
+        return (high << 8) | low
+
+    def _read_reg_by_index(self, index: int) -> int:
+        table = [self.reg.b, self.reg.c, self.reg.d, self.reg.e, self.reg.h, self.reg.l, None, self.reg.a]
+        if index == 6:  # (HL)
+            address = (self.reg.h << 8) | self.reg.l
+            return self.memory.read_byte(address)
+        return table[index]
+
+    def _write_reg_by_index(self, index: int, value: int) -> None:
+        value &= 0xFF
+        if index == 0:
+            self.reg.b = value
+        elif index == 1:
+            self.reg.c = value
+        elif index == 2:
+            self.reg.d = value
+        elif index == 3:
+            self.reg.e = value
+        elif index == 4:
+            self.reg.h = value
+        elif index == 5:
+            self.reg.l = value
+        elif index == 6:
+            address = (self.reg.h << 8) | self.reg.l
+            self.memory.write_byte(address, value)
+        elif index == 7:
+            self.reg.a = value
+        else:
+            raise ValueError(index)
+
+    def _set_reg_pair(self, name: str, value: int) -> None:
+        value &= 0xFFFF
+        if name == "bc":
+            self.reg.bc = value
+        elif name == "de":
+            self.reg.de = value
+        elif name == "hl":
+            self.reg.hl = value
+        elif name == "sp":
+            self.reg.sp = value
+        elif name == "af":
+            self.reg.af = value
+        else:
+            raise ValueError(name)
+
+    def _set_flags_szp(self, value: int) -> None:
+        value &= 0xFF
+        flags = 0
+        if value & 0x80:
+            flags |= FLAG_SIGN
+        if value == 0:
+            flags |= FLAG_ZERO
+        if bin(value).count("1") % 2 == 0:
+            flags |= FLAG_PARITY
+        self.reg.f = (self.reg.f & (FLAG_HALF_CARRY | FLAG_CARRY)) | flags
+
+    def _set_flags_add(self, a: int, b: int, carry: int = 0) -> int:
+        total = a + b + carry
+        result = total & 0xFF
+        flags = 0
+        if result & 0x80:
+            flags |= FLAG_SIGN
+        if result == 0:
+            flags |= FLAG_ZERO
+        if ((a & 0x0F) + (b & 0x0F) + carry) & 0x10:
+            flags |= FLAG_HALF_CARRY
+        if (~(a ^ b) & (a ^ result) & 0x80) != 0:
+            flags |= FLAG_PARITY
+        if total > 0xFF:
+            flags |= FLAG_CARRY
+        self.reg.f = flags
+        return result
+
+    def _set_flags_sub(self, a: int, b: int, carry: int = 0) -> int:
+        diff = a - b - carry
+        result = diff & 0xFF
+        flags = FLAG_SUBTRACT
+        if result & 0x80:
+            flags |= FLAG_SIGN
+        if result == 0:
+            flags |= FLAG_ZERO
+        if ((a & 0x0F) - (b & 0x0F) - carry) & 0x10:
+            flags |= FLAG_HALF_CARRY
+        if ((a ^ b) & (a ^ result) & 0x80) != 0:
+            flags |= FLAG_PARITY
+        if diff < 0:
+            flags |= FLAG_CARRY
+        self.reg.f = flags
+        return result
+
+    def _push(self, value: int) -> None:
+        self.reg.sp = (self.reg.sp - 1) & 0xFFFF
+        self.memory.write_byte(self.reg.sp, (value >> 8) & 0xFF)
+        self.reg.sp = (self.reg.sp - 1) & 0xFFFF
+        self.memory.write_byte(self.reg.sp, value & 0xFF)
+
+    def _pop(self) -> int:
+        low = self.memory.read_byte(self.reg.sp)
+        self.reg.sp = (self.reg.sp + 1) & 0xFFFF
+        high = self.memory.read_byte(self.reg.sp)
+        self.reg.sp = (self.reg.sp + 1) & 0xFFFF
+        return (high << 8) | low
+
+    # ------------------------------------------------------------------
+    # Opcode implementations
+    # ------------------------------------------------------------------
+    def _op_nop(self, opcode: int) -> ExecutionTrace:
+        return ExecutionTrace(self.reg.pc - 1, opcode, "NOP", cycles=4)
+
+    def _op_ld_r_r(self, opcode: int) -> ExecutionTrace:
+        dest = (opcode >> 3) & 0x07
+        src = opcode & 0x07
+        value = self._read_reg_by_index(src)
+        self._write_reg_by_index(dest, value)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "LD", cycles=4)
+
+    def _op_ld_r_n(self, opcode: int) -> ExecutionTrace:
+        dest = (opcode >> 3) & 0x07
+        value = self._fetch_byte()
+        self._write_reg_by_index(dest, value)
+        return ExecutionTrace(self.reg.pc - 2, opcode, "LD", cycles=7)
+
+    def _op_ld_mem_hl_n(self, opcode: int) -> ExecutionTrace:
+        value = self._fetch_byte()
+        address = (self.reg.h << 8) | self.reg.l
+        self.memory.write_byte(address, value)
+        return ExecutionTrace(self.reg.pc - 2, opcode, "LD (HL),n", cycles=10)
+
+    def _op_inc_r(self, opcode: int) -> ExecutionTrace:
+        dest = (opcode >> 3) & 0x07
+        value = self._read_reg_by_index(dest)
+        result = (value + 1) & 0xFF
+        half = ((value & 0x0F) + 1) & 0x10
+        flags = self.reg.f & FLAG_CARRY
+        if result & 0x80:
+            flags |= FLAG_SIGN
+        if result == 0:
+            flags |= FLAG_ZERO
+        if half:
+            flags |= FLAG_HALF_CARRY
+        if result == 0x80:
+            flags |= FLAG_PARITY
+        self.reg.f = flags
+        self._write_reg_by_index(dest, result)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "INC", cycles=4)
+
+    def _op_dec_r(self, opcode: int) -> ExecutionTrace:
+        dest = (opcode >> 3) & 0x07
+        value = self._read_reg_by_index(dest)
+        result = (value - 1) & 0xFF
+        half = ((value & 0x0F) - 1) & 0x10
+        flags = FLAG_SUBTRACT | (self.reg.f & FLAG_CARRY)
+        if result & 0x80:
+            flags |= FLAG_SIGN
+        if result == 0:
+            flags |= FLAG_ZERO
+        if half:
+            flags |= FLAG_HALF_CARRY
+        if result == 0x7F:
+            flags |= FLAG_PARITY
+        self.reg.f = flags
+        self._write_reg_by_index(dest, result)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "DEC", cycles=4)
+
+    def _op_inc_mem_hl(self, opcode: int) -> ExecutionTrace:
+        address = (self.reg.h << 8) | self.reg.l
+        value = self.memory.read_byte(address)
+        result = (value + 1) & 0xFF
+        half = ((value & 0x0F) + 1) & 0x10
+        flags = self.reg.f & FLAG_CARRY
+        if result & 0x80:
+            flags |= FLAG_SIGN
+        if result == 0:
+            flags |= FLAG_ZERO
+        if half:
+            flags |= FLAG_HALF_CARRY
+        if result == 0x80:
+            flags |= FLAG_PARITY
+        self.reg.f = flags
+        self.memory.write_byte(address, result)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "INC (HL)", cycles=11)
+
+    def _op_dec_mem_hl(self, opcode: int) -> ExecutionTrace:
+        address = (self.reg.h << 8) | self.reg.l
+        value = self.memory.read_byte(address)
+        result = (value - 1) & 0xFF
+        half = ((value & 0x0F) - 1) & 0x10
+        flags = FLAG_SUBTRACT | (self.reg.f & FLAG_CARRY)
+        if result & 0x80:
+            flags |= FLAG_SIGN
+        if result == 0:
+            flags |= FLAG_ZERO
+        if half:
+            flags |= FLAG_HALF_CARRY
+        if result == 0x7F:
+            flags |= FLAG_PARITY
+        self.reg.f = flags
+        self.memory.write_byte(address, result)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "DEC (HL)", cycles=11)
+
+    def _op_add_a_r(self, opcode: int) -> ExecutionTrace:
+        index = opcode & 0x07
+        value = self._read_reg_by_index(index)
+        self.reg.a = self._set_flags_add(self.reg.a, value)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "ADD", cycles=4)
+
+    def _op_adc_a_r(self, opcode: int) -> ExecutionTrace:
+        index = opcode & 0x07
+        value = self._read_reg_by_index(index)
+        carry = 1 if (self.reg.f & FLAG_CARRY) else 0
+        self.reg.a = self._set_flags_add(self.reg.a, value, carry)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "ADC", cycles=4)
+
+    def _op_sub_r(self, opcode: int) -> ExecutionTrace:
+        index = opcode & 0x07
+        value = self._read_reg_by_index(index)
+        self.reg.a = self._set_flags_sub(self.reg.a, value)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "SUB", cycles=4)
+
+    def _op_sbc_a_r(self, opcode: int) -> ExecutionTrace:
+        index = opcode & 0x07
+        value = self._read_reg_by_index(index)
+        carry = 1 if (self.reg.f & FLAG_CARRY) else 0
+        self.reg.a = self._set_flags_sub(self.reg.a, value, carry)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "SBC", cycles=4)
+
+    def _op_and_r(self, opcode: int) -> ExecutionTrace:
+        index = opcode & 0x07
+        value = self._read_reg_by_index(index)
+        self.reg.a &= value
+        self.reg.a &= 0xFF
+        self.reg.f = FLAG_HALF_CARRY
+        self._set_flags_szp(self.reg.a)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "AND", cycles=4)
+
+    def _op_or_r(self, opcode: int) -> ExecutionTrace:
+        index = opcode & 0x07
+        value = self._read_reg_by_index(index)
+        self.reg.a |= value
+        self.reg.a &= 0xFF
+        self.reg.f = 0
+        self._set_flags_szp(self.reg.a)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "OR", cycles=4)
+
+    def _op_xor_r(self, opcode: int) -> ExecutionTrace:
+        index = opcode & 0x07
+        value = self._read_reg_by_index(index)
+        self.reg.a ^= value
+        self.reg.a &= 0xFF
+        self.reg.f = 0
+        self._set_flags_szp(self.reg.a)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "XOR", cycles=4)
+
+    def _op_cp_r(self, opcode: int) -> ExecutionTrace:
+        index = opcode & 0x07
+        value = self._read_reg_by_index(index)
+        self._set_flags_sub(self.reg.a, value)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "CP", cycles=4)
+
+    def _op_add_a_n(self, opcode: int) -> ExecutionTrace:
+        value = self._fetch_byte()
+        self.reg.a = self._set_flags_add(self.reg.a, value)
+        return ExecutionTrace(self.reg.pc - 2, opcode, "ADD n", cycles=7)
+
+    def _op_adc_a_n(self, opcode: int) -> ExecutionTrace:
+        value = self._fetch_byte()
+        carry = 1 if (self.reg.f & FLAG_CARRY) else 0
+        self.reg.a = self._set_flags_add(self.reg.a, value, carry)
+        return ExecutionTrace(self.reg.pc - 2, opcode, "ADC n", cycles=7)
+
+    def _op_sub_n(self, opcode: int) -> ExecutionTrace:
+        value = self._fetch_byte()
+        self.reg.a = self._set_flags_sub(self.reg.a, value)
+        return ExecutionTrace(self.reg.pc - 2, opcode, "SUB n", cycles=7)
+
+    def _op_sbc_a_n(self, opcode: int) -> ExecutionTrace:
+        value = self._fetch_byte()
+        carry = 1 if (self.reg.f & FLAG_CARRY) else 0
+        self.reg.a = self._set_flags_sub(self.reg.a, value, carry)
+        return ExecutionTrace(self.reg.pc - 2, opcode, "SBC n", cycles=7)
+
+    def _op_and_n(self, opcode: int) -> ExecutionTrace:
+        value = self._fetch_byte()
+        self.reg.a &= value
+        self.reg.a &= 0xFF
+        self.reg.f = FLAG_HALF_CARRY
+        self._set_flags_szp(self.reg.a)
+        return ExecutionTrace(self.reg.pc - 2, opcode, "AND n", cycles=7)
+
+    def _op_or_n(self, opcode: int) -> ExecutionTrace:
+        value = self._fetch_byte()
+        self.reg.a |= value
+        self.reg.a &= 0xFF
+        self.reg.f = 0
+        self._set_flags_szp(self.reg.a)
+        return ExecutionTrace(self.reg.pc - 2, opcode, "OR n", cycles=7)
+
+    def _op_xor_n(self, opcode: int) -> ExecutionTrace:
+        value = self._fetch_byte()
+        self.reg.a ^= value
+        self.reg.a &= 0xFF
+        self.reg.f = 0
+        self._set_flags_szp(self.reg.a)
+        return ExecutionTrace(self.reg.pc - 2, opcode, "XOR n", cycles=7)
+
+    def _op_cp_n(self, opcode: int) -> ExecutionTrace:
+        value = self._fetch_byte()
+        self._set_flags_sub(self.reg.a, value)
+        return ExecutionTrace(self.reg.pc - 2, opcode, "CP n", cycles=7)
+
+    def _op_ld_rr_nn(self, opcode: int) -> ExecutionTrace:
+        pair_map = {0x01: "bc", 0x11: "de", 0x21: "hl", 0x31: "sp"}
+        pair = pair_map.get(opcode)
+        if pair is None:
+            raise NotImplementedError(f"Opcode 0x{opcode:02X} not implemented")
+        value = self._fetch_word()
+        self._set_reg_pair(pair, value)
+        return ExecutionTrace(self.reg.pc - 3, opcode, f"LD {pair.upper()},nn", cycles=10)
+
+    def _op_ld_rr_indirect_a(self, opcode: int) -> ExecutionTrace:
+        addr = self._get_indirect_address(opcode)
+        self.memory.write_byte(addr, self.reg.a)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "LD (rr),A", cycles=7)
+
+    def _op_ld_a_rr_indirect(self, opcode: int) -> ExecutionTrace:
+        addr = self._get_indirect_address(opcode)
+        self.reg.a = self.memory.read_byte(addr)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "LD A,(rr)", cycles=7)
+
+    def _get_indirect_address(self, opcode: int) -> int:
+        if opcode in (0x02, 0x0A):
+            return (self.reg.b << 8) | self.reg.c
+        if opcode in (0x12, 0x1A):
+            return (self.reg.d << 8) | self.reg.e
+        if opcode in (0x22, 0x2A, 0x32, 0x3A):
+            return self._fetch_word()
+        raise NotImplementedError(f"Indirect addressing for opcode 0x{opcode:02X}")
+
+    def _op_inc_rr(self, opcode: int) -> ExecutionTrace:
+        pair_map = {0x03: "bc", 0x13: "de", 0x23: "hl", 0x33: "sp"}
+        pair = pair_map.get(opcode)
+        if pair is None:
+            raise NotImplementedError(f"Opcode 0x{opcode:02X} not implemented")
+        value = (self._get_reg_pair_value(pair) + 1) & 0xFFFF
+        self._set_reg_pair(pair, value)
+        return ExecutionTrace(self.reg.pc - 1, opcode, f"INC {pair.upper()}", cycles=6)
+
+    def _op_dec_rr(self, opcode: int) -> ExecutionTrace:
+        pair_map = {0x0B: "bc", 0x1B: "de", 0x2B: "hl", 0x3B: "sp"}
+        pair = pair_map.get(opcode)
+        if pair is None:
+            raise NotImplementedError(f"Opcode 0x{opcode:02X} not implemented")
+        value = (self._get_reg_pair_value(pair) - 1) & 0xFFFF
+        self._set_reg_pair(pair, value)
+        return ExecutionTrace(self.reg.pc - 1, opcode, f"DEC {pair.upper()}", cycles=6)
+
+    def _get_reg_pair_value(self, name: str) -> int:
+        if name == "bc":
+            return self.reg.bc
+        if name == "de":
+            return self.reg.de
+        if name == "hl":
+            return self.reg.hl
+        if name == "sp":
+            return self.reg.sp
+        raise ValueError(name)
+
+    def _op_add_hl_rr(self, opcode: int) -> ExecutionTrace:
+        pair_map = {0x09: "bc", 0x19: "de", 0x29: "hl", 0x39: "sp"}
+        src = pair_map.get(opcode)
+        if src is None:
+            raise NotImplementedError(f"Opcode 0x{opcode:02X} not implemented")
+        hl = self._get_reg_pair_value("hl")
+        value = self._get_reg_pair_value(src)
+        total = hl + value
+        result = total & 0xFFFF
+        new_flags = self.reg.f & ~(FLAG_SUBTRACT | FLAG_HALF_CARRY | FLAG_CARRY)
+        if ((hl & 0x0FFF) + (value & 0x0FFF)) > 0x0FFF:
+            new_flags |= FLAG_HALF_CARRY
+        if total > 0xFFFF:
+            new_flags |= FLAG_CARRY
+        self.reg.f = new_flags
+        self._set_reg_pair("hl", result)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "ADD HL,rr", cycles=11)
+
+    def _op_ld_indirect_nn_rr(self, opcode: int) -> ExecutionTrace:
+        address = self._fetch_word()
+        value = self._get_reg_pair_value("hl")
+        self.memory.write_byte(address, value & 0xFF)
+        self.memory.write_byte((address + 1) & 0xFFFF, (value >> 8) & 0xFF)
+        return ExecutionTrace(self.reg.pc - 3, opcode, "LD (nn),HL", cycles=16)
+
+    def _op_ld_rr_indirect_nn(self, opcode: int) -> ExecutionTrace:
+        address = self._fetch_word()
+        low = self.memory.read_byte(address)
+        high = self.memory.read_byte((address + 1) & 0xFFFF)
+        self._set_reg_pair("hl", (high << 8) | low)
+        return ExecutionTrace(self.reg.pc - 3, opcode, "LD HL,(nn)", cycles=16)
+
+    def _op_ld_indirect_nn_a(self, opcode: int) -> ExecutionTrace:
+        address = self._fetch_word()
+        self.memory.write_byte(address, self.reg.a)
+        return ExecutionTrace(self.reg.pc - 3, opcode, "LD (nn),A", cycles=13)
+
+    def _op_ld_a_indirect_nn(self, opcode: int) -> ExecutionTrace:
+        address = self._fetch_word()
+        self.reg.a = self.memory.read_byte(address)
+        return ExecutionTrace(self.reg.pc - 3, opcode, "LD A,(nn)", cycles=13)
+
+    def _op_add_hl_rr_placeholder(self, opcode: int) -> ExecutionTrace:
+        raise NotImplementedError("Deprecated placeholder")
+
+    def _op_rlca(self, opcode: int) -> ExecutionTrace:
+        carry = (self.reg.a >> 7) & 0x01
+        self.reg.a = ((self.reg.a << 1) | carry) & 0xFF
+        self.reg.f = carry
+        self._set_flags_szp(self.reg.a)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "RLCA", cycles=4)
+
+    def _op_rrca(self, opcode: int) -> ExecutionTrace:
+        carry = self.reg.a & 0x01
+        self.reg.a = ((carry << 7) | (self.reg.a >> 1)) & 0xFF
+        self.reg.f = carry
+        self._set_flags_szp(self.reg.a)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "RRCA", cycles=4)
+
+    def _op_rla(self, opcode: int) -> ExecutionTrace:
+        carry = 1 if (self.reg.f & FLAG_CARRY) else 0
+        new_carry = (self.reg.a >> 7) & 0x01
+        self.reg.a = ((self.reg.a << 1) | carry) & 0xFF
+        self.reg.f = new_carry
+        self._set_flags_szp(self.reg.a)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "RLA", cycles=4)
+
+    def _op_rra(self, opcode: int) -> ExecutionTrace:
+        carry = 1 if (self.reg.f & FLAG_CARRY) else 0
+        new_carry = self.reg.a & 0x01
+        self.reg.a = ((carry << 7) | (self.reg.a >> 1)) & 0xFF
+        self.reg.f = new_carry
+        self._set_flags_szp(self.reg.a)
+        return ExecutionTrace(self.reg.pc - 1, opcode, "RRA", cycles=4)
+
+    def _op_daa(self, opcode: int) -> ExecutionTrace:
+        a = self.reg.a
+        adjust = 0
+        carry = False
+        if (self.reg.f & FLAG_HALF_CARRY) or ((a & 0x0F) > 9):
+            adjust |= 0x06
+        if (self.reg.f & FLAG_CARRY) or (a > 0x99):
+            adjust |= 0x60
+            carry = True
+        if self.reg.f & FLAG_SUBTRACT:
+            a = (a - adjust) & 0xFF
+        else:
+            a = (a + adjust) & 0xFF
+        self.reg.a = a
+        self.reg.f &= ~(FLAG_HALF_CARRY | FLAG_ZERO | FLAG_SIGN | FLAG_PARITY | FLAG_CARRY)
+        if a == 0:
+            self.reg.f |= FLAG_ZERO
+        if a & 0x80:
+            self.reg.f |= FLAG_SIGN
+        if bin(a).count("1") % 2 == 0:
+            self.reg.f |= FLAG_PARITY
+        if carry:
+            self.reg.f |= FLAG_CARRY
+        return ExecutionTrace(self.reg.pc - 1, opcode, "DAA", cycles=4)
+
+    def _op_cpl(self, opcode: int) -> ExecutionTrace:
+        self.reg.a ^= 0xFF
+        self.reg.f |= FLAG_HALF_CARRY | FLAG_SUBTRACT
+        return ExecutionTrace(self.reg.pc - 1, opcode, "CPL", cycles=4)
+
+    def _op_scf(self, opcode: int) -> ExecutionTrace:
+        self.reg.f = (self.reg.f & ~(FLAG_SUBTRACT | FLAG_HALF_CARRY)) | FLAG_CARRY
+        return ExecutionTrace(self.reg.pc - 1, opcode, "SCF", cycles=4)
+
+    def _op_ccf(self, opcode: int) -> ExecutionTrace:
+        carry = 1 if (self.reg.f & FLAG_CARRY) else 0
+        new_flags = self.reg.f & ~(FLAG_SUBTRACT | FLAG_HALF_CARRY | FLAG_CARRY)
+        if carry:
+            new_flags |= FLAG_HALF_CARRY
+        else:
+            new_flags |= FLAG_CARRY
+        self.reg.f = new_flags
+        return ExecutionTrace(self.reg.pc - 1, opcode, "CCF", cycles=4)
+
+    def _op_jr(self, opcode: int) -> ExecutionTrace:
+        offset = self._fetch_byte()
+        if offset & 0x80:
+            offset -= 0x100
+        old_pc = self.reg.pc
+        self.reg.pc = (self.reg.pc + offset) & 0xFFFF
+        return ExecutionTrace(old_pc - 2, opcode, "JR", cycles=12)
+
+    def _op_jr_cond(self, opcode: int) -> ExecutionTrace:
+        conditions = {
+            0x20: lambda: not (self.reg.f & FLAG_ZERO),
+            0x28: lambda: bool(self.reg.f & FLAG_ZERO),
+            0x30: lambda: not (self.reg.f & FLAG_CARRY),
+            0x38: lambda: bool(self.reg.f & FLAG_CARRY),
+        }
+        condition = conditions.get(opcode)
+        if condition is None:
+            raise NotImplementedError(f"JR condition for opcode 0x{opcode:02X}")
+        offset = self._fetch_byte()
+        if offset & 0x80:
+            offset -= 0x100
+        origin = self.reg.pc
+        taken = condition()
+        if taken:
+            self.reg.pc = (self.reg.pc + offset) & 0xFFFF
+            mnemonic = "JR taken"
+        else:
+            mnemonic = "JR not taken"
+        return ExecutionTrace(origin - 2, opcode, mnemonic, cycles=12 if taken else 7)
+
+    def _op_jp_nn(self, opcode: int) -> ExecutionTrace:
+        address = self._fetch_word()
+        self.reg.pc = address
+        return ExecutionTrace(self.reg.pc, opcode, "JP", cycles=10)
+
+    def _op_jp_hl(self, opcode: int) -> ExecutionTrace:
+        self.reg.pc = (self.reg.h << 8) | self.reg.l
+        return ExecutionTrace(self.reg.pc, opcode, "JP (HL)", cycles=4)
+
+    def _op_jp_cond(self, opcode: int) -> ExecutionTrace:
+        conditions = {
+            0xCA: lambda: bool(self.reg.f & FLAG_ZERO),
+            0xDA: lambda: bool(self.reg.f & FLAG_CARRY),
+        }
+        address = self._fetch_word()
+        condition = conditions.get(opcode)
+        if condition is None:
+            raise NotImplementedError(f"JP condition for opcode 0x{opcode:02X}")
+        if condition():
+            self.reg.pc = address
+            mnemonic = "JP taken"
+        else:
+            mnemonic = "JP not taken"
+        return ExecutionTrace(self.reg.pc, opcode, mnemonic, cycles=10)
+
+    def _op_call_nn(self, opcode: int) -> ExecutionTrace:
+        address = self._fetch_word()
+        self._push(self.reg.pc)
+        self.reg.pc = address
+        return ExecutionTrace(self.reg.pc, opcode, "CALL", cycles=17)
+
+    def _op_ret(self, opcode: int) -> ExecutionTrace:
+        self.reg.pc = self._pop()
+        return ExecutionTrace(self.reg.pc, opcode, "RET", cycles=10)
+
+    def _op_ret_cond(self, opcode: int) -> ExecutionTrace:
+        conditions = {
+            0xC8: lambda: bool(self.reg.f & FLAG_ZERO),
+            0xD8: lambda: bool(self.reg.f & FLAG_CARRY),
+        }
+        condition = conditions.get(opcode)
+        if condition is None:
+            raise NotImplementedError(f"RET condition for opcode 0x{opcode:02X}")
+        origin = self.reg.pc
+        taken = condition()
+        if taken:
+            self.reg.pc = self._pop()
+            mnemonic = "RET taken"
+        else:
+            mnemonic = "RET not taken"
+        return ExecutionTrace(origin - 1, opcode, mnemonic, cycles=11 if taken else 5)
+
+    def _op_push_rr(self, opcode: int) -> ExecutionTrace:
+        pair_map = {0xC5: "bc", 0xD5: "de", 0xE5: "hl", 0xF5: "af"}
+        pair = pair_map.get(opcode)
+        if pair is None:
+            raise NotImplementedError(f"PUSH pair for opcode 0x{opcode:02X}")
+        if pair == "af":
+            value = (self.reg.a << 8) | self.reg.f
+        else:
+            value = self._get_reg_pair_value(pair)
+        self._push(value)
+        return ExecutionTrace(self.reg.pc - 1, opcode, f"PUSH {pair.upper()}", cycles=11)
+
+    def _op_pop_rr(self, opcode: int) -> ExecutionTrace:
+        pair_map = {0xC1: "bc", 0xD1: "de", 0xE1: "hl", 0xF1: "af"}
+        pair = pair_map.get(opcode)
+        if pair is None:
+            raise NotImplementedError(f"POP pair for opcode 0x{opcode:02X}")
+        value = self._pop()
+        if pair == "af":
+            self.reg.a = (value >> 8) & 0xFF
+            self.reg.f = value & 0xFF
+        else:
+            self._set_reg_pair(pair, value)
+        return ExecutionTrace(self.reg.pc - 1, opcode, f"POP {pair.upper()}", cycles=10)
+
+    def _op_halt(self, opcode: int) -> ExecutionTrace:
+        self._halted = True
+        self.reg.pc = (self.reg.pc - 1) & 0xFFFF
+        return ExecutionTrace(self.reg.pc, opcode, "HALT", cycles=4)
+
+    def _op_out(self, opcode: int) -> ExecutionTrace:
+        # TI-86 hardware maps peripherals into memory.  We treat OUT as a NOP so
+        # the CPU core remains usable for diagnostics without a peripheral bus.
+        port = self._fetch_byte()
+        value = self.reg.a
+        _ = port, value
+        return ExecutionTrace(self.reg.pc - 2, opcode, "OUT (stub)", cycles=11)
+
+    def _op_di(self, opcode: int) -> ExecutionTrace:
+        return ExecutionTrace(self.reg.pc - 1, opcode, "DI", cycles=4)
+
+    def _op_ei(self, opcode: int) -> ExecutionTrace:
+        return ExecutionTrace(self.reg.pc - 1, opcode, "EI", cycles=4)
+
+    def _op_ld_sp_hl(self, opcode: int) -> ExecutionTrace:
+        self.reg.sp = (self.reg.h << 8) | self.reg.l
+        return ExecutionTrace(self.reg.pc - 1, opcode, "LD SP,HL", cycles=6)
+
+    def _op_prefix_cb(self, opcode: int) -> ExecutionTrace:
+        cb_opcode = self._fetch_byte()
+        bit = (cb_opcode >> 3) & 0x07
+        target_index = cb_opcode & 0x07
+        if cb_opcode >= 0x40 and cb_opcode < 0x80:
+            value = self._read_reg_by_index(target_index)
+            mask = 1 << bit
+            flags = (self.reg.f & FLAG_CARRY) | FLAG_HALF_CARRY
+            if (value & mask) == 0:
+                flags |= FLAG_ZERO
+                flags |= FLAG_PARITY
+            if mask & 0x80 and (value & mask):
+                flags |= FLAG_SIGN
+            self.reg.f = flags
+            return ExecutionTrace(self.reg.pc - 2, 0xCB00 | cb_opcode, "BIT", cycles=8)
+        raise NotImplementedError(f"CB-prefixed opcode 0x{cb_opcode:02X} not implemented")
+
+    # Utility wrappers -------------------------------------------------
+    def load_state(self, snapshot: Dict[str, int]) -> None:
+        for key, value in snapshot.items():
+            if key in {"pc", "sp", "ix", "iy"}:
+                setattr(self.reg, key, value & 0xFFFF)
+            elif key in {"a", "b", "c", "d", "e", "h", "l", "f"}:
+                setattr(self.reg, key, value & 0xFF)
+            elif key in {"bc", "de", "hl", "af"}:
+                setattr(self.reg, key, value & 0xFFFF)
+
+    def export_state(self) -> Dict[str, int]:
+        return self.reg.snapshot()

--- a/src/pro_g_rammingchallenges4/emulation/ti86/debugger.py
+++ b/src/pro_g_rammingchallenges4/emulation/ti86/debugger.py
@@ -1,0 +1,42 @@
+"""Minimalist single-step debugger helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+from .cpu import ExecutionTrace, Z80CPU
+
+
+@dataclass
+class Breakpoint:
+    address: int
+    enabled: bool = True
+
+
+class Debugger:
+    """Convenience wrapper used in tests and documentation examples."""
+
+    def __init__(self, cpu: Z80CPU) -> None:
+        self.cpu = cpu
+        self.breakpoints: List[Breakpoint] = []
+        self.on_step: Optional[Callable[[ExecutionTrace], None]] = None
+
+    def add_breakpoint(self, address: int) -> None:
+        bp = Breakpoint(address & 0xFFFF)
+        self.breakpoints.append(bp)
+        self.cpu.set_breakpoint(bp.address)
+
+    def remove_breakpoint(self, address: int) -> None:
+        address &= 0xFFFF
+        self.breakpoints = [bp for bp in self.breakpoints if bp.address != address]
+        self.cpu.clear_breakpoint(address)
+
+    def clear(self) -> None:
+        self.breakpoints.clear()
+        self.cpu.clear_breakpoints()
+
+    def step(self) -> ExecutionTrace:
+        trace = self.cpu.step()
+        if self.on_step is not None:
+            self.on_step(trace)
+        return trace

--- a/src/pro_g_rammingchallenges4/emulation/ti86/emulator.py
+++ b/src/pro_g_rammingchallenges4/emulation/ti86/emulator.py
@@ -1,0 +1,50 @@
+"""High level TI-86 emulator façade."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .cpu import ExecutionTrace, Z80CPU
+from .keypad import Keypad
+from .lcd import LCD
+from .memory import Memory
+
+
+@dataclass
+class TI86:
+    """Bundles CPU, memory, LCD and keypad."""
+
+    memory: Memory
+    cpu: Z80CPU
+    lcd: LCD
+    keypad: Keypad
+
+    @classmethod
+    def create(cls) -> "TI86":
+        memory = Memory()
+        lcd = LCD()
+        keypad = Keypad()
+        cpu = Z80CPU(memory)
+        return cls(memory=memory, cpu=cpu, lcd=lcd, keypad=keypad)
+
+    def reset(self) -> None:
+        self.cpu.reset()
+        self.memory.ram[:] = b"\x00" * len(self.memory.ram)
+        self.lcd.clear()
+        self.keypad.reset()
+
+    def step(self) -> ExecutionTrace:
+        return self.cpu.step()
+
+    def run_until_break(self, max_instructions: Optional[int] = None) -> None:
+        executed = 0
+        while True:
+            self.step()
+            executed += 1
+            if self.cpu.halted:
+                break
+            if max_instructions is not None and executed >= max_instructions:
+                break
+
+    def load_rom(self, data: bytes) -> None:
+        self.memory.load_rom(data)

--- a/src/pro_g_rammingchallenges4/emulation/ti86/keypad.py
+++ b/src/pro_g_rammingchallenges4/emulation/ti86/keypad.py
@@ -1,0 +1,31 @@
+"""Keypad matrix abstraction."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Tuple
+
+
+@dataclass
+class Keypad:
+    """Tracks key states for the TI-86 keypad matrix."""
+
+    matrix: Dict[Tuple[int, int], bool] = field(default_factory=dict)
+
+    def press(self, row: int, column: int) -> None:
+        self.matrix[(row & 0x07, column & 0x07)] = True
+
+    def release(self, row: int, column: int) -> None:
+        self.matrix[(row & 0x07, column & 0x07)] = False
+
+    def is_pressed(self, row: int, column: int) -> bool:
+        return self.matrix.get((row & 0x07, column & 0x07), False)
+
+    def active_columns(self, row_mask: int) -> int:
+        value = 0xFF
+        for (row, column), pressed in self.matrix.items():
+            if pressed and (row_mask & (1 << row)):
+                value &= ~(1 << column)
+        return value & 0xFF
+
+    def reset(self) -> None:
+        self.matrix.clear()

--- a/src/pro_g_rammingchallenges4/emulation/ti86/lcd.py
+++ b/src/pro_g_rammingchallenges4/emulation/ti86/lcd.py
@@ -1,0 +1,40 @@
+"""Simplified LCD panel for the TI-86."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+LCD_WIDTH = 128
+LCD_HEIGHT = 64
+
+
+@dataclass
+class LCD:
+    """Monochrome LCD buffer.
+
+    The physical device organises pixels as 8 vertical banks.  For the emulator we
+    expose a linear frame buffer and convenience helpers for unit testing and
+    future visualisation back-ends.
+    """
+
+    width: int = LCD_WIDTH
+    height: int = LCD_HEIGHT
+    buffer: List[int] = field(default_factory=lambda: [0] * (LCD_WIDTH * LCD_HEIGHT))
+
+    def clear(self, value: int = 0) -> None:
+        value = 1 if value else 0
+        for idx in range(len(self.buffer)):
+            self.buffer[idx] = value
+
+    def write_pixel(self, x: int, y: int, value: int) -> None:
+        if 0 <= x < self.width and 0 <= y < self.height:
+            self.buffer[y * self.width + x] = 1 if value else 0
+
+    def blit_bitmap(self, x: int, y: int, bitmap: Iterable[int], stride: int) -> None:
+        for row, row_data in enumerate(bitmap):
+            for col in range(stride):
+                pixel = (row_data >> col) & 0x01
+                self.write_pixel(x + col, y + row, pixel)
+
+    def get_pixels(self) -> List[int]:
+        return list(self.buffer)

--- a/src/pro_g_rammingchallenges4/emulation/ti86/memory.py
+++ b/src/pro_g_rammingchallenges4/emulation/ti86/memory.py
@@ -1,0 +1,59 @@
+"""Memory map for the TI-86 emulator."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+ROM_SIZE = 128 * 1024
+RAM_SIZE = 32 * 1024
+ADDRESS_SPACE = 0x10000
+
+
+@dataclass
+class Memory:
+    """Represents the 64KiB Z80 address space.
+
+    The TI-86 uses banked ROM/RAM in hardware.  The emulator implements a
+    simplified model that maps the first 32KiB of RAM to 0x8000-0xFFFF and a
+    single 128KiB ROM image to 0x0000-0x7FFF.  This is sufficient for unit tests
+    and interactive experimentation.  The layout is intentionally isolated from
+    the CPU so a more faithful implementation can be swapped in later.
+    """
+
+    rom: bytearray = field(default_factory=lambda: bytearray(0x8000))
+    ram: bytearray = field(default_factory=lambda: bytearray(RAM_SIZE))
+
+    def load_rom(self, data: bytes) -> None:
+        if len(data) not in {0x20000, 0x40000, 0x80000} and len(data) != 0x8000:
+            raise ValueError("Unsupported ROM size for TI-86 image")
+        if len(data) < len(self.rom):
+            self.rom[: len(data)] = data
+        else:
+            self.rom = bytearray(data[: len(self.rom)])
+
+    def read_byte(self, address: int) -> int:
+        address &= 0xFFFF
+        if address < len(self.rom):
+            return self.rom[address]
+        ram_addr = address - 0x8000
+        return self.ram[ram_addr % len(self.ram)]
+
+    def write_byte(self, address: int, value: int) -> None:
+        address &= 0xFFFF
+        if address < 0x8000:
+            return
+        ram_addr = address - 0x8000
+        self.ram[ram_addr % len(self.ram)] = value & 0xFF
+
+    def read_word(self, address: int) -> int:
+        low = self.read_byte(address)
+        high = self.read_byte(address + 1)
+        return (high << 8) | low
+
+    def write_word(self, address: int, value: int) -> None:
+        self.write_byte(address, value & 0xFF)
+        self.write_byte(address + 1, (value >> 8) & 0xFF)
+
+    def load_ram(self, start: int, data: Iterable[int]) -> None:
+        for offset, value in enumerate(data):
+            self.write_byte(start + offset, value)

--- a/src/pro_g_rammingchallenges4/emulation/ti86/rom.py
+++ b/src/pro_g_rammingchallenges4/emulation/ti86/rom.py
@@ -1,0 +1,21 @@
+"""ROM loading helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import BinaryIO
+
+from .memory import Memory
+
+
+def load_rom_image(memory: Memory, path: str | Path) -> None:
+    """Load a TI-86 ROM dump from *path* into *memory*."""
+
+    rom_path = Path(path)
+    with rom_path.open("rb") as handle:
+        data = handle.read()
+    memory.load_rom(data)
+
+
+def load_rom_stream(memory: Memory, stream: BinaryIO) -> None:
+    data = stream.read()
+    memory.load_rom(data)

--- a/tests/emulation/test_ti86_cpu.py
+++ b/tests/emulation/test_ti86_cpu.py
@@ -1,0 +1,79 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+from pro_g_rammingchallenges4.emulation.ti86 import Debugger, Memory, TI86, Z80CPU
+
+DATA_PATH = ROOT / "Emulation" / "TI86" / "opcode_truth.json"
+
+
+def load_opcode_cases():
+    with DATA_PATH.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.mark.parametrize("case", load_opcode_cases(), ids=lambda c: c["name"])
+def test_cpu_against_known_good_cases(case):
+    memory = Memory()
+    program = bytes(case["program"])
+    memory.rom[: len(program)] = program
+
+    if "pre_memory" in case:
+        for addr_str, value in case["pre_memory"].items():
+            memory.write_byte(int(addr_str), value)
+
+    cpu = Z80CPU(memory)
+    cpu.reset()
+    cpu.load_state(case.get("initial", {}))
+
+    steps = case.get("steps", 1)
+    for _ in range(steps):
+        cpu.step()
+
+    state = cpu.export_state()
+    for key, value in case["expected"].items():
+        assert state[key] == value, f"{case['name']} -> {key}"
+
+    if "post_memory" in case:
+        for addr_str, value in case["post_memory"].items():
+            addr = int(addr_str)
+            assert memory.read_byte(addr) == value, f"{case['name']} memory[{addr:#04x}]"
+
+
+def test_memory_map_distinguishes_rom_and_ram():
+    memory = Memory()
+    memory.rom[0] = 0xAA
+    memory.write_byte(0x0000, 0x55)
+    assert memory.read_byte(0x0000) == 0xAA
+
+    memory.write_byte(0x8000, 0x12)
+    assert memory.read_byte(0x8000) == 0x12
+
+
+def test_debugger_breakpoint_triggers_runtime_error():
+    memory = Memory()
+    memory.rom[0] = 0x00
+    cpu = Z80CPU(memory)
+    dbg = Debugger(cpu)
+    dbg.add_breakpoint(0x0000)
+
+    with pytest.raises(RuntimeError):
+        dbg.step()
+
+
+def test_lcd_and_keypad_integration():
+    calc = TI86.create()
+    calc.lcd.write_pixel(10, 10, 1)
+    assert calc.lcd.get_pixels()[10 * calc.lcd.width + 10] == 1
+
+    calc.keypad.press(1, 2)
+    assert calc.keypad.is_pressed(1, 2)
+    assert calc.keypad.active_columns(0b00000010) == 0xFB
+
+    calc.keypad.release(1, 2)
+    assert not calc.keypad.is_pressed(1, 2)


### PR DESCRIPTION
## Summary
- implement a modular TI-86 emulator core with CPU, memory, LCD, keypad and ROM loader components
- document the architecture, usage and legal considerations for the new emulator
- add opcode regression data and pytest coverage for instruction execution, memory mapping and debugger helpers

## Testing
- pytest tests/emulation/test_ti86_cpu.py

------
https://chatgpt.com/codex/tasks/task_b_68df52a114b08323bc320acfb7d98978