### PR TITLE
Improve ray tracer CLI error handling

### DIFF
--- a/challenges/Emulation/RayTracer/raytracer.py
+++ b/challenges/Emulation/RayTracer/raytracer.py
@@ -556,7 +556,14 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
     if args.scene is not None:
-        scene = load_scene_file(args.scene)
+        try:
+            scene = load_scene_file(args.scene)
+        except FileNotFoundError as exc:
+            parser.error(f"Scene file not found: {exc}")
+        except json.JSONDecodeError as exc:
+            parser.error(
+                f"Failed to parse scene file '{args.scene}': {exc.msg} (line {exc.lineno} column {exc.colno})"
+            )
         # override with CLI additions
         if args.sphere:
             for text in args.sphere:
@@ -598,6 +605,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         height = args.height
     tracer = RayTracer(width=width, height=height, scene=scene)
     image = tracer.render()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
     image.save(args.output)
     if args.show:
         image.show()


### PR DESCRIPTION
## Summary
- report missing or invalid scene files via argparse errors when loading
- create the output image directory before saving renders to disk

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6908be7d79d88330b82469c59d37167b