### PR TITLE
Handle ValueError when loading CHIP-8 ROMs

### DIFF
--- a/challenges/Emulation/Chip8/cli.py
+++ b/challenges/Emulation/Chip8/cli.py
@@ -114,8 +114,8 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     try:
         memory.load_rom_file(str(rom_path))
-    except OSError as exc:
-        print(f"Failed to load ROM: {exc}", file=sys.stderr)
+    except (OSError, ValueError) as exc:
+        print(f"Failed to load ROM '{rom_path}': {exc}", file=sys.stderr)
         return 1
 
     cpu.reset()


### PR DESCRIPTION
## Summary
- catch ValueError in the CHIP-8 CLI when loading ROM files
- provide a descriptive error message and keep the non-zero exit code when ROM loading fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908be732c5c8330b8c48b4f9e9aab33