### PR TITLE
Set explicit n_init for KMeans in 5cs script

### DIFF
--- a/challenges/Emulation/5 color scheme/5cs.py
+++ b/challenges/Emulation/5 color scheme/5cs.py
@@ -115,7 +115,9 @@ def extract_colors(pixels: np.ndarray, k: int) -> np.ndarray:
     """
     if k <= 0:
         raise ValueError("num_colors must be > 0")
-    kmeans = KMeans(n_clusters=k, n_init="auto", random_state=42)
+    # Use an explicit integer for ``n_init`` for compatibility with older scikit-learn versions
+    # where the string value "auto" is not supported.
+    kmeans = KMeans(n_clusters=k, n_init=10, random_state=42)
     kmeans.fit(pixels)
     return kmeans.cluster_centers_.astype(np.uint8)
 


### PR DESCRIPTION
## Summary
- replace the 5cs KMeans configuration to use an integer n_init value
- document the reason for avoiding the "auto" string for compatibility with older scikit-learn releases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908be689f54833091d2b629edb660a5