### PR TITLE
Add FFT spectrum visualizer challenge solution

### DIFF
--- a/Emulation/FFTSpectrum/README.md
+++ b/Emulation/FFTSpectrum/README.md
@@ -1,0 +1,67 @@
+# Real-Time FFT Spectrum Visualizer
+
+A lightweight spectrum analyzer that listens to a microphone (via [sounddevice](https://python-sounddevice.readthedocs.io/en/latest/)) or streams audio blocks from a WAV file and renders a real-time FFT plot in matplotlib. Window size, sample rate, refresh cadence, and scaling are configurable at runtime so you can tune fidelity vs latency.
+
+## Hardware Requirements
+
+- **Microphone input**: Any ALSA/CoreAudio/WASAPI-compatible device. USB condensers and laptop microphones work out of the box; multi-channel interfaces are mixed down to mono.
+- **CPU**: Modern dual-core processor recommended. FFTs on 2048-sample windows execute comfortably on low-voltage CPUs, but extremely small windows at high refresh rates increase CPU load.
+- **GPU/Display**: Matplotlib updates run on the CPU but require an active display server (X11/Wayland/macOS/Windows). Headless servers should use the WAV replay mode or set a non-interactive backend.
+
+## Latency Considerations
+
+- **Window size** controls temporal resolution. Smaller windows (~512 samples) lower latency but smear frequency resolution. Larger windows (>4096) stabilize the spectrum but add up to ~100 ms delay at 44.1 kHz.
+- **Refresh rate** dictates how often the plot redraws. High FPS (>60) increases CPU/GPU usage; 20–30 FPS provides smooth motion without spikes.
+- **Audio backend buffers** (sounddevice/PortAudio) add their own latency. Use the `--device` flag to select low-latency hardware and experiment with `--window-size` to balance responsiveness.
+
+## Installation
+
+Install from the repository root using the optional extras that bundle visualization and audio tooling:
+
+```bash
+python -m pip install -e .[visual]
+```
+
+The `visual` extra now pulls in `numpy`, `matplotlib`, `imageio`, `colour-science`, `opencv-python`, and `sounddevice`, covering this demo. If you prefer a lean install for CLI testing only, `numpy` and `matplotlib` are the hard requirements.
+
+## Usage
+
+```bash
+python Emulation/FFTSpectrum/fft_spectrum.py \
+    --source mic \
+    --samplerate 48000 \
+    --window-size 2048 \
+    --scale log
+```
+
+Switch to a WAV file input:
+
+```bash
+python Emulation/FFTSpectrum/fft_spectrum.py \
+    --source wav \
+    --wav-path Emulation/FFTSpectrum/test_tone.wav \
+    --window-size 4096 \
+    --scale linear \
+    --loop
+```
+
+### Useful Flags
+
+- `--window` selects Hann (default), Hamming, or rectangular windows.
+- `--refresh` adjusts redraw rate (frames per second).
+- `--device` passes an explicit PortAudio device string/index when multiple microphones are connected.
+- `--loop` replays a WAV file continuously; omit to stop at EOF.
+
+## Testing Without a Microphone
+
+The repository ships a `test_tone.wav` sine wave sample. Automated tests consume this file to verify FFT shape and magnitude, ensuring the analyzer works even in headless CI environments.
+
+## Known Limitations
+
+- 24-bit WAV files are not supported yet. Convert to 16-bit PCM if necessary.
+- The matplotlib window must stay in the foreground on some window managers to continue refreshing.
+- Microphone mode depends on the `sounddevice` package; if it's missing, the script fails with a clear error and you can still analyze WAV files.
+
+## Challenge Status
+
+This implementation completes `/g/` Challenge **#95 – Real-Time Fast Fourier Transform Spectrum Visualizer**.

--- a/Emulation/FFTSpectrum/__init__.py
+++ b/Emulation/FFTSpectrum/__init__.py
@@ -1,0 +1,5 @@
+"""Real-time FFT spectrum visualizer utilities."""
+
+from .fft_spectrum import SpectrumConfig, chunk_to_fft, main
+
+__all__ = ["SpectrumConfig", "chunk_to_fft", "main"]

--- a/Emulation/FFTSpectrum/fft_spectrum.py
+++ b/Emulation/FFTSpectrum/fft_spectrum.py
@@ -1,0 +1,223 @@
+"""Realtime FFT spectrum visualizer for microphone or WAV input."""
+from __future__ import annotations
+
+import argparse
+import queue
+import sys
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generator, Iterable, Optional, Tuple
+
+import numpy as np
+
+
+@dataclass
+class SpectrumConfig:
+    """Configuration values for FFT processing."""
+
+    sample_rate: int = 44100
+    window_size: int = 2048
+    window_type: str = "hann"
+
+    def window(self, length: int) -> np.ndarray:
+        """Return a windowing function array for the given length."""
+        if self.window_type.lower() in {"hann", "hanning"}:
+            return np.hanning(length)
+        if self.window_type.lower() == "hamming":
+            return np.hamming(length)
+        return np.ones(length)
+
+
+def _ensure_mono(samples: np.ndarray) -> np.ndarray:
+    if samples.ndim == 1:
+        return samples
+    return samples.mean(axis=1)
+
+
+def _to_float32(samples: np.ndarray) -> np.ndarray:
+    if samples.dtype == np.float32:
+        return samples
+    if np.issubdtype(samples.dtype, np.floating):
+        return samples.astype(np.float32, copy=False)
+    if np.issubdtype(samples.dtype, np.integer):
+        info = np.iinfo(samples.dtype)
+        return samples.astype(np.float32) / max(abs(info.min), info.max)
+    return samples.astype(np.float32)
+
+
+def chunk_to_fft(samples: np.ndarray, config: SpectrumConfig) -> Tuple[np.ndarray, np.ndarray]:
+    """Compute FFT magnitude spectrum for the provided audio chunk."""
+
+    array = np.asarray(samples)
+    if array.size == 0:
+        raise ValueError("Cannot compute FFT of empty sample array")
+    if array.ndim > 1:
+        array = _ensure_mono(array)
+    array = _to_float32(array)
+    window = config.window(len(array))
+    windowed = array * window
+    spectrum = np.fft.rfft(windowed, n=len(array))
+    freqs = np.fft.rfftfreq(len(array), d=1.0 / config.sample_rate)
+    magnitude = np.abs(spectrum) / max(len(array), 1)
+    return freqs, magnitude
+
+
+class WavStream:
+    """Generator over WAV frames."""
+
+    def __init__(self, path: Path, config: SpectrumConfig, loop: bool = False):
+        self.path = Path(path)
+        self.config = config
+        self.loop = loop
+
+    def __iter__(self) -> Iterable[np.ndarray]:
+        while True:
+            with wave.open(self.path, "rb") as wav_file:
+                channels = wav_file.getnchannels()
+                width = wav_file.getsampwidth()
+                dtype = {1: np.int8, 2: np.int16, 4: np.int32}.get(width)
+                if dtype is None:
+                    raise ValueError(f"Unsupported sample width: {width} bytes")
+                framerate = wav_file.getframerate()
+                if self.config.sample_rate != framerate:
+                    self.config.sample_rate = framerate
+                blocksize = self.config.window_size
+                while True:
+                    frames = wav_file.readframes(blocksize)
+                    if not frames:
+                        break
+                    data = np.frombuffer(frames, dtype=dtype)
+                    if channels > 1:
+                        data = data.reshape(-1, channels)
+                    yield data
+            if not self.loop:
+                break
+
+
+class MicrophoneStream:
+    """Yield audio blocks from the active input device using sounddevice."""
+
+    def __init__(
+        self,
+        config: SpectrumConfig,
+        device: Optional[str] = None,
+    ) -> None:
+        self.config = config
+        self.device = device
+        self._queue: "queue.Queue[np.ndarray]" = queue.Queue()
+        self._stream = None
+
+    def __enter__(self) -> "MicrophoneStream":
+        try:
+            import sounddevice as sd  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("sounddevice is required for microphone capture") from exc
+
+        def callback(indata, frames, time, status):  # pragma: no cover - requires hardware
+            if status:
+                print(status, file=sys.stderr)
+            self._queue.put(indata.copy())
+
+        self._stream = sd.InputStream(
+            samplerate=self.config.sample_rate,
+            blocksize=self.config.window_size,
+            channels=1,
+            device=self.device,
+            callback=callback,
+        )
+        self._stream.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._stream is not None:  # pragma: no cover - requires hardware
+            self._stream.stop()
+            self._stream.close()
+            self._stream = None
+
+    def __iter__(self) -> Generator[np.ndarray, None, None]:  # pragma: no cover - requires hardware
+        while True:
+            yield self._queue.get()
+
+
+def _run_visualizer(
+    source: Iterable[np.ndarray],
+    config: SpectrumConfig,
+    scale: str,
+    refresh_rate: float,
+) -> None:
+    import matplotlib.pyplot as plt
+    from matplotlib.animation import FuncAnimation
+
+    source_iter = iter(source)
+    fig, ax = plt.subplots()
+    base_freqs = np.fft.rfftfreq(config.window_size, d=1.0 / config.sample_rate)
+    line, = ax.plot(base_freqs, np.zeros_like(base_freqs))
+    ax.set_xlabel("Frequency (Hz)")
+    ax.set_ylabel("Magnitude" if scale == "linear" else "dBFS")
+    ax.set_xlim(0, config.sample_rate / 2)
+    ax.set_ylim(0, 1)
+    ax.set_title("Real-time FFT Spectrum")
+
+    def update(_):
+        try:
+            chunk = next(source_iter)
+        except StopIteration:
+            plt.close(fig)
+            return line
+        freqs, magnitude = chunk_to_fft(chunk, config)
+        if scale == "log":
+            magnitude = 20 * np.log10(np.maximum(magnitude, 1e-12))
+            ax.set_ylim(-120, 0)
+        else:
+            peak = float(np.max(magnitude))
+            ax.set_ylim(0, max(1e-6, peak * 1.2))
+        line.set_data(freqs, magnitude)
+        ax.set_xlim(0, config.sample_rate / 2)
+        return line
+
+    interval_ms = 1000.0 / refresh_rate if refresh_rate > 0 else 0
+    animation = FuncAnimation(fig, update, interval=interval_ms, blit=False)
+    plt.show()
+    del animation
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", choices=["mic", "wav"], default="mic", help="Audio input source")
+    parser.add_argument("--wav-path", type=Path, help="Path to WAV file when using --source=wav")
+    parser.add_argument("--samplerate", type=int, default=None, help="Sample rate to request")
+    parser.add_argument("--window-size", type=int, default=2048, help="FFT window size (samples)")
+    parser.add_argument("--window", choices=["hann", "hamming", "rect"], default="hann", help="Window function")
+    parser.add_argument("--device", help="Optional sounddevice input identifier")
+    parser.add_argument("--refresh", type=float, default=30.0, help="Plot refresh rate (frames per second)")
+    parser.add_argument("--scale", choices=["linear", "log"], default="linear", help="Display magnitude scale")
+    parser.add_argument("--loop", action="store_true", help="Loop WAV file playback")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    config = SpectrumConfig(
+        sample_rate=args.samplerate or 44100,
+        window_size=args.window_size,
+        window_type="rect" if args.window == "rect" else args.window,
+    )
+
+    if args.source == "wav":
+        if not args.wav_path:
+            parser.error("--wav-path is required when --source=wav")
+        stream = WavStream(args.wav_path, config, loop=args.loop)
+        try:
+            _run_visualizer(stream, config, args.scale, args.refresh)
+        except ValueError as exc:
+            parser.error(str(exc))
+        return 0
+
+    try:
+        with MicrophoneStream(config, device=args.device) as mic_stream:
+            _run_visualizer(mic_stream, config, args.scale, args.refresh)
+    except RuntimeError as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Emulation/FFTSpectrum/test_tone.wav
+++ b/Emulation/FFTSpectrum/test_tone.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5f3a19cd7e043147381667a0c2d50106b7dbeb25671ab61ca628f3d9426988c
+size 88244

--- a/Emulation/README.md
+++ b/Emulation/README.md
@@ -55,6 +55,7 @@ python -m pip install -e .[ai]            # palette clustering (scikit-learn)
 | CompColor | Color space component visualizer & composite manipulator. | numpy, Pillow | — |
 | EulerianPath | Fleury vs Hierholzer algorithm demos (Java/Python/C++). | stdlib (Py) | — |
 | SpinnyCube | Text-based + optional VPython 3D spinning cube. | stdlib (text mode) | vpython |
+| FFTSpectrum | Real-time FFT spectrum analyzer with mic/WAV sources. | numpy, matplotlib, sounddevice | — |
 
 > Some folders may contain experimental or WIP code; stable scripts include `5cs.py`, `comp.py`, `hierholzer.py`, `ClockSynced.py`.
 
@@ -82,6 +83,7 @@ Install only the extras you need:
 | OpenCV acceleration | `visual` | Adds `opencv-python` alongside Pillow/imageio. |
 | Component color visualizer (CompColor) | `visual` | Only Pillow + numpy required. |
 | SpinnyCube VPython 3D version | `visual` | VPython is part of the visual extra. |
+| FFTSpectrum real-time analyzer | `visual` | Adds numpy, matplotlib, sounddevice for live plots. |
 | Pure stdlib demos (Eulerian path, ASCII clock) | *(none)* | Standard library only. |
 
 ---

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ The solutions are organized by category and difficulty, making it easy to naviga
 
 ## Progress
 
-<progress value="99" max="131"></progress>
+<progress value="100" max="131"></progress>
 
-**Overall:** 99 / 131 challenges completed (75.6%).
+**Overall:** 100 / 131 challenges completed (76.3%).
 
 | Category | Completed | Total | Progress |
 | --- | --- | --- | --- |
 | Practical | 53 | 53 | 100% |
 | Algorithmic | 27 | 27 | 100% |
 | Artificial Intelligence | 3 | 8 | 37.5% |
-| Emulation/Modeling | 6 | 14 | 42.9% |
+| Emulation/Modeling | 7 | 14 | 50.0% |
 | Games | 10 | 29 | 34.5% |
 
 _Progress counts are generated from the actual solution folders in the repository (see tables below)._ 
@@ -58,7 +58,7 @@ The repository now ships a `pyproject.toml` so you can install challenge stacks 
 | ----- | ------ | ---------- |
 | `practical` | `Practical/` utilities, desktop apps, and web tools | Flask imageboard, Streamlit dashboards, Seam Carving, Shazam clone |
 | `algorithmic` | `Algorithmic/` problem set helpers | Steganography, stock analysis, crawler tooling |
-| `visual` | Visualization add-ons used across categories | Matplotlib demos, colour-science palettes, VPython spinny cube |
+| `visual` | Visualization add-ons used across categories | Matplotlib demos, colour-science palettes, VPython spinny cube, FFT spectrum analyzer |
 | `audio` | Audio processing stacks | WAV equalizer, Shazam clone, music streaming |
 | `games` | Python games in `Games/` | Sudoku solver, Simon, Oil Panic tribute |
 | `ai` | `Artificial Intelligence/` demos | A* Sudoku, Connect4 AI, neural network |
@@ -207,7 +207,7 @@ The repository includes a GitHub Actions workflow at `.github/workflows/keep-str
 | 92 | Double Pendulum Simulation | Not Yet |
 | 93 | Constructive Solid Geometry | Not Yet |
 | 94 | Ray Tracer | Not Yet |
-| 95 | Real-Time Fast Fourier Transform Spectrum Visualizer | Not Yet |
+| 95 | Real-Time Fast Fourier Transform Spectrum Visualizer | [View Solution](./Emulation/FFTSpectrum/) |
 | 96 | Generate a Complimentary Color from any input color | [View Solution](./Emulation/CompColor/) |
 | 97 | Generate a 5-Color Scheme from the most dominant tones in any image | [View Solution](./Emulation/5%20color%20scheme/) |
 | 98 | General Lambert's-Problem Solver (At least it's not rocket science... Oh wait it actually is) | Not Yet |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ algorithmic = [
     "yt-dlp>=2024.7.1",
 ]
 visual = [
+    "numpy>=1.26,<2.0",
     "Pillow>=10.4,<10.5",
     "matplotlib>=3.8,<3.9",
     "imageio>=2.34,<2.35",
@@ -70,6 +71,7 @@ visual = [
     "colour-science>=0.4,<0.5",
     "vpython>=7.6,<7.7",
     "opencv-python>=4.10,<5.0",
+    "sounddevice>=0.4,<0.5",
 ]
 audio = [
     "numpy>=1.26,<2.0",

--- a/tests/test_fft_spectrum.py
+++ b/tests/test_fft_spectrum.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from pathlib import Path
+import wave
+
+import numpy as np
+
+from Emulation.FFTSpectrum.fft_spectrum import SpectrumConfig, chunk_to_fft
+
+
+def load_samples(window_size: int) -> np.ndarray:
+    wav_path = Path("Emulation/FFTSpectrum/test_tone.wav")
+    with wave.open(str(wav_path), "rb") as wav_file:
+        frames = wav_file.readframes(window_size)
+    data = np.frombuffer(frames, dtype=np.int16)
+    return data
+
+
+def test_fft_shape_and_peak_frequency():
+    window_size = 4096
+    config = SpectrumConfig(sample_rate=44100, window_size=window_size)
+    samples = load_samples(window_size)
+    freqs, magnitude = chunk_to_fft(samples, config)
+
+    assert freqs.shape[0] == window_size // 2 + 1
+    assert magnitude.shape == freqs.shape
+
+    dominant_frequency = float(freqs[int(np.argmax(magnitude))])
+    assert abs(dominant_frequency - 440.0) < 5.0
+    assert float(np.max(magnitude)) > 1e-3


### PR DESCRIPTION
## Summary
- add a configurable FFT spectrum visualizer supporting microphone and WAV inputs
- document hardware requirements, latency tips, and install guidance for the new challenge
- extend the visual extra stack, mark challenge #95 solved, and add a regression test using a bundled tone sample

## Testing
- pytest tests/test_fft_spectrum.py

------
https://chatgpt.com/codex/tasks/task_b_68df529e8acc8323a461000d96246ca5