### PR TITLE
Ensure complementary color tool creates output directories

### DIFF
--- a/challenges/Emulation/CompColor/comp.py
+++ b/challenges/Emulation/CompColor/comp.py
@@ -116,6 +116,7 @@ def complement_image(input_path: Path, output_path: Path, keep_alpha: bool) -> S
         max_after = (int(xa_arr[0]), int(xa_arr[1]), int(xa_arr[2]))
         mean_after = (float(ava_arr[0]), float(ava_arr[1]), float(ava_arr[2]))
 
+        output_path.parent.mkdir(parents=True, exist_ok=True)
         out_img = Image.fromarray(comp, mode="RGB")
         if alpha is not None:
             out_img.putalpha(alpha)
@@ -150,6 +151,8 @@ def build_output_path(
     if out_file is not None:
         return out_file
     target_dir = dest_dir if dest_dir else src.parent
+    if dest_dir:
+        dest_dir.mkdir(parents=True, exist_ok=True)
     return target_dir / f"{src.stem}{suffix}{src.suffix}"
 
 


### PR DESCRIPTION
## Summary
- ensure the complementary color transformer creates parent directories before saving images
- create derived batch destination directories on demand

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6908be75db888330bdc3d3e2699c0c40