### PR TITLE
Handle missing Streamlit ping URL gracefully

### DIFF
--- a/.github/workflows/keep-streamlit-alive.yml
+++ b/.github/workflows/keep-streamlit-alive.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Validate target URL
         run: |
           if [ -z "${TARGET_URL}" ]; then
-            echo "The target URL is not configured. Provide it as a workflow input or configure the STREAMLIT_PING_URL secret." >&2
-            exit 1
+            echo "::warning::No Streamlit target URL configured; skipping keep-alive ping."
+            exit 0
           fi
 
           echo "::add-mask::${TARGET_URL}"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ The repository includes a GitHub Actions workflow at `.github/workflows/keep-str
 
 1. In GitHub, open **Settings → Secrets and variables → Actions** for this repository.
 2. Add a new repository secret named `STREAMLIT_PING_URL` that contains the fully qualified URL of the Streamlit deployment (e.g., `https://example.streamlit.app/`).
-3. Save the secret; the workflow will automatically read the value when it runs on its hourly schedule.
+3. Save the secret; the workflow will automatically read the value when it runs on its hourly schedule. If the secret is missing (or blank), the job now logs a warning and exits successfully instead of failing, so unattended runs will not flap.
+
+### Override the ping target for debugging
+
+When triggering the workflow manually via **Actions → Keep Streamlit deployment alive → Run workflow**, you can provide the optional `target_url` input to override the secret for a single run. This is useful when testing staging environments or validating that the workflow definition still functions end-to-end without touching the production secret.
 
 ### Manually test the keep-alive workflow
 


### PR DESCRIPTION
## Summary
- make the keep-alive workflow warn and exit successfully when no Streamlit URL is configured
- document how to configure the STREAMLIT_PING_URL secret and override the ping target via manual dispatch

## Testing
- bash -c 'set -e; TARGET_URL=""; if [ -z "${TARGET_URL}" ]; then echo "::warning::No Streamlit target URL configured; skipping keep-alive ping."; exit 0; fi; echo "::add-mask::${TARGET_URL}"'
- bash -c 'set -e; TARGET_URL="https://example.com"; if [ -z "${TARGET_URL}" ]; then echo "::warning::No Streamlit target URL configured; skipping keep-alive ping."; exit 0; fi; echo "::add-mask::${TARGET_URL}"; curl --fail --silent --show-error --max-time 2 "$TARGET_URL" || true'


------
https://chatgpt.com/codex/tasks/task_b_68df639c479883239096956bdc966637