### PR TITLE
Implement AI roguelike agent with CLI and smoke tests

### DIFF
--- a/Artificial Intelligence/AI Roguelike/README.md
+++ b/Artificial Intelligence/AI Roguelike/README.md
@@ -1,0 +1,83 @@
+# AI Roguelike Agent
+
+This package provides an automated agent for the [Roguelike challenge](../../Games/Roguelike/).
+It drives the existing `Games/Roguelike` engine headlessly and chooses actions with a
+Monte Carlo Tree Search (MCTS) planner.  The agent is intentionally lightweight so it can
+be embedded into tutorials, smoke tests, or benchmarking scripts without requiring a full
+rendering stack.
+
+## Features
+
+- Deterministic, headless wrapper around the roguelike engine (`Games.Roguelike`).
+- Monte Carlo Tree Search agent with configurable rollout depth and exploration constant.
+- ASCII renderer for logging/visualising the agent's perception of the dungeon.
+- Command-line interface for running the agent through sample dungeons.
+- Smoke tests that ensure the agent can survive several automated turns without crashing.
+
+## Installation
+
+The agent depends on the same libraries as the base game, most notably
+[`tcod`](https://github.com/libtcod/libtcod) for dungeon utilities and `numpy` for
+map manipulation.  Install the extras declared in the repository's `pyproject.toml`:
+
+```bash
+pip install -e .[ai_roguelike]
+```
+
+This pulls in:
+
+- `tcod` for field-of-view and tile helpers used by `Games.Roguelike`.
+- `numpy` for map representations and deterministic dungeon generation.
+- `scipy` for compatibility with other AI tooling in the repository (it is used by
+  some roguelike combat utilities).
+
+## Command-line usage
+
+The CLI runs the Monte Carlo agent against a compact sample dungeon.  From the repository
+root run:
+
+```bash
+PYTHONPATH="Artificial Intelligence/AI Roguelike" \
+    python -m ai_roguelike.cli --turns 30 --iterations 128 --visualise
+```
+
+Behind the scenes the `ai_roguelike` package lives in `Artificial Intelligence/AI Roguelike/`.
+If you prefer to invoke it from that directory you can also run:
+
+```bash
+cd "Artificial Intelligence/AI Roguelike"
+python -m ai_roguelike.cli --turns 20 --seed 42 --log-file run.log
+```
+
+Useful flags:
+
+- `--turns`: maximum number of turns to simulate.
+- `--iterations`: number of MCTS iterations per turn.
+- `--rollout-depth`: depth of random playouts during search.
+- `--seed`: seed for reproducible dungeon layouts.
+- `--visualise`: print an ASCII snapshot of the dungeon after each decision.
+- `--log-file`: capture detailed logs in addition to console output.
+
+Example output (truncated for brevity):
+
+```
+2024-09-01 12:00:00 | ai_roguelike | INFO | Starting automated run for 20 turns
+2024-09-01 12:00:01 | ai_roguelike | INFO | Chosen action: north
+2024-09-01 12:00:01 | ai_roguelike | INFO | Turn 1 | HP=30 | hostiles=5 | hostile HP=54
+```
+
+## Development
+
+Automated smoke tests ensure the planner can advance several turns without triggering
+errors:
+
+```bash
+pytest tests/test_ai_roguelike_smoke.py
+```
+
+The tests load a small dungeon via `create_sample_environment`, run the agent for a few
+turns, and assert that the player remains alive or the run terminates cleanly.
+
+Feel free to tune the heuristics in `environment.py` or swap in a different planner.  The
+`RoguelikeEnvironment` exposes a small action space and deterministic seeding helpers that
+make it easy to prototype reinforcement learning agents or search-based controllers.

--- a/Artificial Intelligence/AI Roguelike/ai_roguelike/__init__.py
+++ b/Artificial Intelligence/AI Roguelike/ai_roguelike/__init__.py
@@ -1,0 +1,26 @@
+"""AI agent utilities for the Roguelike challenge.
+
+The module exposes helpers to create headless game environments and
+plan turns using Monte Carlo Tree Search.  The implementation leans on
+``Games.Roguelike`` for the underlying game rules so that automated
+agents can run the exact same content as the interactive client.
+"""
+
+from .environment import (
+    Action,
+    RoguelikeEnvironment,
+    create_environment,
+    create_sample_environment,
+    render_ascii,
+)
+from .mcts import ActionEvaluation, MCTSAgent
+
+__all__ = [
+    "Action",
+    "ActionEvaluation",
+    "MCTSAgent",
+    "RoguelikeEnvironment",
+    "create_environment",
+    "create_sample_environment",
+    "render_ascii",
+]

--- a/Artificial Intelligence/AI Roguelike/ai_roguelike/cli.py
+++ b/Artificial Intelligence/AI Roguelike/ai_roguelike/cli.py
@@ -1,0 +1,141 @@
+"""Command-line interface for running the roguelike AI agent."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import random
+from typing import Sequence
+
+from .environment import RoguelikeEnvironment, create_sample_environment
+from .mcts import ActionEvaluation, MCTSAgent
+
+
+def _format_action_stats(stats: Sequence[ActionEvaluation]) -> str:
+    if not stats:
+        return "<no actions explored>"
+    rows = ["Action       Visits  Mean Reward  Total Reward"]
+    for entry in stats:
+        rows.append(
+            f"{entry.action.name:<11} {entry.visits:>6}  {entry.mean_reward:>11.2f}  {entry.total_reward:>12.2f}"
+        )
+    return "\n".join(rows)
+
+
+def _log_environment(logger: logging.Logger, env: RoguelikeEnvironment) -> None:
+    summary = env.summary()
+    logger.info(
+        "Turn %(turn)d | HP=%(player_hp)d | hostiles=%(hostiles)d | hostile HP=%(hostile_hp)d",
+        summary,
+    )
+
+
+def run_episode(
+    *,
+    turns: int,
+    iterations: int,
+    rollout_depth: int,
+    exploration: float,
+    seed: int | None,
+    visualise: bool,
+) -> None:
+    if seed is not None:
+        random.seed(seed)
+
+    env = create_sample_environment(seed=seed)
+    agent = MCTSAgent(
+        iterations=iterations,
+        rollout_depth=rollout_depth,
+        exploration_weight=exploration,
+        rng=random.Random(seed),
+    )
+    logger = logging.getLogger("ai_roguelike")
+
+    logger.info("Starting automated run for %d turns", turns)
+    if visualise:
+        print(env.to_ascii())
+        print()
+
+    for turn in range(1, turns + 1):
+        if env.is_terminal:
+            logger.info("Episode finished early at turn %d", turn - 1)
+            break
+        action, stats = agent.choose_action(env)
+        logger.info("Chosen action: %s", action.name)
+        logger.debug("\n%s", _format_action_stats(stats))
+        reward, done = env.apply_action(action)
+        logger.info("Reward %.2f", reward)
+        _log_environment(logger, env)
+        if visualise:
+            print(env.to_ascii())
+            print()
+        if done:
+            logger.info("Terminal state reached at turn %d", turn)
+            break
+    else:
+        logger.info("Reached turn limit without a terminal state")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Headless roguelike runner powered by a Monte Carlo agent.",
+    )
+    parser.add_argument("--turns", type=int, default=20, help="Maximum number of turns to simulate")
+    parser.add_argument(
+        "--iterations", type=int, default=96, help="MCTS iterations to run each turn"
+    )
+    parser.add_argument(
+        "--rollout-depth", type=int, default=4, help="Depth of each random rollout"
+    )
+    parser.add_argument(
+        "--exploration", type=float, default=1.1, help="Exploration constant for UCT"
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Seed for deterministic runs")
+    parser.add_argument(
+        "--log-file",
+        default=None,
+        help="Optional path to write detailed logs (defaults to stderr only)",
+    )
+    parser.add_argument(
+        "--visualise",
+        action="store_true",
+        help="Print an ASCII view of the dungeon after each decision",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Verbosity for console logging",
+    )
+    return parser
+
+
+def configure_logging(level: str, *, log_file: str | None) -> None:
+    logging_kwargs: dict = {
+        "level": getattr(logging, level.upper(), logging.INFO),
+        "format": "%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+    }
+    handlers = []
+    if log_file:
+        handlers.append(logging.FileHandler(log_file, mode="w", encoding="utf-8"))
+    handlers.append(logging.StreamHandler())
+    logging_kwargs["handlers"] = handlers
+    logging.basicConfig(**logging_kwargs)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.log_level, log_file=args.log_file)
+    run_episode(
+        turns=args.turns,
+        iterations=args.iterations,
+        rollout_depth=args.rollout_depth,
+        exploration=args.exploration,
+        seed=args.seed,
+        visualise=args.visualise,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/Artificial Intelligence/AI Roguelike/ai_roguelike/environment.py
+++ b/Artificial Intelligence/AI Roguelike/ai_roguelike/environment.py
@@ -1,0 +1,292 @@
+"""Headless environment helpers for the Roguelike challenge.
+
+The environment exposes a light-weight wrapper around ``Games.Roguelike``'s
+``Engine`` so that automated agents can plan in the same world model used by
+the interactive client.  It provides deterministic seeding, a compact action
+space, heuristics for evaluating states, and convenience helpers for
+rendering an ASCII representation of the dungeon for logging purposes.
+"""
+
+from __future__ import annotations
+
+import copy
+import random
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from Games.Roguelike.config import GameConfig
+from Games.Roguelike.entity import Actor
+from Games.Roguelike.main import new_game
+
+# The roguelike is fundamentally tile based so a Moore neighbourhood (including
+# diagonals) plus a wait action offers a compact-yet-expressive action space for
+# planning algorithms like MCTS.
+
+
+@dataclass(frozen=True)
+class Action:
+    """High-level intent for the agent.
+
+    ``dx`` and ``dy`` map onto the player's attempted movement vector.
+    ``name`` is used purely for logging/visualisation and keeps CLI output
+    readable without additional lookups.
+    """
+
+    name: str
+    dx: int
+    dy: int
+
+
+ALL_ACTIONS: Tuple[Action, ...] = (
+    Action("north", 0, -1),
+    Action("south", 0, 1),
+    Action("west", -1, 0),
+    Action("east", 1, 0),
+    Action("north_west", -1, -1),
+    Action("north_east", 1, -1),
+    Action("south_west", -1, 1),
+    Action("south_east", 1, 1),
+    Action("wait", 0, 0),
+)
+
+
+class RoguelikeEnvironment:
+    """Mutable game wrapper tailored for automated agents."""
+
+    def __init__(self, engine, *, turn: int = 0) -> None:
+        self.engine = engine
+        self.turn = turn
+        self._terminal_cache: Optional[bool] = None
+
+    # ------------------------------------------------------------------
+    # Creation helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_config(
+        cls, config: GameConfig, *, seed: Optional[int] = None
+    ) -> "RoguelikeEnvironment":
+        """Create a fresh environment using ``config``.
+
+        ``Games.Roguelike`` relies on Python's global PRNG during dungeon
+        generation.  For deterministic tests/experiments ``seed`` can be
+        supplied to seed both :mod:`random` and :mod:`numpy.random`.
+        """
+
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed % (2**32))
+        engine = new_game(config)
+        return cls(engine)
+
+    @classmethod
+    def sample(
+        cls,
+        *,
+        seed: Optional[int] = None,
+        map_width: int = 40,
+        map_height: int = 30,
+        max_rooms: int = 8,
+        max_monsters_per_room: int = 2,
+        max_items_per_room: int = 1,
+    ) -> "RoguelikeEnvironment":
+        """Return a compact dungeon suitable for automated smoke-tests."""
+
+        config = GameConfig(
+            map_width=map_width,
+            map_height=map_height,
+            max_rooms=max_rooms,
+            max_monsters_per_room=max_monsters_per_room,
+            max_items_per_room=max_items_per_room,
+            screen_width=map_width,
+            screen_height=map_height + 7,
+        )
+        return cls.from_config(config, seed=seed)
+
+    # ------------------------------------------------------------------
+    # Basic environment protocol
+    # ------------------------------------------------------------------
+    def clone(self) -> "RoguelikeEnvironment":
+        """Deep copy the environment so planners can explore hypotheticals."""
+
+        return RoguelikeEnvironment(copy.deepcopy(self.engine), turn=self.turn)
+
+    def available_actions(self) -> Sequence[Action]:
+        """Return the actions that are legal in the current state."""
+
+        if self.is_terminal:
+            return ()
+
+        actions: List[Action] = []
+        player = self.engine.player
+        game_map = self.engine.game_map
+        for action in ALL_ACTIONS:
+            if action.dx == 0 and action.dy == 0:
+                actions.append(action)
+                continue
+            dest_x = player.x + action.dx
+            dest_y = player.y + action.dy
+            if not game_map.in_bounds(dest_x, dest_y):
+                continue
+            tile = game_map.tiles[dest_x, dest_y]
+            if not tile["walkable"]:
+                # Wall or obstacle – the only time we allow stepping into it is
+                # if an enemy blocks the way so we can attack.
+                target = game_map.get_blocking_entity_at_location(dest_x, dest_y)
+                if isinstance(target, Actor) and target is not player and target.is_alive:
+                    actions.append(action)
+                continue
+            blocker = game_map.get_blocking_entity_at_location(dest_x, dest_y)
+            if blocker and blocker is not player:
+                # Enemy standing on a floor tile: still a legal attack action.
+                if isinstance(blocker, Actor) and blocker.is_alive:
+                    actions.append(action)
+                continue
+            actions.append(action)
+        return tuple(actions)
+
+    def step(self, action: Action) -> Tuple[float, bool]:
+        """Apply ``action`` in-place.
+
+        Returns a reward signal derived from the heuristic evaluation change and
+        a boolean indicating whether the game reached a terminal state.
+        """
+
+        if self.is_terminal:
+            return 0.0, True
+
+        before = self.evaluate()
+        self._apply_action(action)
+        after = self.evaluate()
+        self.turn += 1
+        self._terminal_cache = None
+        reward = after - before
+        return reward, self.is_terminal
+
+    def apply_action(self, action: Action) -> Tuple[float, bool]:
+        """Alias for :meth:`step` used by higher-level orchestration."""
+
+        return self.step(action)
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+    @property
+    def is_terminal(self) -> bool:
+        if self._terminal_cache is None:
+            player_alive = getattr(self.engine.player, "is_alive", False)
+            hostile_count, _ = self._hostile_stats()
+            self._terminal_cache = not player_alive or hostile_count == 0
+        return self._terminal_cache
+
+    def evaluate(self) -> float:
+        """Heuristic valuation of the current state.
+
+        The score rewards the player's health, exploration progress, and the
+        elimination of hostiles.  It is intentionally heuristic – the goal is
+        to give the planner a smooth landscape to optimise over, not to be a
+        perfect value function.
+        """
+
+        player = self.engine.player
+        if not player.is_alive:
+            return -1_000.0
+        player_hp = float(player.fighter.hp if player.fighter else 0)
+        hostile_count, hostile_hp = self._hostile_stats()
+        explored_ratio = float(np.count_nonzero(self.engine.game_map.explored))
+        explored_ratio /= max(1, self.engine.game_map.explored.size)
+        # Weight terms: HP is critical, hostiles penalise, exploration encourages
+        # moving through the dungeon instead of waiting in place.
+        return (player_hp * 2.0) - (hostile_hp * 0.75) - (hostile_count * 1.5) + (
+            explored_ratio * 10.0
+        )
+
+    def summary(self) -> dict:
+        """Return lightweight telemetry for logging or dashboards."""
+
+        hostile_count, hostile_hp = self._hostile_stats()
+        player = self.engine.player
+        return {
+            "turn": self.turn,
+            "player_hp": player.fighter.hp if player.fighter else 0,
+            "hostiles": hostile_count,
+            "hostile_hp": hostile_hp,
+        }
+
+    # ------------------------------------------------------------------
+    # Rendering helpers
+    # ------------------------------------------------------------------
+    def to_ascii(self, *, reveal: bool = False) -> str:
+        """Render the dungeon as ASCII for logging/debugging."""
+
+        return render_ascii(self.engine, reveal=reveal)
+
+    # ------------------------------------------------------------------
+    # Internal utilities
+    # ------------------------------------------------------------------
+    def _apply_action(self, action: Action) -> None:
+        self.engine.handle_player_movement(action.dx, action.dy)
+
+    def _hostile_stats(self) -> Tuple[int, int]:
+        count = 0
+        total_hp = 0
+        for entity in self.engine.game_map.entities:
+            if isinstance(entity, Actor) and entity is not self.engine.player and entity.is_alive:
+                count += 1
+                total_hp += int(entity.fighter.hp if entity.fighter else 0)
+        return count, total_hp
+
+
+def create_environment(
+    config: Optional[GameConfig] = None, *, seed: Optional[int] = None
+) -> RoguelikeEnvironment:
+    """Factory helper mirroring :meth:`RoguelikeEnvironment.from_config`."""
+
+    config = config or GameConfig()
+    return RoguelikeEnvironment.from_config(config, seed=seed)
+
+
+def create_sample_environment(*, seed: Optional[int] = None) -> RoguelikeEnvironment:
+    """Return a deterministic small dungeon used by the CLI and tests."""
+
+    return RoguelikeEnvironment.sample(seed=seed)
+
+
+def render_ascii(engine, *, reveal: bool = False) -> str:
+    """Return a text-mode representation of ``engine``'s dungeon state."""
+
+    game_map = engine.game_map
+    width, height = game_map.tiles.shape
+    visible = game_map.visible
+    explored = game_map.explored
+    chars: List[List[str]] = []
+    for y in range(height):
+        row: List[str] = []
+        for x in range(width):
+            if reveal or visible[x, y] or explored[x, y]:
+                glyph = game_map.tiles[x, y]["light"]["ch"]
+                row.append(chr(int(glyph)))
+            else:
+                row.append(" ")
+        chars.append(row)
+
+    # Overlay entities
+    for entity in game_map.entities:
+        if reveal or visible[entity.x, entity.y]:
+            chars[entity.y][entity.x] = entity.char
+    # Ensure the player is visible even if dead (glyph already mutated by engine)
+    player = engine.player
+    chars[player.y][player.x] = player.char
+
+    return "\n".join("".join(row) for row in chars)
+
+
+__all__ = [
+    "Action",
+    "ALL_ACTIONS",
+    "RoguelikeEnvironment",
+    "create_environment",
+    "create_sample_environment",
+    "render_ascii",
+]

--- a/Artificial Intelligence/AI Roguelike/ai_roguelike/mcts.py
+++ b/Artificial Intelligence/AI Roguelike/ai_roguelike/mcts.py
@@ -1,0 +1,161 @@
+"""Monte Carlo Tree Search planner for the roguelike environment."""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+from .environment import Action, RoguelikeEnvironment
+
+
+@dataclass
+class ActionEvaluation:
+    """Aggregated statistics for an action explored by MCTS."""
+
+    action: Action
+    visits: int
+    total_reward: float
+
+    @property
+    def mean_reward(self) -> float:
+        return self.total_reward / self.visits if self.visits else 0.0
+
+
+class _TreeNode:
+    __slots__ = (
+        "env",
+        "parent",
+        "action",
+        "children",
+        "untried_actions",
+        "visits",
+        "total_reward",
+        "terminal",
+    )
+
+    def __init__(
+        self,
+        env: RoguelikeEnvironment,
+        *,
+        parent: Optional["_TreeNode"] = None,
+        action: Optional[Action] = None,
+    ) -> None:
+        self.env = env
+        self.parent = parent
+        self.action = action
+        self.children: List[_TreeNode] = []
+        self.untried_actions: List[Action] = list(env.available_actions())
+        self.visits = 0
+        self.total_reward = 0.0
+        self.terminal = env.is_terminal
+
+    def is_fully_expanded(self) -> bool:
+        return not self.untried_actions
+
+    def best_child(self, exploration_weight: float) -> "_TreeNode":
+        if not self.children:
+            raise RuntimeError("best_child called on a leaf node with no children")
+        log_parent = math.log(self.visits) if self.visits > 0 else 0.0
+        best_score = float("-inf")
+        best = self.children[0]
+        for child in self.children:
+            if child.visits == 0:
+                return child
+            exploit = child.total_reward / child.visits
+            explore = math.sqrt(log_parent / child.visits) if child.visits else 0.0
+            score = exploit + exploration_weight * explore
+            if score > best_score:
+                best_score = score
+                best = child
+        return best
+
+    def expand(self, rng: random.Random) -> "_TreeNode":
+        if not self.untried_actions:
+            raise RuntimeError("expand called on fully expanded node")
+        index = rng.randrange(len(self.untried_actions)) if len(self.untried_actions) > 1 else 0
+        action = self.untried_actions.pop(index)
+        child_env = self.env.clone()
+        child_env.step(action)
+        child = _TreeNode(child_env, parent=self, action=action)
+        self.children.append(child)
+        return child
+
+    def backpropagate(self, reward: float) -> None:
+        node: Optional[_TreeNode] = self
+        while node is not None:
+            node.visits += 1
+            node.total_reward += reward
+            node = node.parent
+
+
+class MCTSAgent:
+    """Simple MCTS controller for the roguelike."""
+
+    def __init__(
+        self,
+        *,
+        iterations: int = 64,
+        rollout_depth: int = 4,
+        exploration_weight: float = 1.4,
+        rng: Optional[random.Random] = None,
+    ) -> None:
+        self.iterations = iterations
+        self.rollout_depth = rollout_depth
+        self.exploration_weight = exploration_weight
+        self.rng = rng or random.Random()
+
+    def choose_action(
+        self, env: RoguelikeEnvironment
+    ) -> Tuple[Action, Sequence[ActionEvaluation]]:
+        """Return the next action and statistics about explored actions."""
+
+        if env.is_terminal:
+            raise RuntimeError("Environment is terminal; no actions available")
+
+        root = _TreeNode(env.clone())
+        for _ in range(self.iterations):
+            node = root
+            # Selection
+            while node.is_fully_expanded() and node.children and not node.terminal:
+                node = node.best_child(self.exploration_weight)
+            # Expansion
+            if not node.terminal and node.untried_actions:
+                node = node.expand(self.rng)
+            # Simulation
+            reward = self._rollout(node)
+            # Backpropagation
+            node.backpropagate(reward)
+
+        if not root.children:
+            raise RuntimeError("Planner failed to explore any actions")
+
+        best_child = max(root.children, key=lambda child: child.visits)
+        evaluations = tuple(
+            ActionEvaluation(action=child.action, visits=child.visits, total_reward=child.total_reward)
+            for child in sorted(root.children, key=lambda c: c.visits, reverse=True)
+        )
+        return best_child.action, evaluations
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _rollout(self, node: _TreeNode) -> float:
+        if node.terminal:
+            return 0.0
+        rollout_env = node.env.clone()
+        total_reward = 0.0
+        for _ in range(self.rollout_depth):
+            actions = rollout_env.available_actions()
+            if not actions:
+                break
+            action = self.rng.choice(actions)
+            reward, done = rollout_env.step(action)
+            total_reward += reward
+            if done:
+                break
+        return total_reward
+
+
+__all__ = ["ActionEvaluation", "MCTSAgent"]

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The repository includes a GitHub Actions workflow at `.github/workflows/keep-str
 | # | Challenge | Status |
 | --- | --------- | ------ |
 | 70 | OpenAI Gym Project | Not Yet |
-| 71 | AI for Roguelikes | Not Yet |
+| 71 | AI for Roguelikes | [View Solution](./Artificial%20Intelligence/AI%20Roguelike/) |
 | 72 | Sudoku/n-Puzzle Solver using A* algorithm | [View Solution](./Artificial%20Intelligence/Sudoku/) |
 | 73 | Connect-4 AI Player using Alpha-Beta Pruning | [View Solution](./Artificial%20Intelligence/Connect4/) |
 | 74 | Basic Neural Network - Simulate individual neurons and their connections | [View Solution](./Artificial%20Intelligence/Basic%20Neural%20Network/) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,11 @@ ai = [
     "scipy>=1.11,<1.13",
     "scikit-learn>=1.5,<1.6",
 ]
+ai_roguelike = [
+    "numpy>=1.26,<2.0",
+    "scipy>=1.11,<1.13",
+    "tcod>=16.2,<17.0",
+]
 midi = [
     "mido>=1.3,<1.4",
     "python-rtmidi>=1.5,<1.6",

--- a/tests/test_ai_roguelike_smoke.py
+++ b/tests/test_ai_roguelike_smoke.py
@@ -1,0 +1,220 @@
+"""Smoke tests for the AI Roguelike agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+
+import numpy as np
+
+import pytest
+
+# Ensure the ai_roguelike package (stored under Artificial Intelligence) is importable.
+PACKAGE_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "Artificial Intelligence"
+    / "AI Roguelike"
+)
+if str(PACKAGE_DIR) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_DIR))
+
+
+def _install_tcod_stub() -> None:
+    """Install a minimal ``tcod`` stub so tests can run without the real library."""
+
+    if "tcod" in sys.modules:
+        return
+
+    tcod = types.ModuleType("tcod")
+
+    # tcod.map
+    tcod_map = types.ModuleType("tcod.map")
+
+    def compute_fov(transparency, pov, radius, algorithm=None):
+        width, height = transparency.shape
+        visible = np.zeros((width, height), dtype=bool)
+        px, py = pov
+        for x in range(width):
+            for y in range(height):
+                if abs(x - px) + abs(y - py) <= radius:
+                    visible[x, y] = True
+        return visible
+
+    tcod_map.compute_fov = compute_fov
+
+    # tcod.console
+    tcod_console = types.ModuleType("tcod.console")
+
+    class Console:
+        def __init__(self, width, height, order="F") -> None:  # pragma: no cover - stub
+            self.width = width
+            self.height = height
+
+    tcod_console.Console = Console
+
+    # tcod.context
+    tcod_context = types.ModuleType("tcod.context")
+
+    class _DummyContext:
+        def __enter__(self):  # pragma: no cover - stub
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - stub
+            return None
+
+        def convert_event(self, event) -> None:  # pragma: no cover - stub
+            return None
+
+        def present(self, console) -> None:  # pragma: no cover - stub
+            return None
+
+    def new(*args, **kwargs):  # pragma: no cover - stub
+        return _DummyContext()
+
+    tcod_context.new = new
+
+    # tcod.event
+    tcod_event = types.ModuleType("tcod.event")
+
+    class Event:  # pragma: no cover - stub
+        pass
+
+    class KeyDown(Event):  # pragma: no cover - stub
+        def __init__(self, sym: int) -> None:
+            self.sym = sym
+
+    class Quit(Event):  # pragma: no cover - stub
+        pass
+
+    class EventDispatch:  # pragma: no cover - stub
+        def __class_getitem__(cls, item):  # pragma: no cover - stub
+            return cls
+
+        def dispatch(self, event):
+            method_name = f"ev_{event.__class__.__name__.lower()}"
+            handler = getattr(self, method_name, None)
+            if handler:
+                return handler(event)
+            return None
+
+    def wait():  # pragma: no cover - stub
+        return []
+
+    for code, name in enumerate(
+        [
+            "K_UP",
+            "K_DOWN",
+            "K_LEFT",
+            "K_RIGHT",
+            "K_HOME",
+            "K_END",
+            "K_PAGEUP",
+            "K_PAGEDOWN",
+            "K_KP_1",
+            "K_KP_2",
+            "K_KP_3",
+            "K_KP_4",
+            "K_KP_5",
+            "K_KP_6",
+            "K_KP_7",
+            "K_KP_8",
+            "K_KP_9",
+            "K_PERIOD",
+            "K_g",
+            "K_d",
+            "K_i",
+            "K_u",
+            "K_ESCAPE",
+        ]
+    ):
+        setattr(tcod_event, name, code)
+
+    tcod_event.Event = Event
+    tcod_event.KeyDown = KeyDown
+    tcod_event.Quit = Quit
+    tcod_event.EventDispatch = EventDispatch
+    tcod_event.wait = wait
+
+    # tcod.tileset
+    tcod_tileset = types.ModuleType("tcod.tileset")
+
+    def load_truetype_font(*args, **kwargs):  # pragma: no cover - stub
+        class _TileSet:
+            pass
+
+        return _TileSet()
+
+    tcod_tileset.load_truetype_font = load_truetype_font
+
+    # tcod.path
+    tcod_path = types.ModuleType("tcod.path")
+
+    class SimpleGraph:  # pragma: no cover - stub
+        def __init__(self, cost, cardinal=2, diagonal=3) -> None:
+            self.cost = cost
+
+    class Pathfinder:  # pragma: no cover - stub
+        def __init__(self, graph: SimpleGraph) -> None:
+            self._root = (0, 0)
+
+        def add_root(self, root) -> None:
+            self._root = root
+
+        def path_to(self, target):
+            return np.array([self._root, target], dtype=object)
+
+    tcod_path.SimpleGraph = SimpleGraph
+    tcod_path.Pathfinder = Pathfinder
+
+    # Register modules
+    tcod.console = tcod_console
+    tcod.context = tcod_context
+    tcod.event = tcod_event
+    tcod.tileset = tcod_tileset
+    tcod.map = tcod_map
+    tcod.path = tcod_path
+    tcod.FOV_RESTRICTIVE = 0
+
+    sys.modules["tcod"] = tcod
+    sys.modules["tcod.console"] = tcod_console
+    sys.modules["tcod.context"] = tcod_context
+    sys.modules["tcod.event"] = tcod_event
+    sys.modules["tcod.tileset"] = tcod_tileset
+    sys.modules["tcod.map"] = tcod_map
+    sys.modules["tcod.path"] = tcod_path
+
+
+_install_tcod_stub()
+
+from ai_roguelike.environment import create_sample_environment, render_ascii
+from ai_roguelike.mcts import MCTSAgent
+
+
+@pytest.mark.parametrize("seed", [7, 21])
+def test_agent_advances_through_sample_dungeon(seed: int) -> None:
+    env = create_sample_environment(seed=seed)
+    agent = MCTSAgent(iterations=32, rollout_depth=3, exploration_weight=1.1)
+
+    max_turns = 6
+    for _ in range(max_turns):
+        if env.is_terminal:
+            break
+        action, _ = agent.choose_action(env)
+        reward, done = env.apply_action(action)
+        # The heuristic reward is bounded and should not be NaN/inf.
+        assert reward == reward  # NaN guard
+        assert abs(reward) < 1_000
+        if done:
+            break
+
+    summary = env.summary()
+    assert summary["turn"] <= max_turns
+    # Either the player is still alive or the run terminated due to success/failure.
+    assert env.engine.player.is_alive or env.is_terminal
+
+
+def test_ascii_renderer_contains_player_glyph() -> None:
+    env = create_sample_environment(seed=11)
+    ascii_map = render_ascii(env.engine, reveal=True)
+    assert "@" in ascii_map


### PR DESCRIPTION
## Summary
- add an AI Roguelike package with a headless environment wrapper, Monte Carlo planner, and CLI for running sample dungeons
- document dependencies and mark challenge #71 as solved, including a dedicated README and extras entry
- add smoke tests with a lightweight tcod stub so automated runs cover multiple turns without crashes

## Testing
- pytest tests/test_ai_roguelike_smoke.py

------
https://chatgpt.com/codex/tasks/task_b_68df529590688323927f8dd3f4d2e81e