### PR TITLE
Apply review improvements across games

### DIFF
--- a/Games/64kDemo/build.py
+++ b/Games/64kDemo/build.py
@@ -1,36 +1,95 @@
 #!/usr/bin/env python3
+"""Bundle and compress the 64k demo using esbuild for robustness."""
+
+from __future__ import annotations
+
 import gzip
-import re
+import shutil
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).parent
 SRC = ROOT / "src"
 DIST = ROOT / "dist"
-DIST.mkdir(exist_ok=True)
-html = (SRC / "index.html").read_text()
-js = (SRC / "main.js").read_text()
 
 
-def minify_js(code: str) -> str:
-    code = re.sub(r"//.*", "", code)
-    code = re.sub(r"/\*.*?\*/", "", code, flags=re.S)
-    code = re.sub(r"\s+", " ", code)
-    return code.strip()
+class BuildError(RuntimeError):
+    """Raised when the bundler encounters a fatal error."""
+
+
+def bundle_js(entry: Path) -> str:
+    """Run esbuild (via local install or npx) and return the bundled source."""
+
+    esbuild = shutil.which("esbuild")
+    npx = shutil.which("npx")
+    commands = []
+    if esbuild:
+        commands.append([esbuild])
+    if npx:
+        commands.append([npx, "esbuild"])
+    if not commands:
+        raise BuildError(
+            "esbuild is required for bundling. Install it globally or ensure 'npx' is available."
+        )
+
+    with tempfile.NamedTemporaryFile(suffix=".js", delete=False) as tmp:
+        outfile = Path(tmp.name)
+
+    for prefix in commands:
+        cmd = [
+            *prefix,
+            str(entry),
+            "--bundle",
+            "--minify",
+            "--format=iife",
+            "--target=es2017",
+            f"--outfile={outfile}",
+            "--log-level=error",
+        ]
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True)
+            result = outfile.read_text(encoding="utf-8")
+            outfile.unlink(missing_ok=True)
+            return result
+        except FileNotFoundError:
+            continue
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - surfaced to CLI
+            outfile.unlink(missing_ok=True)
+            raise BuildError(exc.stderr or "esbuild failed to bundle the entry point")
+
+    outfile.unlink(missing_ok=True)
+    raise BuildError("Unable to execute esbuild via installed binary or npx.")
 
 
 def minify_html(text: str) -> str:
-    text = re.sub(r">\s+", " >", text)
-    text = re.sub(r"\s+<", "<", text)
-    text = re.sub(r"\s+", " ", text)
-    return text.strip()
+    """Whitespace-only HTML minifier that preserves inline scripts/styles."""
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return "".join(lines)
 
 
-packed_html = html.replace(
-    '<script src="main.js"></script>', f"<script>{minify_js(js)}</script>"
-)
-packed_html = minify_html(packed_html)
-(DIST / "index.html").write_text(packed_html)
-with gzip.open(DIST / "index.html.gz", "wb", compresslevel=9) as f:
-    f.write(packed_html.encode("utf-8"))
-print("minified bytes:", len(packed_html.encode("utf-8")))
-print("gzipped bytes:", (DIST / "index.html.gz").stat().st_size)
+def build() -> None:
+    DIST.mkdir(exist_ok=True)
+    html = (SRC / "index.html").read_text(encoding="utf-8")
+    try:
+        js_bundle = bundle_js(SRC / "main.js")
+    except BuildError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    packed_html = html.replace(
+        '<script src="main.js"></script>', f"<script>{js_bundle}</script>"
+    )
+    packed_html = minify_html(packed_html)
+    output = DIST / "index.html"
+    output.write_text(packed_html, encoding="utf-8")
+    with gzip.open(DIST / "index.html.gz", "wb", compresslevel=9) as fh:
+        fh.write(packed_html.encode("utf-8"))
+    print("minified bytes:", len(packed_html.encode("utf-8")))
+    print("gzipped bytes:", (DIST / "index.html.gz").stat().st_size)
+
+
+if __name__ == "__main__":
+    build()

--- a/Games/Connect4/connect4.py
+++ b/Games/Connect4/connect4.py
@@ -1,45 +1,60 @@
-import numpy as np
-import pygame
-import sys
-import math
-from typing import Tuple, List, Optional
+"""Pygame implementation of the Connect 4 board game."""
 
-# --- Constants ---
-# Colors
-BLUE = (20, 50, 200)
-BLACK = (0, 0, 0)
-RED = (210, 40, 40)
-YELLOW = (255, 200, 0)
-
-# Board dimensions
-ROW_COUNT = 6
-COLUMN_COUNT = 7
-WINDOW_LENGTH = 4
-
-# Player pieces
-PLAYER_1_PIECE = 1
-
-"""
-Connect 4 Game (Two Player, Pygame)
-Modern, well-documented, and beginner-friendly implementation.
-"""
+from dataclasses import dataclass
+from typing import Deque, Iterable, List, Optional, Tuple
 
 import numpy as np
 import pygame
 import sys
-from typing import Tuple, List, Optional
+from collections import deque
 
-# --- Constants ---
-BLUE = (20, 50, 200)  # Board color
-BLACK = (0, 0, 0)  # Background and empty slot color
-RED = (210, 40, 40)  # Player 1 color
-YELLOW = (255, 200, 0)  # Player 2 color
 
-ROW_COUNT = 6
-COLUMN_COUNT = 7
-WINDOW_LENGTH = 4
-PLAYER_1_PIECE = 1
-PLAYER_2_PIECE = 2
+@dataclass(frozen=True)
+class Connect4Config:
+    """Configuration container so constants stay in one place."""
+
+    rows: int = 6
+    columns: int = 7
+    window_length: int = 4
+    board_colour: Tuple[int, int, int] = (20, 50, 200)
+    background_colour: Tuple[int, int, int] = (0, 0, 0)
+    player_colours: Tuple[Tuple[int, int, int], Tuple[int, int, int]] = (
+        (210, 40, 40),
+        (255, 200, 0),
+    )
+    message_colour: Tuple[int, int, int] = (255, 255, 255)
+
+    @property
+    def player_1_piece(self) -> int:
+        return 1
+
+    @property
+    def player_2_piece(self) -> int:
+        return 2
+
+
+class InputController:
+    """Normalises pygame events into queued intents."""
+
+    def __init__(self) -> None:
+        self._clicks: Deque[int] = deque()
+        self._quit_requested = False
+
+    def pump(self, events: Iterable[pygame.event.Event]) -> None:
+        for event in events:
+            if event.type == pygame.QUIT:
+                self._quit_requested = True
+            elif event.type == pygame.MOUSEBUTTONDOWN:
+                self._clicks.append(event.pos[0])
+
+    def pop_click(self) -> Optional[int]:
+        if self._clicks:
+            return self._clicks.popleft()
+        return None
+
+    @property
+    def quit_requested(self) -> bool:
+        return self._quit_requested
 
 
 class Board:
@@ -48,8 +63,11 @@ class Board:
     Board is a 6x7 numpy array. 0 = empty, 1 = Player 1, 2 = Player 2.
     """
 
-    def __init__(self) -> None:
-        self.board: np.ndarray = np.zeros((ROW_COUNT, COLUMN_COUNT), dtype=int)
+    def __init__(self, config: Connect4Config) -> None:
+        self.config = config
+        self.board: np.ndarray = np.zeros(
+            (config.rows, config.columns), dtype=int
+        )
 
     def drop_piece(self, row: int, col: int, piece: int) -> None:
         """Place a piece in the board at the given row and column."""
@@ -57,11 +75,11 @@ class Board:
 
     def is_valid_location(self, col: int) -> bool:
         """Return True if the top cell in the column is empty (valid move)."""
-        return self.board[ROW_COUNT - 1][col] == 0
+        return self.board[self.config.rows - 1][col] == 0
 
     def get_next_open_row(self, col: int) -> Optional[int]:
         """Return the lowest empty row in the given column, or None if full."""
-        for r in range(ROW_COUNT):
+        for r in range(self.config.rows):
             if self.board[r][col] == 0:
                 return r
         return None
@@ -69,30 +87,42 @@ class Board:
     def winning_move(self, piece: int) -> bool:
         """Check if the given piece has a winning position on the board."""
         # Horizontal check
-        for c in range(COLUMN_COUNT - 3):
-            for r in range(ROW_COUNT):
-                if all(self.board[r][c + i] == piece for i in range(WINDOW_LENGTH)):
+        for c in range(self.config.columns - 3):
+            for r in range(self.config.rows):
+                if all(
+                    self.board[r][c + i] == piece
+                    for i in range(self.config.window_length)
+                ):
                     return True
         # Vertical check
-        for c in range(COLUMN_COUNT):
-            for r in range(ROW_COUNT - 3):
-                if all(self.board[r + i][c] == piece for i in range(WINDOW_LENGTH)):
+        for c in range(self.config.columns):
+            for r in range(self.config.rows - 3):
+                if all(
+                    self.board[r + i][c] == piece
+                    for i in range(self.config.window_length)
+                ):
                     return True
         # Positive diagonal
-        for c in range(COLUMN_COUNT - 3):
-            for r in range(ROW_COUNT - 3):
-                if all(self.board[r + i][c + i] == piece for i in range(WINDOW_LENGTH)):
+        for c in range(self.config.columns - 3):
+            for r in range(self.config.rows - 3):
+                if all(
+                    self.board[r + i][c + i] == piece
+                    for i in range(self.config.window_length)
+                ):
                     return True
         # Negative diagonal
-        for c in range(COLUMN_COUNT - 3):
-            for r in range(3, ROW_COUNT):
-                if all(self.board[r - i][c + i] == piece for i in range(WINDOW_LENGTH)):
+        for c in range(self.config.columns - 3):
+            for r in range(3, self.config.rows):
+                if all(
+                    self.board[r - i][c + i] == piece
+                    for i in range(self.config.window_length)
+                ):
                     return True
         return False
 
     def is_full(self) -> bool:
         """Return True if the board is full (no empty slots in top row)."""
-        return 0 not in self.board[ROW_COUNT - 1]
+        return 0 not in self.board[self.config.rows - 1]
 
 
 class Connect4Game:
@@ -101,30 +131,38 @@ class Connect4Game:
     Uses Pygame for rendering and input.
     """
 
-    def __init__(self, square_size: int = 100) -> None:
+    def __init__(
+        self,
+        square_size: int = 100,
+        *,
+        config: Connect4Config | None = None,
+        controller: Optional[InputController] = None,
+    ) -> None:
         pygame.init()
         self.square_size = square_size
-        self.width = COLUMN_COUNT * self.square_size
-        self.height = (ROW_COUNT + 1) * self.square_size
+        self.config = config or Connect4Config()
+        self.width = self.config.columns * self.square_size
+        self.height = (self.config.rows + 1) * self.square_size
         self.radius = int(self.square_size / 2 - 5)
 
         self.screen = pygame.display.set_mode((self.width, self.height))
         pygame.display.set_caption("Connect 4 - Two Player")
         self.font = pygame.font.SysFont("monospace", 75)
 
-        self.board = Board()
+        self.board = Board(self.config)
         self.game_over = False
         self.turn = 0  # 0 for Player 1, 1 for Player 2
+        self.controller = controller or InputController()
 
     def draw_board(self) -> None:
         """Draw the Connect 4 board and all pieces."""
-        self.screen.fill(BLACK)
+        self.screen.fill(self.config.background_colour)
         # Draw the board grid and empty slots
-        for c in range(COLUMN_COUNT):
-            for r in range(ROW_COUNT):
+        for c in range(self.config.columns):
+            for r in range(self.config.rows):
                 pygame.draw.rect(
                     self.screen,
-                    BLUE,
+                    self.config.board_colour,
                     (
                         c * self.square_size,
                         r * self.square_size + self.square_size,
@@ -134,7 +172,7 @@ class Connect4Game:
                 )
                 pygame.draw.circle(
                     self.screen,
-                    BLACK,
+                    self.config.background_colour,
                     (
                         int(c * self.square_size + self.square_size / 2),
                         int(
@@ -146,12 +184,12 @@ class Connect4Game:
                     self.radius,
                 )
         # Draw the pieces
-        for c in range(COLUMN_COUNT):
-            for r in range(ROW_COUNT):
-                if self.board.board[r][c] == PLAYER_1_PIECE:
+        for c in range(self.config.columns):
+            for r in range(self.config.rows):
+                if self.board.board[r][c] == self.config.player_1_piece:
                     pygame.draw.circle(
                         self.screen,
-                        RED,
+                        self.config.player_colours[0],
                         (
                             int(c * self.square_size + self.square_size / 2),
                             self.height
@@ -159,10 +197,10 @@ class Connect4Game:
                         ),
                         self.radius,
                     )
-                elif self.board.board[r][c] == PLAYER_2_PIECE:
+                elif self.board.board[r][c] == self.config.player_2_piece:
                     pygame.draw.circle(
                         self.screen,
-                        YELLOW,
+                        self.config.player_colours[1],
                         (
                             int(c * self.square_size + self.square_size / 2),
                             self.height
@@ -172,7 +210,7 @@ class Connect4Game:
                     )
         # Draw the current player's piece at the top
         if not self.game_over:
-            color = RED if self.turn == 0 else YELLOW
+            color = self.config.player_colours[self.turn]
             posx = pygame.mouse.get_pos()[0]
             pygame.draw.circle(
                 self.screen, color, (posx, int(self.square_size / 2)), self.radius
@@ -187,14 +225,18 @@ class Connect4Game:
         if self.board.is_valid_location(col):
             row = self.board.get_next_open_row(col)
             if row is not None:
-                piece = PLAYER_1_PIECE if self.turn == 0 else PLAYER_2_PIECE
+                piece = (
+                    self.config.player_1_piece
+                    if self.turn == 0
+                    else self.config.player_2_piece
+                )
                 self.board.drop_piece(row, col, piece)
                 if self.board.winning_move(piece):
                     player_num = 1 if self.turn == 0 else 2
-                    color = RED if player_num == 1 else YELLOW
+                    color = self.config.player_colours[player_num - 1]
                     self.end_game(f"Player {player_num} wins!!", color)
                 elif self.board.is_full():
-                    self.end_game("It's a Tie!", BLUE)
+                    self.end_game("It's a Tie!", self.config.board_colour)
                 self.turn = (self.turn + 1) % 2
 
     def end_game(self, message: str, color: Tuple[int, int, int]) -> None:
@@ -206,11 +248,12 @@ class Connect4Game:
     def run(self) -> None:
         """Main game loop: handle events, update display, and manage game state."""
         while True:
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    sys.exit()
-                if event.type == pygame.MOUSEBUTTONDOWN:
-                    self.handle_mouse_click(event.pos[0])
+            self.controller.pump(pygame.event.get())
+            if self.controller.quit_requested:
+                sys.exit()
+            posx = self.controller.pop_click()
+            if posx is not None:
+                self.handle_mouse_click(posx)
             self.draw_board()
             if self.game_over:
                 pygame.time.wait(3000)

--- a/Games/DanmakuEngine/src/main.ts
+++ b/Games/DanmakuEngine/src/main.ts
@@ -75,8 +75,17 @@ function initializeStage(
     stageRunner.update(delta);
     powerUps.update(delta, player);
 
-    for (const bullet of bullets.activeBullets) {
-      if (hitTest(player.position, config.player.hitbox, bullet.position, bullet.definition.hitbox)) {
+    const detectionRadius =
+      Math.max(config.player.hitbox.radius, config.player.grazeBox.radius) + 48;
+    bullets.forEachNearby(player.position, detectionRadius, (bullet) => {
+      if (
+        hitTest(
+          player.position,
+          config.player.hitbox,
+          bullet.position,
+          bullet.definition.hitbox
+        )
+      ) {
         const gameOver = player.takeHit();
         if (gameOver) {
           app.ticker.stop();
@@ -85,7 +94,7 @@ function initializeStage(
         player.addGraze(bullet.definition.grazeScore ?? 1);
         player.addScore(50);
       }
-    }
+    });
   });
 }
 

--- a/Games/Tron/networking.js
+++ b/Games/Tron/networking.js
@@ -1,0 +1,165 @@
+export class NetworkManager {
+  constructor(updateCallback, inputCallback, statusCallback) {
+    this.peer = null;
+    this.channel = null;
+    this.role = 'standalone';
+    this.updateCallback = updateCallback;
+    this.inputCallback = inputCallback;
+    this.statusCallback = statusCallback;
+    this.isReady = false;
+    this.pendingPlayerId = null;
+  }
+
+  setRole(role) {
+    this.role = role;
+    if (role === 'standalone') {
+      this.teardown();
+    }
+  }
+
+  teardown() {
+    if (this.channel) {
+      this.channel.close();
+    }
+    if (this.peer) {
+      this.peer.close();
+    }
+    this.peer = null;
+    this.channel = null;
+    this.isReady = false;
+  }
+
+  async createOffer(playerId) {
+    this.pendingPlayerId = playerId;
+    this.peer = new RTCPeerConnection({
+      iceServers: [{ urls: ['stun:stun.l.google.com:19302'] }]
+    });
+    this.channel = this.peer.createDataChannel('tron');
+    this.attachChannel();
+    const offer = await this.peer.createOffer();
+    await this.peer.setLocalDescription(offer);
+    await this.waitForIceGathering();
+    return btoa(JSON.stringify(this.peer.localDescription));
+  }
+
+  async acceptAnswer(answerText) {
+    if (!this.peer) {
+      throw new Error('Create an offer first.');
+    }
+    const answer = JSON.parse(atob(answerText));
+    await this.peer.setRemoteDescription(answer);
+    this.statusCallback('Remote pilot connected.');
+  }
+
+  async submitOffer(offerText, playerId) {
+    this.pendingPlayerId = playerId;
+    this.peer = new RTCPeerConnection({
+      iceServers: [{ urls: ['stun:stun.l.google.com:19302'] }]
+    });
+    this.peer.ondatachannel = (event) => {
+      this.channel = event.channel;
+      this.attachChannel();
+    };
+    await this.peer.setRemoteDescription(JSON.parse(atob(offerText)));
+    const answer = await this.peer.createAnswer();
+    await this.peer.setLocalDescription(answer);
+    await this.waitForIceGathering();
+    return btoa(JSON.stringify(this.peer.localDescription));
+  }
+
+  attachChannel() {
+    this.channel.binaryType = 'arraybuffer';
+    this.channel.onopen = () => {
+      this.isReady = true;
+      this.statusCallback('Data channel ready.');
+      if (this.role === 'client') {
+        this.channel.send(
+          JSON.stringify({
+            type: 'identify',
+            playerId: this.pendingPlayerId
+          })
+        );
+      } else if (this.role === 'host' && this.pendingPlayerId) {
+        this.requestInputControl(this.pendingPlayerId);
+      }
+    };
+    this.channel.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === 'state') {
+          this.updateCallback(data.payload);
+        } else if (data.type === 'requestInput') {
+          this.pendingPlayerId = data.playerId;
+        } else if (data.type === 'identify') {
+          this.pendingPlayerId = data.playerId;
+          this.statusCallback(`Remote pilot ready as ${data.playerId}.`);
+        } else if (data.type === 'input') {
+          this.inputCallback(data.payload);
+        } else if (data.type === 'status') {
+          this.statusCallback(data.payload);
+        }
+      } catch (error) {
+        console.error('Failed to parse network message', error);
+      }
+    };
+    this.channel.onclose = () => {
+      this.statusCallback('Connection closed.');
+      this.isReady = false;
+    };
+  }
+
+  requestInputControl(playerId) {
+    if (!this.channel || this.channel.readyState !== 'open') return;
+    this.channel.send(
+      JSON.stringify({
+        type: 'requestInput',
+        playerId
+      })
+    );
+  }
+
+  sendState(payload) {
+    if (!this.channel || this.channel.readyState !== 'open') return;
+    this.channel.send(
+      JSON.stringify({
+        type: 'state',
+        payload
+      })
+    );
+  }
+
+  sendInput(direction) {
+    if (!this.channel || this.channel.readyState !== 'open') return;
+    this.channel.send(
+      JSON.stringify({
+        type: 'input',
+        payload: direction
+      })
+    );
+  }
+
+  sendStatus(message) {
+    if (!this.channel || this.channel.readyState !== 'open') return;
+    this.channel.send(
+      JSON.stringify({
+        type: 'status',
+        payload: message
+      })
+    );
+  }
+
+  async waitForIceGathering() {
+    if (!this.peer) return;
+    if (this.peer.iceGatheringState === 'complete') return;
+    await new Promise((resolve) => {
+      const checkState = () => {
+        if (!this.peer) return;
+        if (this.peer.iceGatheringState === 'complete') {
+          this.peer.removeEventListener('icegatheringstatechange', checkState);
+          resolve();
+        }
+      };
+      this.peer.addEventListener('icegatheringstatechange', checkState);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- refactor Connect 4 configuration and input handling while modernising several other game-specific systems
- replace the 64k demo bundler with an esbuild pipeline and add caching/spatial indices to Go, Pac-Man, Danmaku, and Tron
- extend the chess AI with a transposition table, allow seeding in Monster Raising, and clean up additional review items

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f11589e8d883308b406f7ad46f3715