### PR TITLE
Fix status bar timeout scheduling in autosave editor

### DIFF
--- a/Practical/AutoSave Text Editor/aste.py
+++ b/Practical/AutoSave Text Editor/aste.py
@@ -84,6 +84,7 @@ class AutosaveTextEditor:
         self.encoding = self.config.encoding
         self.backup_dir = self.config.backup_dir
         self.max_backups = max(0, self.config.max_backups)
+        self._status_after_id: Optional[str] = None
 
         # Event bindings
         self.text_area.bind("<<Modified>>", self._on_modified)
@@ -335,8 +336,17 @@ class AutosaveTextEditor:
 
     def _set_status(self, msg: str) -> None:
         self.status_bar.config(text=msg)
+        if self._status_after_id is not None:
+            with contextlib.suppress(tk.TclError):
+                self.master.after_cancel(self._status_after_id)
+            self._status_after_id = None
+
+        def clear() -> None:
+            self.status_bar.config(text="")
+            self._status_after_id = None
+
         # Clear after 5 seconds
-        self.master.after(5000, lambda: self.status_bar.config(text=""))
+        self._status_after_id = self.master.after(5000, clear)
 
     def _on_close(self) -> None:
         if not self._maybe_discard_changes():

--- a/tests/practical/test_aste_status.py
+++ b/tests/practical/test_aste_status.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Callable
+
+
+def load_aste_module():
+    module_path = (
+        Path(__file__).resolve().parents[2] / "Practical" / "AutoSave Text Editor" / "aste.py"
+    )
+    spec = importlib.util.spec_from_file_location("aste_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeMaster:
+    def __init__(self) -> None:
+        self._next_id = 0
+        self.after_calls: list[tuple[str, int, Callable[[], None]]] = []
+        self.cancelled: list[str] = []
+
+    def after(self, delay_ms: int, func):
+        self._next_id += 1
+        handle = f"after-{self._next_id}"
+        self.after_calls.append((handle, delay_ms, func))
+        return handle
+
+    def after_cancel(self, handle: str) -> None:
+        self.cancelled.append(handle)
+
+
+class FakeStatusBar:
+    def __init__(self) -> None:
+        self.text = ""
+
+    def config(self, *, text: str) -> None:
+        self.text = text
+
+
+def test_set_status_cancels_previous_timeout():
+    module = load_aste_module()
+    AutosaveTextEditor = module.AutosaveTextEditor
+
+    editor = AutosaveTextEditor.__new__(AutosaveTextEditor)
+    editor.master = FakeMaster()
+    editor.status_bar = FakeStatusBar()
+    editor._status_after_id = None
+
+    editor._set_status("First message")
+    first_id = editor._status_after_id
+
+    assert editor.status_bar.text == "First message"
+    assert editor.master.after_calls[-1][1] == 5000
+
+    editor._set_status("Second message")
+    second_id = editor._status_after_id
+
+    assert editor.status_bar.text == "Second message"
+    assert editor.master.cancelled == [first_id]
+    assert first_id != second_id
+
+    # Simulate the timeout firing for the second message.
+    callbacks = {handle: func for handle, _, func in editor.master.after_calls}
+    callbacks[second_id]()
+
+    assert editor.status_bar.text == ""
+    assert editor._status_after_id is None


### PR DESCRIPTION
## Summary
- track the pending status clear callback in `AutosaveTextEditor`
- cancel any previous timeout before scheduling a replacement
- add a regression test that ensures the latest status message remains until its timeout fires

## Testing
- pytest tests/practical/test_aste_status.py

------
https://chatgpt.com/codex/tasks/task_e_68f1f3a8c21c8330a684359ce189387f