### PR TITLE
Add NumPy-based MLP with MNIST tooling

### DIFF
--- a/Artificial Intelligence/README.md
+++ b/Artificial Intelligence/README.md
@@ -4,8 +4,11 @@ This folder contains a collection of classic and educational artificial intellig
 
 ## Contents
 
-- **Basic Neural Network (`BNN.py`)**  
+- **Basic Neural Network (`BNN.py`)**
   A simple, from-scratch implementation of a feedforward neural network. Great for learning the fundamentals of neural nets and backpropagation.
+
+- **Real Neural Network (`Real Neural Network/`)**
+  A NumPy-only multilayer perceptron with configurable depth, MNIST training script, evaluation CLI, and reusable checkpoint format.
 
 - **Connect4 (`c4.py`)**  
   A playable Connect Four game with a basic AI opponent. Demonstrates game logic, state evaluation, and simple AI strategies.

--- a/Artificial Intelligence/Real Neural Network/README.md
+++ b/Artificial Intelligence/Real Neural Network/README.md
@@ -1,0 +1,94 @@
+# Real Neural Network (Challenge #75)
+
+This project implements a configurable multilayer perceptron (MLP) using
+NumPy matrix operations only.  It can be trained on MNIST from
+OpenML and includes scripts for evaluation and model serialization.
+
+## Features
+
+- Arbitrary depth network with ReLU/Tanh/Sigmoid hidden activations
+- Mini-batch gradient descent with optional L2 regularisation
+- Softmax output layer with cross-entropy loss
+- Checkpoint saving/loading via compressed `.npz` files
+- Training history export for plotting
+
+## Usage
+
+Install the AI extras to grab the required dependencies:
+
+```bash
+python -m pip install -e .[ai,developer]
+```
+
+### Training
+
+```bash
+python "Artificial Intelligence/Real Neural Network/train.py" \
+    --hidden-layers 256 128 \
+    --epochs 15 \
+    --batch-size 128 \
+    --learning-rate 0.01 \
+    --model-out mnist-mlp.npz
+```
+
+Key hyperparameters:
+
+- `--hidden-layers`: Sequence of hidden layer sizes (default: `128 64`)
+- `--epochs`: Number of passes over the training data (default: `10`)
+- `--batch-size`: Mini-batch size for gradient descent (default: `64`)
+- `--learning-rate`: Optimisation step size (default: `0.01`)
+- `--l2`: L2 regularisation strength (default: `0.0`)
+- `--validation-split`: Fraction of the training split used for
+  validation metrics (default: `0.1`)
+- `--data-home`: Cache directory for downloaded datasets
+
+Training prints per-epoch metrics, persists the model weights, and writes
+a `*.history.npz` file containing the loss/accuracy curves.
+
+### Evaluation
+
+```bash
+python "Artificial Intelligence/Real Neural Network/evaluate.py" mnist-mlp.npz
+```
+
+This reloads the saved checkpoint, recreates the MNIST split using the
+same random seed, and reports loss, accuracy, and a confusion matrix.
+The optional `--limit` flag constrains evaluation to the first *N*
+samples of the test split for quick smoke tests.
+
+### Module API
+
+You can also import the `MLP` class directly for use in notebooks or
+other scripts:
+
+```python
+from pathlib import Path
+import numpy as np
+
+from mlp import MLP
+
+model = MLP([4, 8, 3], seed=0)
+X = np.random.rand(32, 4)
+y = np.random.randint(0, 3, size=32)
+model.fit(X, y, epochs=25, batch_size=16)
+model.save(Path("toy_model.npz"))
+```
+
+The weights are stored in compressed NumPy archives with keys `W0`,
+`b0`, etc., making it easy to inspect or port to other frameworks.
+
+## Files
+
+- `mlp.py` – core MLP implementation
+- `data.py` – helper utilities for dataset loading
+- `train.py` – command-line interface for training on MNIST
+- `evaluate.py` – evaluation CLI with confusion matrix reporting
+- `README.md` – this documentation
+
+## Notes
+
+- The MNIST loader uses `sklearn.datasets.fetch_openml`.  Ensure
+  internet access for the initial download or pass a `--data-home`
+  directory containing a cached copy.
+- The model operates entirely in NumPy and is intended for educational
+  purposes rather than state-of-the-art accuracy.

--- a/Artificial Intelligence/Real Neural Network/data.py
+++ b/Artificial Intelligence/Real Neural Network/data.py
@@ -1,0 +1,43 @@
+"""Utilities for loading datasets used by the real neural network project."""
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+from sklearn.datasets import fetch_openml
+from sklearn.model_selection import train_test_split
+
+
+def load_mnist(
+    *,
+    test_size: float = 0.2,
+    random_state: int = 42,
+    data_home: str | None = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return train/test splits for the MNIST dataset.
+
+    Parameters
+    ----------
+    test_size:
+        Proportion of the dataset to include in the test split.
+    random_state:
+        Seed controlling the train/test split.
+    data_home:
+        Optional directory where the dataset is cached.
+    """
+
+    mnist = fetch_openml(
+        "mnist_784",
+        version=1,
+        as_frame=False,
+        data_home=data_home,
+    )
+    X = mnist.data.astype(np.float32) / 255.0
+    y = mnist.target.astype(np.int64)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=random_state, stratify=y
+    )
+    return X_train, X_test, y_train, y_test
+
+
+__all__ = ["load_mnist"]

--- a/Artificial Intelligence/Real Neural Network/evaluate.py
+++ b/Artificial Intelligence/Real Neural Network/evaluate.py
@@ -1,0 +1,65 @@
+"""Evaluate a trained NumPy MLP checkpoint on MNIST."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from data import load_mnist
+from mlp import MLP
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model", type=Path, help="Path to the saved .npz checkpoint")
+    parser.add_argument(
+        "--data-home",
+        type=Path,
+        default=None,
+        help="Directory used to cache the dataset",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional limit of test samples to evaluate",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed used to reproduce the train/test split",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+
+    X_train, X_test, y_train, y_test = load_mnist(
+        test_size=0.2, random_state=args.seed, data_home=str(args.data_home) if args.data_home else None
+    )
+
+    model = MLP.load(args.model)
+
+    if args.limit is not None:
+        X_test = X_test[: args.limit]
+        y_test = y_test[: args.limit]
+
+    loss, accuracy = model.evaluate(X_test, y_test)
+    print(f"Loss: {loss:.4f}")
+    print(f"Accuracy: {accuracy:.3f}")
+
+    preds = model.predict(X_test)
+    confusion = np.zeros((model.layer_sizes[-1], model.layer_sizes[-1]), dtype=np.int64)
+    for true_label, pred_label in zip(y_test, preds):
+        confusion[int(true_label), int(pred_label)] += 1
+    np.set_printoptions(linewidth=200)
+    print("Confusion matrix (rows=true, cols=pred):")
+    print(confusion)
+
+
+if __name__ == "__main__":
+    main()

--- a/Artificial Intelligence/Real Neural Network/mlp.py
+++ b/Artificial Intelligence/Real Neural Network/mlp.py
@@ -1,0 +1,287 @@
+"""Multilayer perceptron implementation using NumPy only.
+
+This module exposes the :class:`MLP` class which performs forward and
+backward propagation using matrix operations.  It supports multi-class
+classification with cross-entropy loss and softmax output activation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+
+ActivationCache = Tuple[np.ndarray, np.ndarray]
+
+
+def _relu(z: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    activated = np.maximum(0.0, z)
+    derivative = (z > 0).astype(z.dtype)
+    return activated, derivative
+
+
+def _tanh(z: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    activated = np.tanh(z)
+    derivative = 1.0 - activated**2
+    return activated, derivative
+
+
+def _sigmoid(z: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    activated = 1.0 / (1.0 + np.exp(-z))
+    derivative = activated * (1.0 - activated)
+    return activated, derivative
+
+
+_ACTIVATIONS = {
+    "relu": _relu,
+    "tanh": _tanh,
+    "sigmoid": _sigmoid,
+}
+
+
+@dataclass
+class TrainingHistory:
+    """Container holding metrics captured during :meth:`MLP.fit`."""
+
+    loss: List[float]
+    accuracy: List[float]
+    val_loss: List[float]
+    val_accuracy: List[float]
+
+
+class MLP:
+    """Configurable multilayer perceptron.
+
+    Parameters
+    ----------
+    layer_sizes:
+        Sequence describing the network structure including the input and
+        output dimensions.  Example: ``[784, 128, 64, 10]``.
+    hidden_activation:
+        Activation function for hidden layers (``relu``, ``tanh`` or
+        ``sigmoid``).
+    learning_rate:
+        Step size for gradient descent.
+    l2:
+        Optional L2 regularisation coefficient.
+    seed:
+        Optional random seed to make weight initialisation deterministic.
+    """
+
+    def __init__(
+        self,
+        layer_sizes: Sequence[int],
+        *,
+        hidden_activation: str = "relu",
+        learning_rate: float = 0.01,
+        l2: float = 0.0,
+        seed: Optional[int] = None,
+    ) -> None:
+        if len(layer_sizes) < 2:
+            raise ValueError("layer_sizes must contain input and output dimensions")
+        if hidden_activation not in _ACTIVATIONS:
+            raise ValueError(f"Unsupported activation '{hidden_activation}'")
+
+        self.layer_sizes = list(layer_sizes)
+        self.hidden_activation_name = hidden_activation
+        self.hidden_activation = _ACTIVATIONS[hidden_activation]
+        self.learning_rate = float(learning_rate)
+        self.l2 = float(l2)
+        self.rng = np.random.default_rng(seed)
+
+        self.weights: List[np.ndarray] = []
+        self.biases: List[np.ndarray] = []
+        self._initialise_parameters()
+
+    # ------------------------------------------------------------------
+    # Initialisation and serialization
+    # ------------------------------------------------------------------
+    def _initialise_parameters(self) -> None:
+        self.weights.clear()
+        self.biases.clear()
+        for fan_in, fan_out in zip(self.layer_sizes[:-1], self.layer_sizes[1:]):
+            limit = np.sqrt(6.0 / (fan_in + fan_out))
+            self.weights.append(self.rng.uniform(-limit, limit, size=(fan_in, fan_out)))
+            self.biases.append(np.zeros((1, fan_out)))
+
+    def to_dict(self) -> Dict[str, np.ndarray]:
+        data: Dict[str, np.ndarray] = {
+            "layer_sizes": np.array(self.layer_sizes, dtype=np.int64),
+        }
+        for idx, (w, b) in enumerate(zip(self.weights, self.biases)):
+            data[f"W{idx}"] = w
+            data[f"b{idx}"] = b
+        return data
+
+    def save(self, path: str | "os.PathLike[str]") -> None:
+        np.savez_compressed(path, **self.to_dict())
+
+    @classmethod
+    def load(
+        cls,
+        path: str | "os.PathLike[str]",
+        *,
+        hidden_activation: str = "relu",
+        learning_rate: float = 0.01,
+        l2: float = 0.0,
+    ) -> "MLP":
+        data = np.load(path, allow_pickle=False)
+        layer_sizes = data["layer_sizes"].tolist()
+        network = cls(
+            layer_sizes,
+            hidden_activation=hidden_activation,
+            learning_rate=learning_rate,
+            l2=l2,
+        )
+        for idx in range(len(layer_sizes) - 1):
+            network.weights[idx] = data[f"W{idx}"]
+            network.biases[idx] = data[f"b{idx}"]
+        return network
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+    def forward(self, X: np.ndarray) -> Tuple[np.ndarray, List[ActivationCache]]:
+        activations: List[ActivationCache] = []
+        a = X
+        for idx, (w, b) in enumerate(zip(self.weights, self.biases)):
+            z = a @ w + b
+            if idx == len(self.weights) - 1:
+                # Output layer -> softmax
+                exp_z = np.exp(z - np.max(z, axis=1, keepdims=True))
+                a = exp_z / np.sum(exp_z, axis=1, keepdims=True)
+                derivative = a * (1.0 - a)
+            else:
+                a, derivative = self.hidden_activation(z)
+            activations.append((a, derivative))
+        return a, activations
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        probs, _ = self.forward(X)
+        return probs
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return np.argmax(self.predict_proba(X), axis=1)
+
+    def score(self, X: np.ndarray, y: np.ndarray) -> float:
+        return float(np.mean(self.predict(X) == y))
+
+    # ------------------------------------------------------------------
+    def _one_hot(self, y: np.ndarray) -> np.ndarray:
+        n_classes = self.layer_sizes[-1]
+        one_hot = np.zeros((y.shape[0], n_classes), dtype=np.float64)
+        one_hot[np.arange(y.shape[0]), y.astype(int)] = 1.0
+        return one_hot
+
+    def _backward(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        activations: List[ActivationCache],
+    ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+        grads_w = [np.zeros_like(w) for w in self.weights]
+        grads_b = [np.zeros_like(b) for b in self.biases]
+
+        one_hot = self._one_hot(y)
+        probs = activations[-1][0]
+        delta = (probs - one_hot) / X.shape[0]
+
+        for layer in reversed(range(len(self.weights))):
+            a_prev = X if layer == 0 else activations[layer - 1][0]
+            grads_w[layer] = a_prev.T @ delta + self.l2 * self.weights[layer]
+            grads_b[layer] = np.sum(delta, axis=0, keepdims=True)
+            if layer != 0:
+                w = self.weights[layer]
+                derivative = activations[layer - 1][1]
+                delta = (delta @ w.T) * derivative
+        return grads_w, grads_b
+
+    def _update_params(
+        self,
+        grads_w: Sequence[np.ndarray],
+        grads_b: Sequence[np.ndarray],
+    ) -> None:
+        for idx, (gw, gb) in enumerate(zip(grads_w, grads_b)):
+            self.weights[idx] -= self.learning_rate * gw
+            self.biases[idx] -= self.learning_rate * gb
+
+    def _loss(self, probs: np.ndarray, y: np.ndarray) -> float:
+        one_hot = self._one_hot(y)
+        eps = 1e-12
+        loss = -np.sum(one_hot * np.log(probs + eps)) / y.shape[0]
+        if self.l2:
+            loss += (self.l2 / 2.0) * sum(np.sum(w**2) for w in self.weights)
+        return float(loss)
+
+    def fit(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        *,
+        epochs: int = 10,
+        batch_size: int = 32,
+        validation_data: Optional[Tuple[np.ndarray, np.ndarray]] = None,
+        shuffle: bool = True,
+        verbose: bool = False,
+    ) -> TrainingHistory:
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y must contain the same number of samples")
+        n_samples = X.shape[0]
+        history = TrainingHistory([], [], [], [])
+
+        for epoch in range(epochs):
+            indices = np.arange(n_samples)
+            if shuffle:
+                self.rng.shuffle(indices)
+                X, y = X[indices], y[indices]
+
+            for start in range(0, n_samples, batch_size):
+                end = start + batch_size
+                batch_X = X[start:end]
+                batch_y = y[start:end]
+                probs, activations = self.forward(batch_X)
+                grads_w, grads_b = self._backward(batch_X, batch_y, activations)
+                self._update_params(grads_w, grads_b)
+
+            train_probs, _ = self.forward(X)
+            train_loss = self._loss(train_probs, y)
+            train_acc = float(np.mean(np.argmax(train_probs, axis=1) == y))
+
+            if validation_data is not None:
+                val_X, val_y = validation_data
+                val_probs, _ = self.forward(val_X)
+                val_loss = self._loss(val_probs, val_y)
+                val_acc = float(np.mean(np.argmax(val_probs, axis=1) == val_y))
+            else:
+                val_loss = float("nan")
+                val_acc = float("nan")
+
+            history.loss.append(train_loss)
+            history.accuracy.append(train_acc)
+            history.val_loss.append(val_loss)
+            history.val_accuracy.append(val_acc)
+
+            if verbose:
+                if validation_data is not None:
+                    print(
+                        f"Epoch {epoch + 1}/{epochs}: "
+                        f"loss={train_loss:.4f}, acc={train_acc:.3f}, "
+                        f"val_loss={val_loss:.4f}, val_acc={val_acc:.3f}"
+                    )
+                else:
+                    print(
+                        f"Epoch {epoch + 1}/{epochs}: loss={train_loss:.4f}, "
+                        f"acc={train_acc:.3f}"
+                    )
+
+        return history
+
+    def evaluate(self, X: np.ndarray, y: np.ndarray) -> Tuple[float, float]:
+        probs, _ = self.forward(X)
+        loss = self._loss(probs, y)
+        acc = float(np.mean(np.argmax(probs, axis=1) == y))
+        return loss, acc
+
+
+__all__ = ["MLP", "TrainingHistory"]

--- a/Artificial Intelligence/Real Neural Network/train.py
+++ b/Artificial Intelligence/Real Neural Network/train.py
@@ -1,0 +1,144 @@
+"""Train the NumPy MLP on MNIST or a compatible dataset."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from data import load_mnist
+from mlp import MLP
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--hidden-layers",
+        type=int,
+        nargs="*",
+        default=[128, 64],
+        help="Sizes of hidden layers (default: 128 64)",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=10,
+        help="Number of training epochs (default: 10)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Mini-batch size (default: 64)",
+    )
+    parser.add_argument(
+        "--learning-rate",
+        type=float,
+        default=0.01,
+        help="Gradient descent learning rate (default: 0.01)",
+    )
+    parser.add_argument(
+        "--l2",
+        type=float,
+        default=0.0,
+        help="L2 regularisation strength (default: 0.0)",
+    )
+    parser.add_argument(
+        "--model-out",
+        type=Path,
+        default=Path("mlp-mnist.npz"),
+        help="Output path for the trained weights",
+    )
+    parser.add_argument(
+        "--no-shuffle",
+        action="store_true",
+        help="Disable shuffling between epochs",
+    )
+    parser.add_argument(
+        "--data-home",
+        type=Path,
+        default=None,
+        help="Directory used to cache the dataset",
+    )
+    parser.add_argument(
+        "--validation-split",
+        type=float,
+        default=0.1,
+        help="Fraction of the training set used for validation (default: 0.1)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+
+    X_train, X_test, y_train, y_test = load_mnist(
+        test_size=0.2, random_state=args.seed, data_home=str(args.data_home) if args.data_home else None
+    )
+
+    rng = np.random.default_rng(args.seed)
+    permutation = rng.permutation(X_train.shape[0])
+    X_train = X_train[permutation]
+    y_train = y_train[permutation]
+
+    n_classes = len(np.unique(y_train))
+    layer_sizes = [X_train.shape[1], *args.hidden_layers, n_classes]
+
+    model = MLP(
+        layer_sizes,
+        hidden_activation="relu",
+        learning_rate=args.learning_rate,
+        l2=args.l2,
+        seed=args.seed,
+    )
+
+    if not 0.0 <= args.validation_split < 1.0:
+        raise ValueError("validation-split must be in the range [0, 1)")
+
+    if args.validation_split:
+        split = int((1.0 - args.validation_split) * X_train.shape[0])
+        train_X, val_X = X_train[:split], X_train[split:]
+        train_y, val_y = y_train[:split], y_train[split:]
+        validation_data = (val_X, val_y)
+    else:
+        train_X, train_y = X_train, y_train
+        validation_data = None
+
+    history = model.fit(
+        train_X,
+        train_y,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        validation_data=validation_data,
+        shuffle=not args.no_shuffle,
+        verbose=True,
+    )
+
+    train_loss, train_acc = model.evaluate(train_X, train_y)
+    test_loss, test_acc = model.evaluate(X_test, y_test)
+
+    print("Training finished")
+    print(f"Train loss: {train_loss:.4f} | Train accuracy: {train_acc:.3f}")
+    print(f"Test loss:   {test_loss:.4f} | Test accuracy: {test_acc:.3f}")
+
+    model.save(args.model_out)
+    print(f"Model saved to {args.model_out.resolve()}")
+
+    np.savez_compressed(
+        args.model_out.with_suffix(".history.npz"),
+        loss=np.array(history.loss),
+        accuracy=np.array(history.accuracy),
+        val_loss=np.array(history.val_loss),
+        val_accuracy=np.array(history.val_accuracy),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ The solutions are organized by category and difficulty, making it easy to naviga
 
 ## Progress
 
-<progress value="99" max="131"></progress>
+<progress value="100" max="131"></progress>
 
-**Overall:** 99 / 131 challenges completed (75.6%).
+**Overall:** 100 / 131 challenges completed (76.3%).
 
 | Category | Completed | Total | Progress |
 | --- | --- | --- | --- |
 | Practical | 53 | 53 | 100% |
 | Algorithmic | 27 | 27 | 100% |
-| Artificial Intelligence | 3 | 8 | 37.5% |
+| Artificial Intelligence | 4 | 8 | 50.0% |
 | Emulation/Modeling | 6 | 14 | 42.9% |
 | Games | 10 | 29 | 34.5% |
 
@@ -195,7 +195,7 @@ The repository includes a GitHub Actions workflow at `.github/workflows/keep-str
 | 72 | Sudoku/n-Puzzle Solver using A* algorithm | [View Solution](./Artificial%20Intelligence/Sudoku/) |
 | 73 | Connect-4 AI Player using Alpha-Beta Pruning | [View Solution](./Artificial%20Intelligence/Connect4/) |
 | 74 | Basic Neural Network - Simulate individual neurons and their connections | [View Solution](./Artificial%20Intelligence/Basic%20Neural%20Network/) |
-| 75 | Real Neural Network - Implement a basic feed-forward neural network using matrices for entire layers along with matrix operations for computations. | Not Yet |
+| 75 | Real Neural Network - Implement a basic feed-forward neural network using matrices for entire layers along with matrix operations for computations. | [View Solution](./Artificial%20Intelligence/Real%20Neural%20Network/) |
 | 76 | Convolutional Neural Network: Implement a convolutional N.N. for a handwritten digit recognition test on MNIST dataset (Use TensorFlow Theano etc...) | Not Yet |
 | 77 | Convolutional Neural Network: Implement your own convolutional neural network for handwritten digit recognition test on MNIST Dataset (Without TensorFlow Theano etc...) | Not Yet |
 

--- a/tests/artificial_intelligence/test_real_neural_network.py
+++ b/tests/artificial_intelligence/test_real_neural_network.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+
+def load_mlp_module():
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "Artificial Intelligence"
+        / "Real Neural Network"
+        / "mlp.py"
+    )
+    spec = importlib.util.spec_from_file_location("mlp", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    import sys
+
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mlp_module = load_mlp_module()
+MLP = mlp_module.MLP
+
+
+def test_forward_pass_shape():
+    model = MLP([3, 5, 2], seed=0)
+    X = np.random.default_rng(0).normal(size=(7, 3))
+    probs, _ = model.forward(X)
+    assert probs.shape == (7, 2)
+    np.testing.assert_allclose(probs.sum(axis=1), 1.0, rtol=1e-6, atol=1e-6)
+
+
+def test_training_improves_loss():
+    X = np.array(
+        [
+            [0.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 0.0],
+            [1.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    y = np.array([0, 1, 1, 0], dtype=np.int64)
+
+    model = MLP([2, 4, 2], learning_rate=0.5, seed=1)
+    initial_loss, initial_acc = model.evaluate(X, y)
+
+    model.fit(X, y, epochs=250, batch_size=4, shuffle=False, verbose=False)
+    final_loss, final_acc = model.evaluate(X, y)
+
+    assert final_loss < initial_loss
+    assert final_acc > initial_acc
+    assert final_acc >= 0.75
+
+
+def test_serialisation_roundtrip(tmp_path):
+    X = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.float64)
+    y = np.array([0, 1], dtype=np.int64)
+
+    model = MLP([2, 3, 2], learning_rate=0.3, seed=123)
+    model.fit(X, y, epochs=50, batch_size=2, shuffle=False)
+
+    preds_before = model.predict(X)
+
+    save_path = tmp_path / "mlp-test.npz"
+    model.save(save_path)
+
+    loaded = MLP.load(save_path)
+    preds_after = loaded.predict(X)
+
+    np.testing.assert_array_equal(preds_before, preds_after)


### PR DESCRIPTION
## Summary
- add a configurable NumPy multilayer perceptron implementation with serialization helpers
- provide MNIST training and evaluation scripts plus documentation updates
- cover the network with unit tests and mark challenge #75 as complete

## Testing
- pytest tests/artificial_intelligence/test_real_neural_network.py

------
https://chatgpt.com/codex/tasks/task_b_68df52967c0883238759d8ba6633f412