### PR TITLE
Add stdexcept include to Eulerian path example

### DIFF
--- a/challenges/Emulation/EulerianPath/naive.cpp
+++ b/challenges/Emulation/EulerianPath/naive.cpp
@@ -3,6 +3,7 @@
 #include <queue>
 #include <algorithm>
 #include <string>
+#include <stdexcept>
 
 // -----------------------------------------------------------------------------
 // Eulerian Graph Classification & Connectedness Checker (Undirected Simple Graph)


### PR DESCRIPTION
## Summary
- include <stdexcept> to support invalid_argument and out_of_range usage in the Eulerian path sample

## Testing
- g++ -std=c++17 challenges/Emulation/EulerianPath/naive.cpp -o /tmp/naive

------
https://chatgpt.com/codex/tasks/task_e_6908be7905688330897229fe56dfe9e6