### PR TITLE
Remove remaining Streamlit references

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The repository now ships a `pyproject.toml` so you can install challenge stacks 
 
 | Extra | Covers | Highlights |
 | ----- | ------ | ---------- |
-| `practical` | `challenges/Practical/` utilities, desktop apps, and web tools | Flask imageboard, Streamlit dashboards, Seam Carving, Shazam clone |
+| `practical` | `challenges/Practical/` utilities, desktop apps, and web tools | Flask imageboard, Tk dashboards, Seam Carving, Shazam clone |
 | `algorithmic` | `challenges/Algorithmic/` problem set helpers | Steganography, stock analysis, crawler tooling |
 | `visual` | Visualization add-ons used across categories | Matplotlib demos, colour-science palettes, VPython spinny cube, FFT spectrum analyzer |
 | `audio` | Audio processing stacks | WAV equalizer, Shazam clone, music streaming |

--- a/challenges/Practical/Markdown Editor/converter.py
+++ b/challenges/Practical/Markdown Editor/converter.py
@@ -229,10 +229,9 @@ DEFAULT_TEMPLATE_DIR = BASE_DIR / "templates"
 def load_template_manager(template_dir: Optional[Path] = None) -> TemplateManager:
     """Instantiate a :class:`TemplateManager` for ``template_dir``.
 
-    The desktop and Streamlit applications both rely on this helper to lazily
-    construct a manager without importing any Tkinter modules. When
-    ``template_dir`` is ``None`` the default template folder bundled with the
-    project is used.
+    The desktop applications rely on this helper to lazily construct a manager
+    without importing any Tkinter modules. When ``template_dir`` is ``None`` the
+    default template folder bundled with the project is used.
     """
 
     directory = template_dir or DEFAULT_TEMPLATE_DIR

--- a/challenges/Practical/Matrix Arithmetic/matrix_arithmetic.py
+++ b/challenges/Practical/Matrix Arithmetic/matrix_arithmetic.py
@@ -269,7 +269,7 @@ def compute_operation(
     *,
     explain: bool = False,
 ) -> OperationResult:
-    """Dispatch helper shared by the CLI and Streamlit front-ends."""
+    """Dispatch helper shared by the CLI and GUI front-ends."""
 
     operation = operation.lower()
     if operation == "add":

--- a/challenges/Practical/Paint/settings_util.py
+++ b/challenges/Practical/Paint/settings_util.py
@@ -30,7 +30,7 @@ class CanvasSettings:
 
 
 def rgba_from_hex(hex_color: str, alpha: float) -> str:
-    """Convert ``#RRGGBB`` colors to Streamlit-friendly ``rgba()`` strings."""
+    """Convert ``#RRGGBB`` colors to CSS-friendly ``rgba()`` strings."""
 
     hex_color = hex_color.lstrip("#")
     if len(hex_color) != 6:


### PR DESCRIPTION
## Summary
- replace the README highlight so the practical extra no longer advertises Streamlit dashboards
- revise docstrings in the Paint, Markdown Editor, and Matrix Arithmetic helpers to drop the Streamlit wording

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f62b922e6c8330a616343d76e833f1