### PR TITLE
Add constructive solid geometry extra and update CI dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[developer,practical]
+          python -m pip install -e .[developer,practical,constructive_solid_geometry]
 
       - name: Run test suite
         env:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The repository now ships a `pyproject.toml` so you can install challenge stacks 
    ```bash
    python -m pip install -e .[practical]
    python -m pip install -e .[algorithmic]
+   python -m pip install -e .[constructive_solid_geometry]
    ```
    Combine extras (e.g., `.[practical,visual]`) or grab everything with `.[all]`.
 3. **Run scripts/tests** directly from the repo. Editable installs keep your checkout in sync with the environment.
@@ -67,6 +68,7 @@ The repository now ships a `pyproject.toml` so you can install challenge stacks 
 | `visual` | Visualization add-ons used across categories | Matplotlib demos, colour-science palettes, VPython spinny cube, FFT spectrum analyzer |
 | `audio` | Audio processing stacks | WAV equalizer, Shazam clone, music streaming |
 | `games` | Python games in `Games/` | Sudoku solver, Simon, Oil Panic tribute |
+| `constructive_solid_geometry` | `Emulation/ConstructiveSolidGeometry/` mesh utilities | Signed-distance field primitives, marching cubes meshing |
 | `ai` | `Artificial Intelligence/` demos | A* Sudoku, Connect4 AI, neural network |
 | `web` | HTTP and dashboard helpers | Imageboard, IP tracking, web crawlers |
 | `desktop` | GUI/automation conveniences | Window manager, key press bot, Tk front-ends |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,10 @@ games = [
 emulation = [
     "pygame>=2.6,<2.7",
 ]
+constructive_solid_geometry = [
+    "scikit-image>=0.24,<0.25",
+    "trimesh>=4.4,<4.5",
+]
 ai = [
     "numpy>=1.26,<2.0",
     "scipy>=1.11,<1.13",


### PR DESCRIPTION
## Summary
- add a `constructive_solid_geometry` extra that installs `scikit-image` and `trimesh`
- update the CI workflow to install the new extra alongside the existing developer stacks
- document the extra in the developer setup instructions

## Testing
- pytest tests/test_constructive_solid_geometry.py

------
https://chatgpt.com/codex/tasks/task_b_68df63913f788323a30839e58eafdde3