### PR TITLE
Add Git LFS setup guide and link it from docs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+---
+name: General Issue
+about: Report a bug, request a feature, or ask a question
+---
+
+## Summary
+
+<!-- Briefly describe the problem or request. -->
+
+## Repro or Context
+
+<!-- Steps, commands, logs, or links that help us reproduce or understand the issue. -->
+
+## Git LFS checklist
+
+- [ ] I have installed Git LFS (`git lfs install`).
+- [ ] I have run `git lfs pull` in the repository root after my last fetch/clone.
+- [ ] Any errors such as `smudge filter failed` have been addressed using the [Git LFS guide](../docs/git-lfs.md).
+
+## Extra details
+
+<!-- Screenshots, environment info (OS, Python version), or anything else that will help. -->

--- a/Games/README.md
+++ b/Games/README.md
@@ -16,6 +16,7 @@ cd Pro-g-rammingChallenges4/Games
 ```
 
 > Working from the repository root? Swap the final line for `cd Pro-g-rammingChallenges4` and prefix game paths with `Games/` in the commands below.
+> ⚠️ **Large assets ahead:** Before launching any game, follow the [Git LFS setup guide](../docs/git-lfs.md) from the repo root and run `git lfs install` / `git lfs pull` so sprites, audio, and models are available locally.
 
 ### 1.2. Create a virtual environment (recommended)
 

--- a/Practical/README.md
+++ b/Practical/README.md
@@ -23,6 +23,8 @@ git clone https://github.com/saintwithataint/Pro-g-rammingChallenges4.git
 cd Pro-g-rammingChallenges4/Practical
 ```
 
+> ⚠️ **Git LFS required:** Before running any tools, visit the [Git LFS setup guide](../docs/git-lfs.md) in the repo root and run `git lfs install` followed by `git lfs pull` so audio samples, pretrained models, and binary assets are present.
+
 ### 1.2. Create a virtual environment (recommended)
 
 ```pwsh

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This repository is a collection of solutions to a wide array of programming prob
 
 The solutions are organized by category and difficulty, making it easy to navigate and find what you're looking for. Many of the projects are implemented in multiple languages to showcase different ways of solving the same problem.
 
+## Prerequisites
+
+- **Git LFS** – Install Git Large File Storage before cloning and run the sync commands from the [Git LFS setup guide](docs/git-lfs.md). Many challenges (games, audio tools, pretrained AI models) rely on large assets stored with LFS, so remember to run `git lfs install` and `git lfs pull` before building or testing.
+
 ## Progress
 
 <progress value="100" max="131"></progress>
@@ -30,6 +34,8 @@ _Progress counts are generated from the actual solution folders in the repositor
 ## How to Contribute (A Guide for New Developers)
 
 While this is a personal project, the principles behind it are universal. If you're starting your own journey of programming challenges, here's a guide to help you get the most out of it:
+
+> **Working in this repo?** Make sure [Git LFS is installed](docs/git-lfs.md) and that you've run `git lfs install` / `git lfs pull` so game assets, audio packs, and pretrained models are available before you start hacking.
 
 1. **Understand the Problem:** Before writing a single line of code, do your research. Draw diagrams, write out the logic, and break the problem down into smaller pieces. If a problem seems too easy, think about how you can add more features or complexity.
 2. **Implement a Solution:** Start with a language you're comfortable with to get a working solution first. Don't worry about writing perfect code on the first try. The goal is to get it working, then you can refactor and improve it.

--- a/docs/git-lfs.md
+++ b/docs/git-lfs.md
@@ -1,0 +1,98 @@
+# Git LFS Setup and Troubleshooting
+
+Many of the projects in this repository track large binary assets (audio samples, sprites, pretrained models) using [Git Large File Storage (LFS)](https://git-lfs.com/). Install Git LFS before cloning or working on the codebase so that all assets download correctly and builds/tests succeed.
+
+## 1. Install Git LFS
+
+| Platform | Installation command |
+| -------- | -------------------- |
+| **Windows** | `winget install Git.GitLFS` or install via the [Git for Windows](https://gitforwindows.org/) installer by selecting the **Git LFS** component. |
+| **macOS** | `brew install git-lfs` (Homebrew) |
+| **Linux (Debian/Ubuntu)** | `sudo apt update && sudo apt install git-lfs` |
+| **Linux (Fedora/RHEL)** | `sudo dnf install git-lfs` |
+| **Other distros** | Refer to the [official package list](https://github.com/git-lfs/git-lfs#installation) or download the binary release. |
+
+> Already cloned the repo? Install Git LFS now, then continue with the steps below.
+
+## 2. Enable Git LFS in your clone
+
+Run the following once per machine (after installing Git LFS):
+
+```bash
+git lfs install
+```
+
+This command configures the global Git hooks that fetch large files and keeps them synced with `git pull`.
+
+## 3. Fetch LFS assets before building or testing
+
+1. Clone the repository as usual:
+   ```bash
+   git clone https://github.com/saintwithataint/Pro-g-rammingChallenges4.git
+   cd Pro-g-rammingChallenges4
+   ```
+2. Pull all tracked large files:
+   ```bash
+   git lfs pull
+   ```
+3. (Optional) Verify that LFS pointers are replaced with real files:
+   ```bash
+   git lfs ls-files
+   ```
+
+Always run `git lfs pull` after switching branches or when new assets land in a pull request. Without this step, many projects (pygame games, audio tools, pretrained models) will fail to load required resources during builds or tests.
+
+## 4. Troubleshooting: `smudge filter failed` errors
+
+The `smudge filter` runs during checkout to replace Git LFS pointers with real files. If it fails, large assets stay as tiny pointer files and downstream builds break. Use the recovery steps below.
+
+### 4.1. Sync LFS files explicitly
+
+```bash
+git lfs pull
+```
+
+This re-downloads any missing assets from the remote and resolves most smudge failures.
+
+### 4.2. Re-check out LFS pointers
+
+If files remain stuck as pointers, force Git to refresh them:
+
+```bash
+git lfs checkout
+```
+
+### 4.3. Clear cached smudge/clean filters
+
+Corrupted LFS cache or hooks can trigger repeated smudge failures. Reset them with:
+
+```bash
+git lfs uninstall
+rm -rf .git/lfs/tmp
+rm -rf .git/lfs/incomplete
+rm -rf .git/hooks/post-checkout .git/hooks/post-merge .git/hooks/pre-push
+git lfs install
+```
+
+Alternatively, clear only the LFS cache:
+
+```bash
+rm -rf .git/lfs/cache
+```
+
+Then repeat `git lfs pull`.
+
+### 4.4. Re-clone as a last resort
+
+If the repository was cloned without Git LFS installed, the cleanest fix is to reinstall Git LFS, remove the existing clone, and re-clone:
+
+```bash
+rm -rf Pro-g-rammingChallenges4
+git clone https://github.com/saintwithataint/Pro-g-rammingChallenges4.git
+cd Pro-g-rammingChallenges4
+git lfs pull
+```
+
+---
+
+Keeping Git LFS healthy ensures sprite sheets, audio packs, and other binary dependencies download with the rest of the source, letting you build and test every project without missing files.


### PR DESCRIPTION
## Summary
- add a Git LFS installation and troubleshooting guide under docs/
- link the new guide from the root README prerequisites plus the Games and Practical quick starts
- add a lightweight issue template that reminds reporters to install/sync Git LFS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68df613774288323b67f4d99dc02bff2