### PR TITLE
Synchronize requirements.txt with pyproject extras

### DIFF
--- a/.github/workflows/requirements-sync.yml
+++ b/.github/workflows/requirements-sync.yml
@@ -1,0 +1,19 @@
+name: Ensure requirements.txt matches extras
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Verify requirements sync
+        run: python tools/sync_requirements.py --check

--- a/README.md
+++ b/README.md
@@ -404,17 +404,27 @@ git clone https://github.com/saintwithataint/Pro-g-rammingChallenges4.git
 cd Pro-g-rammingChallenges4
 python -m venv .venv
 . .venv/Scripts/Activate.ps1
-pip install -r requirements.txt
+python -m pip install -e .[practical]
 ```
 
-If you only want a subset (e.g., just run the imageboard or seam carving), install that folder's own `requirements.txt` instead of the root.
+The project uses [`pyproject.toml`](pyproject.toml) extras as the single source of truth for optional stacks. Mix and match the ones you need, for example:
+
+```bash
+# Base algorithms + AI helpers
+python -m pip install -e .[algorithmic,ai]
+
+# Everything including developer tooling
+python -m pip install -e .[all,developer]
+```
+
+The root [`requirements.txt`](requirements.txt) is now generated directly from the extras for compatibility with tools that still expect a requirements file. Regenerate it with `python tools/sync_requirements.py` if you update `pyproject.toml`.
 
 ### 2. Dependency Strategy
 
-* Root `requirements.txt` = superset, categorized (web, imaging, analysis, visualization).
-* Folder-level `requirements.txt` files (e.g. `Practical/`, `Emulation/`) are leaner.
+* `pyproject.toml` extras drive dependency selection; install only what you need (e.g. `python -m pip install -e .[visual]`).
+* Run `python tools/sync_requirements.py` after editing extras to keep the generated `requirements.txt` in sync.
+* Folder-level `requirements.txt` files (e.g. `Practical/`, `Emulation/`) remain available for ultra-minimal installs.
 * Heavy/optional libs (plotly, vpython, scikit-learn, colour-science) can be skipped unless you need those features.
-* Future improvement: adopt `pyproject.toml` with extras (e.g. `pip install .[imageboard]`).
 
 ### 3. Binary Asset Management (Git LFS)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ ai = [
     "numpy>=1.26,<2.0",
     "scipy>=1.11,<1.13",
     "scikit-learn>=1.5,<1.6",
-    "torch>=2.3,<3.0",
+    "torch>=2.5,<2.6",
     "torchvision>=0.18,<0.19",
 ]
 ai_roguelike = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,51 @@
-# Dependency management moved to pyproject.toml.
-# Use extras to install the stacks you need, for example:
-#   python -m pip install -e .[practical]
-#   python -m pip install -e .[algorithmic]
-# See the README "Using pyproject.toml" section for more combinations and details.
+# This file is auto-generated from pyproject.toml optional dependencies.
+# Do not edit by hand; run `python tools/sync_requirements.py`.
 
-# Additional ad-hoc dependencies referenced by individual tools.
-streamlit>=1.37
-streamlit-drawable-canvas>=0.9.3  # Interactive canvas widget for Practical/Paint/streamlit_app.py
+beautifulsoup4>=4.12,<5.0
+boto3>=1.34,<1.35
+colorama>=0.4.6,<0.5
+colour-science>=0.4,<0.5
+cryptography>=42.0,<44.0
+Flask>=3.0,<3.1
+gymnasium>=0.29,<0.30
+imageio>=2.34,<2.35
+librosa>=0.10,<0.11
+markdown>=3.6,<3.7
+matplotlib>=3.8,<3.9
+mido>=1.3,<1.4
+mutagen>=1.47,<1.48
+mypy>=1.11,<1.12
+numpy>=1.26,<2.0
+opencv-python>=4.10,<5.0
+pandas>=2.2,<2.3
+Pillow>=10.4,<10.5
+plotly>=5.22,<5.23
+pyautogui>=0.9,<0.10
+pygame>=2.6,<2.7
+pynput>=1.7,<1.8
+pypdf>=4.3,<4.4
+pyproj>=3.6.1,<3.7
+PySide6>=6.7,<6.8
+pytest>=8.3,<8.4
+python-rtmidi>=1.5,<1.6
+python-xlib>=0.33,<0.34
+PyYAML>=6.0.2,<6.1
+requests>=2.31,<3.0
+ruff>=0.5,<0.6
+scikit-image>=0.24,<0.25
+scikit-learn>=1.5,<1.6
+scipy>=1.11,<1.13
+sounddevice>=0.4,<0.5
+soundfile>=0.12,<0.13
+stable-baselines3>=2.3,<2.4
+streamlit-drawable-canvas>=0.9.3,<0.10
+streamlit==1.50.0
+sympy>=1.12,<1.15
+tcod>=16.2,<17.0
+tkhtmlview>=0.3.1,<0.4
+torch>=2.5,<2.6
+torchvision>=0.18,<0.19
+tqdm>=4.66,<4.67
+trimesh>=4.4,<4.5
+vpython>=7.6,<7.7
+yt-dlp>=2024.7.1

--- a/tools/sync_requirements.py
+++ b/tools/sync_requirements.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Synchronize requirements.txt with pyproject optional dependencies."""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError as exc:  # pragma: no cover - fallback for old interpreters
+    raise SystemExit("Python 3.11+ is required to run this script") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+REQUIREMENTS = ROOT / "requirements.txt"
+
+
+def load_optional_dependencies() -> dict[str, list[str]]:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    extras = project.get("optional-dependencies")
+    if extras is None:
+        raise SystemExit("[project.optional-dependencies] section is missing in pyproject.toml")
+    return extras
+
+
+NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+")
+
+
+def normalize_requirement(requirement: str) -> str:
+    """Normalize requirement for consistent key lookup."""
+    requirement = requirement.strip()
+    if not requirement:
+        return ""
+    # Split off environment markers if present.
+    marker_split = requirement.split(";", 1)
+    req_part = marker_split[0]
+    # Remove extras specification for the key.
+    bracket_split = req_part.split("[", 1)
+    name_part = bracket_split[0].strip()
+    match = NAME_RE.match(name_part)
+    if not match:
+        raise SystemExit(f"Unable to determine requirement name for entry: '{requirement}'")
+    return match.group(0).lower()
+
+
+def build_requirement_set(extras: dict[str, list[str]]) -> list[str]:
+    seen: dict[str, str] = {}
+    for group_name, deps in extras.items():
+        for dep in deps:
+            key = normalize_requirement(dep)
+            if not key:
+                continue
+            if key in seen:
+                # All duplicates should agree on the exact specifier; if not, fail fast.
+                if seen[key] != dep:
+                    raise SystemExit(
+                        "Conflicting requirement specifications detected for "
+                        f"'{key}': '{seen[key]}' vs '{dep}'."
+                    )
+            else:
+                seen[key] = dep
+    return sorted(seen.values(), key=lambda value: value.lower())
+
+
+def render_requirements(requirements: list[str]) -> str:
+    header = (
+        "# This file is auto-generated from pyproject.toml optional dependencies.\n"
+        "# Do not edit by hand; run `python tools/sync_requirements.py`.\n\n"
+    )
+    return header + "\n".join(requirements) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify requirements.txt is up-to-date without modifying it",
+    )
+    args = parser.parse_args(argv)
+
+    extras = load_optional_dependencies()
+    requirements = build_requirement_set(extras)
+    content = render_requirements(requirements)
+
+    if args.check:
+        current = REQUIREMENTS.read_text(encoding="utf-8") if REQUIREMENTS.exists() else ""
+        if current != content:
+            print("requirements.txt is out of sync with pyproject.toml optional dependencies.")
+            print("Run `python tools/sync_requirements.py` to regenerate the file.")
+            return 1
+        print("requirements.txt is up to date.")
+        return 0
+
+    REQUIREMENTS.write_text(content, encoding="utf-8")
+    print("requirements.txt regenerated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- regenerate requirements.txt directly from the optional dependencies declared in pyproject.toml
- document extras-based installation flow and align the AI extra's torch pin with the shared range
- add a sync script and CI check that keeps requirements.txt in lockstep with pyproject.toml

## Testing
- python tools/sync_requirements.py --check
- python -m compileall tools/sync_requirements.py

------
https://chatgpt.com/codex/tasks/task_b_68df63a3c80483238cc48cc5f7a2a953