### PR TITLE
Handle mesh generation errors gracefully

### DIFF
--- a/challenges/Emulation/ConstructiveSolidGeometry/cli.py
+++ b/challenges/Emulation/ConstructiveSolidGeometry/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from typing import Tuple
 
 from . import SDF, Bounds, box, cylinder, export_mesh, mesh_from_sdf, plot_mesh, sphere
@@ -112,7 +113,11 @@ def main(argv: list[str] | None = None) -> None:
     primitive_b = parse_primitive(args.primitive_b)
     scene = build_scene(args.operation, primitive_a, primitive_b)
     bounds = parse_bounds(args.bounds)
-    mesh = mesh_from_sdf(scene, bounds=bounds, resolution=args.resolution)
+    try:
+        mesh = mesh_from_sdf(scene, bounds=bounds, resolution=args.resolution)
+    except ValueError as exc:
+        print(str(exc))
+        sys.exit(1)
 
     print(
         f"Vertices: {len(mesh.vertices)} | Faces: {len(mesh.faces)} | Volume: {mesh.volume:.4f}"


### PR DESCRIPTION
## Summary
- add sys import to support exiting the CLI with a non-zero status
- wrap mesh generation in a try/except block to catch ValueError
- report the error message to the user and exit with status code 1 when mesh generation fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908be77bde48330ad3f1daac1893c3c