### PR TITLE
Add RPN stack visualizer and expose evaluation trace hook

### DIFF
--- a/challenges/Algorithmic/RPN Calculator/README.md
+++ b/challenges/Algorithmic/RPN Calculator/README.md
@@ -16,13 +16,22 @@ Evaluate arithmetic expressions written in Reverse Polish Notation (postfix nota
   ```bash
   python postifx_evaluator.py --repl
   ```
+- Visualise the stack evolution while evaluating:
+  ```bash
+  python rpn_visualizer.py --expr "3 4 + 2 *" --mode both
+  ```
+  Use `--export snapshots.json` to persist the trace, and `--load snapshots.json`
+  to replay an existing capture. Pass `--no-animate` for non-clearing output or
+  `--mode table`/`--mode bars` to focus on a single view.
 
 ## Debugging Tips
 - Stack traces help: pass `--trace` to inspect how the operand stack evolves after each token.
+- For richer exploration, `rpn_visualizer.py` can animate the stack with ASCII
+  bar charts or tables and export the token-by-token state sequence as JSON.
 - Known values: `5 !` should return `120`, while `pi 2 / sin` should equal 1.0.
 - Automated tests cover parsing and error conditions:
   ```bash
-  pytest test_rpn.py
+  pytest tests/algorithmic/test_rpn_visualizer.py
   ```
 
 ## Implementation Notes

--- a/challenges/Algorithmic/RPN Calculator/postifx_evaluator.py
+++ b/challenges/Algorithmic/RPN Calculator/postifx_evaluator.py
@@ -49,11 +49,17 @@ def _format_stack(stack: List[Number]) -> str:
     return "[" + ", ".join(f"{x:g}" for x in stack) + "]"
 
 
-def evaluate_rpn(expression: str, *, config: Optional[EvalConfig] = None) -> Number:
+def evaluate_rpn(
+    expression: str,
+    *,
+    config: Optional[EvalConfig] = None,
+    trace_hook: Optional[Callable[[str, List[Number]], None]] = None,
+) -> Number:
     """Evaluate RPN expression and return numeric result.
 
     expression: tokens separated by whitespace.
     config: optional EvalConfig controlling interpretation.
+    trace_hook: optional callable receiving ``(token, stack)`` after each step.
     Raises RPNError on malformed expressions.
     """
     if config is None:
@@ -139,6 +145,8 @@ def evaluate_rpn(expression: str, *, config: Optional[EvalConfig] = None) -> Num
                 raise RPNError(f"Unknown token '{token}'")
         else:
             stack.append(val)
+        if trace_hook is not None:
+            trace_hook(token, list(stack))
         if trace_enabled:
             print(f"token={token:>6} stack={_format_stack(stack)}")
 

--- a/challenges/Algorithmic/RPN Calculator/rpn_visualizer.py
+++ b/challenges/Algorithmic/RPN Calculator/rpn_visualizer.py
@@ -1,0 +1,263 @@
+"""Interactive stack visualizer for the enhanced RPN calculator.
+
+The module exposes a ``capture_stack_snapshots`` helper that hooks into
+``evaluate_rpn`` and records the operand stack after each processed token.
+It also provides a small CLI utility capable of animating the stack evolution
+as ASCII bar charts or textual tables and exporting/importing the snapshot log
+as JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from postifx_evaluator import EvalConfig, RPNError, evaluate_rpn
+
+Number = float
+
+
+@dataclass
+class StackSnapshot:
+    """Token and stack state captured after one evaluation step."""
+
+    token: str
+    stack: List[Number] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        # Store values as floats to ensure JSON serialisability and consistency.
+        self.stack = [float(value) for value in self.stack]
+
+    def as_dict(self) -> dict:
+        return {"token": self.token, "stack": self.stack}
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "StackSnapshot":
+        token = str(payload["token"])
+        stack = [float(value) for value in payload.get("stack", [])]
+        return cls(token=token, stack=stack)
+
+
+SnapshotLog = List[StackSnapshot]
+
+
+def capture_stack_snapshots(
+    expression: str, *, config: Optional[EvalConfig] = None
+) -> Tuple[SnapshotLog, Number]:
+    """Evaluate *expression* while capturing stack snapshots."""
+
+    snapshots: SnapshotLog = []
+
+    def _hook(token: str, stack: List[Number]) -> None:
+        snapshots.append(StackSnapshot(token=token, stack=stack))
+
+    result = evaluate_rpn(expression, config=config, trace_hook=_hook)
+    return snapshots, result
+
+
+def snapshots_to_json(
+    snapshots: SnapshotLog,
+    *,
+    expression: Optional[str] = None,
+    result: Optional[Number] = None,
+) -> dict:
+    """Serialise captured snapshots into a JSON-compatible dictionary."""
+
+    return {
+        "expression": expression,
+        "result": None if result is None else float(result),
+        "frames": [snapshot.as_dict() for snapshot in snapshots],
+    }
+
+
+def snapshots_from_json(payload: dict) -> Tuple[Optional[str], Optional[Number], SnapshotLog]:
+    """Recreate snapshots, expression and result from *payload*."""
+
+    expression = payload.get("expression")
+    result = payload.get("result")
+    frames_payload = payload.get("frames", [])
+    snapshots = [StackSnapshot.from_dict(frame) for frame in frames_payload]
+    return expression, result if result is None else float(result), snapshots
+
+
+def render_bar_chart(snapshot: StackSnapshot) -> str:
+    values = snapshot.stack
+    header = f"Token: {snapshot.token}"
+    if not values:
+        return f"{header}\n(empty stack)"
+
+    max_val = max((abs(v) for v in values), default=1.0)
+    scale = 20.0 / max_val if max_val else 1.0
+    lines = [header]
+    for idx, value in enumerate(values):
+        length = int(round(abs(value) * scale))
+        if length == 0:
+            bar = "·"
+        else:
+            bar = "█" * length
+        prefix = "-" if value < 0 else ""
+        lines.append(f"{idx:>2}: {prefix}{bar} {value:g}")
+    return "\n".join(lines)
+
+
+def render_table(snapshot: StackSnapshot) -> str:
+    header = f"Token: {snapshot.token}"
+    if not snapshot.stack:
+        return f"{header}\n└─ empty"
+
+    lines = [header, "┌──────┬────────────┐", "│ index│ value      │", "├──────┼────────────┤"]
+    for idx, value in enumerate(snapshot.stack):
+        lines.append(f"│ {idx:>4} │ {value:>10g} │")
+    lines.append("└──────┴────────────┘")
+    return "\n".join(lines)
+
+
+def _clear_screen(stream) -> None:
+    if hasattr(stream, "isatty") and stream.isatty():
+        stream.write("\033[2J\033[H")
+    else:
+        stream.write("\n" * 2)
+    stream.flush()
+
+
+def animate_snapshots(
+    snapshots: SnapshotLog,
+    *,
+    mode: str = "bars",
+    delay: float = 0.6,
+    animate: bool = True,
+    stream=sys.stdout,
+) -> None:
+    if not snapshots:
+        stream.write("No snapshots captured.\n")
+        stream.flush()
+        return
+
+    renderers = []
+    if mode in {"bars", "both"}:
+        renderers.append(render_bar_chart)
+    if mode in {"table", "both"}:
+        renderers.append(render_table)
+    if not renderers:
+        raise ValueError(f"Unsupported render mode: {mode}")
+
+    for index, snapshot in enumerate(snapshots):
+        block = "\n\n".join(renderer(snapshot) for renderer in renderers)
+        if animate:
+            _clear_screen(stream)
+            stream.write(block + "\n")
+            stream.flush()
+            time.sleep(max(0.0, delay))
+        else:
+            if index:
+                stream.write("\n" + "-" * 40 + "\n")
+            stream.write(block + "\n")
+    if animate:
+        stream.write("\n")
+        stream.flush()
+
+
+def _load_expression_from_file(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise RPNError(f"Failed to read expression file: {exc}") from exc
+
+
+def _resolve_expression(args: argparse.Namespace) -> str:
+    sources = [bool(args.expr), bool(args.file), args.stdin]
+    if sum(sources) > 1:
+        raise RPNError("Specify only one of --expr/--file/--stdin")
+    if sum(sources) == 0:
+        raise RPNError("Provide an expression via --expr/--file/--stdin")
+    if args.expr:
+        return args.expr
+    if args.file:
+        return _load_expression_from_file(Path(args.file))
+    if args.stdin:
+        return sys.stdin.read().strip()
+    raise RPNError("No expression source provided")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Visualise RPN stack evolution")
+    parser.add_argument("--expr", help="Evaluate and visualise this expression")
+    parser.add_argument("--file", help="Read expression from file")
+    parser.add_argument("--stdin", action="store_true", help="Read expression from stdin")
+    parser.add_argument("--load", help="Load a previously exported JSON snapshot log")
+    parser.add_argument("--export", help="Write the captured log to JSON")
+    parser.add_argument(
+        "--mode",
+        choices=["bars", "table", "both"],
+        default="bars",
+        help="Rendering mode for the stack visualisation",
+    )
+    parser.add_argument("--delay", type=float, default=0.6, help="Delay between frames in seconds")
+    parser.add_argument("--no-animate", action="store_true", help="Print frames without clearing the screen")
+    parser.add_argument("--deg", action="store_true", dest="degrees", help="Interpret trig inputs as degrees")
+    return parser
+
+
+def _export_snapshots(path: Path, payload: dict) -> None:
+    try:
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError as exc:
+        raise RPNError(f"Failed to write export file: {exc}") from exc
+
+
+def _load_snapshots(path: Path) -> Tuple[Optional[str], Optional[Number], SnapshotLog]:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RPNError(f"Failed to read snapshot log: {exc}") from exc
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise RPNError(f"Invalid JSON payload: {exc}") from exc
+    return snapshots_from_json(payload)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        snapshots: SnapshotLog
+        result: Optional[Number]
+        expression: Optional[str]
+
+        if args.load:
+            expression, result, snapshots = _load_snapshots(Path(args.load))
+        else:
+            expression = _resolve_expression(args)
+            config = EvalConfig(degrees=bool(args.degrees))
+            snapshots, result = capture_stack_snapshots(expression, config=config)
+
+        if args.export:
+            payload = snapshots_to_json(snapshots, expression=expression, result=result)
+            _export_snapshots(Path(args.export), payload)
+
+        animate_snapshots(
+            snapshots,
+            mode=args.mode,
+            delay=args.delay,
+            animate=not args.no_animate,
+            stream=sys.stdout,
+        )
+
+        if result is not None:
+            print(f"Result: {result:g}")
+
+        return 0
+    except RPNError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tests/algorithmic/test_rpn_visualizer.py
+++ b/tests/algorithmic/test_rpn_visualizer.py
@@ -1,0 +1,70 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+CHALLENGE_ROOT = (
+    Path(__file__).resolve().parents[2]
+    / "challenges"
+    / "Algorithmic"
+    / "RPN Calculator"
+)
+
+
+def _load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, CHALLENGE_ROOT / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[call-arg]
+    return module
+
+
+rpn = _load_module("postifx_evaluator", "postifx_evaluator.py")
+visualizer = _load_module("rpn_visualizer", "rpn_visualizer.py")
+
+
+def test_stack_snapshots_follow_expected_progression():
+    expression = "3 4 + 2 *"
+    snapshots, result = visualizer.capture_stack_snapshots(expression)
+
+    tokens = [snap.token for snap in snapshots]
+    stacks = [snap.stack for snap in snapshots]
+
+    assert tokens == ["3", "4", "+", "2", "*"]
+    assert stacks == [
+        [3.0],
+        [3.0, 4.0],
+        [7.0],
+        [7.0, 2.0],
+        [14.0],
+    ]
+    assert pytest.approx(result, rel=1e-12) == 14.0
+
+
+def test_snapshots_respect_degree_mode_for_trig():
+    cfg = rpn.EvalConfig(degrees=True)
+    snapshots, result = visualizer.capture_stack_snapshots("90 sin", config=cfg)
+
+    assert [snap.stack for snap in snapshots] == [[90.0], [1.0]]
+    assert pytest.approx(result, rel=1e-12) == 1.0
+
+
+def test_json_roundtrip_preserves_stack(tmp_path: Path):
+    expression = "2 3 ^ 4 /"
+    snapshots, result = visualizer.capture_stack_snapshots(expression)
+
+    payload = visualizer.snapshots_to_json(
+        snapshots, expression=expression, result=result
+    )
+    file_path = tmp_path / "snapshots.json"
+    file_path.write_text(json.dumps(payload))
+
+    loaded_expression, loaded_result, loaded_snapshots = visualizer.snapshots_from_json(
+        json.loads(file_path.read_text())
+    )
+
+    assert loaded_expression == expression
+    assert pytest.approx(loaded_result, rel=1e-12) == result
+    assert [snap.stack for snap in loaded_snapshots] == [snap.stack for snap in snapshots]


### PR DESCRIPTION
## Summary
- allow `evaluate_rpn` to stream stack updates through an optional callback
- add a CLI visualizer that animates token-by-token stack evolution and supports JSON exports
- expand documentation and automated tests around stack snapshot logging

## Testing
- pytest tests/algorithmic/test_rpn_visualizer.py

------
https://chatgpt.com/codex/tasks/task_e_68f63108d90c8330b1d8d978b8a9bebb