### PR TITLE
Add Haskell yt-dlp CLI and usage documentation

### DIFF
--- a/challenges/Algorithmic/ytmp3/README.md
+++ b/challenges/Algorithmic/ytmp3/README.md
@@ -4,6 +4,8 @@
 Download audio tracks from YouTube (or other yt-dlp supported sites), convert them to a chosen format/quality, and optionally export a JSON summary.
 
 ## Usage
+
+### Python CLI (`cringe.py`)
 - Download a single video as MP3 (default quality):
   ```bash
   python cringe.py https://youtu.be/VIDEOID
@@ -16,6 +18,38 @@ Download audio tracks from YouTube (or other yt-dlp supported sites), convert th
   ```bash
   python cringe.py -F mp3 -q 192 -o downloads/ -i urls.txt --json
   ```
+
+### Haskell CLI (`YTDL.hs`)
+
+1. Ensure tooling dependencies are installed:
+   - `ghc` or another Haskell build toolchain (`cabal-install`/`stack`).
+   - Haskell libraries: `aeson`, `bytestring`, and `process` (all available via `cabal install aeson` or as part of most modern `stack` snapshots).
+   - External executables: `yt-dlp` (preferred) or `youtube-dl`, plus `ffmpeg` on your `PATH`.
+2. Compile the helper once (or run it via `runghc` for quick tests):
+   ```bash
+   cd challenges/Algorithmic/ytmp3
+   ghc -O2 YTDL.hs   # produces ./YTDL
+   ```
+3. Mirror the Python flags from the compiled binary:
+   ```bash
+   ./YTDL https://youtu.be/VIDEOID
+   ./YTDL -f opus -q 128 https://youtu.be/ID1 https://youtu.be/ID2
+   ./YTDL -f mp3 -q 192 -o downloads/ -i urls.txt --json
+   ./YTDL --quiet --json https://youtu.be/ID3
+   ```
+
+Flag parity with `cringe.py`:
+
+| Flag | Description |
+| ---- | ----------- |
+| `-f/--format` | Select the audio container/codec (`mp3`, `m4a`, `opus`, `vorbis`, `wav`, `flac`). |
+| `-q/--quality` | Target audio bitrate (forwarded to ffmpeg via yt-dlp). |
+| `-o/--out-dir` | Destination directory (auto-created when missing). |
+| `-i/--input` | Read additional URLs from a file (blank lines and `#` comments ignored). |
+| `--json` | Emit a JSON summary identical to the Python tool (backend, counts, per-item status). |
+| `--quiet` | Suppress progress logs; errors still appear inside the JSON summary. |
+
+The JSON schema matches `cringe.py`, allowing the existing `download_visualizer.py` and any automation consuming the Python output to ingest Haskell runs without modification.
 
 ### Visualising Batch Runs
 

--- a/challenges/Algorithmic/ytmp3/YTDL.hs
+++ b/challenges/Algorithmic/ytmp3/YTDL.hs
@@ -1,0 +1,230 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+-- | Minimal yt-dlp powered audio downloader in Haskell.
+-- Mirrors the functionality of challenges/Algorithmic/ytmp3/cringe.py.
+module Main (main) where
+
+import Control.Exception (SomeException, try)
+import Control.Monad (foldM, unless, when)
+import Data.Aeson (ToJSON, (.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BL8
+import Data.Char (isSpace, toLower)
+import Data.List (dropWhileEnd, isSuffixOf)
+import GHC.Generics (Generic)
+import System.Console.GetOpt
+import System.Directory (createDirectoryIfMissing, doesFileExist, findExecutable, makeAbsolute)
+import System.Environment (getArgs, getProgName)
+import System.Exit (ExitCode (..), exitFailure, exitSuccess)
+import System.FilePath ((</>))
+import System.IO (hPutStrLn, stderr)
+import System.Process (readProcessWithExitCode)
+
+-- | Command-line options for the downloader.
+data Options = Options
+  { optFormat :: String
+  , optQuality :: String
+  , optOutDir :: FilePath
+  , optInput :: Maybe FilePath
+  , optJSON :: Bool
+  , optQuiet :: Bool
+  }
+
+-- | Defaults mirror the Python script.
+defaultOptions :: Options
+defaultOptions = Options
+  { optFormat = "mp3"
+  , optQuality = "192"
+  , optOutDir = "."
+  , optInput = Nothing
+  , optJSON = False
+  , optQuiet = False
+  }
+
+-- | Supported formats to validate user input.
+validFormats :: [String]
+validFormats = ["mp3", "m4a", "opus", "vorbis", "wav", "flac"]
+
+-- | Representation of a per-URL download result.
+data ItemResult = ItemResult
+  { itemUrl :: String
+  , itemSuccess :: Bool
+  , itemError :: Maybe String
+  }
+  deriving (Generic, Show)
+
+instance ToJSON ItemResult where
+  toJSON (ItemResult url ok errMsg) =
+    Aeson.object
+      [ "url" .= url
+      , "success" .= ok
+      , "error" .= errMsg
+      ]
+
+-- | Summary structure emitted as JSON (compatible with cringe.py).
+data Summary = Summary
+  { sumBackend :: String
+  , sumFormat :: String
+  , sumQuality :: String
+  , sumOutDir :: FilePath
+  , sumTotal :: Int
+  , sumSuccess :: Int
+  , sumFailed :: Int
+  , sumItems :: [ItemResult]
+  }
+  deriving (Generic, Show)
+
+instance ToJSON Summary where
+  toJSON (Summary backend fmt q dir total ok failed items) =
+    Aeson.object
+      [ "backend" .= backend
+      , "format" .= fmt
+      , "quality" .= q
+      , "out_dir" .= dir
+      , "total" .= total
+      , "success" .= ok
+      , "failed" .= failed
+      , "items" .= items
+      ]
+
+-- | Modify options via GetOpt descriptors.
+optionDescriptors :: [OptDescr (Options -> IO Options)]
+optionDescriptors =
+  [ Option ['f', 'F'] ["format"] (ReqArg setFormat "FORMAT")
+      "Output audio format (mp3,m4a,opus,vorbis,wav,flac)"
+  , Option ['q'] ["quality", "bitrate"] (ReqArg setQuality "KBPS")
+      "Audio quality/bitrate target (e.g. 192)"
+  , Option ['o'] ["out-dir"] (ReqArg setOutDir "PATH")
+      "Directory where audio files are written"
+  , Option ['i'] ["input"] (ReqArg setInput "FILE")
+      "File containing URLs (one per line; # comments ignored)"
+  , Option [] ["json"] (NoArg setJSON)
+      "Emit JSON summary to stdout"
+  , Option [] ["quiet"] (NoArg setQuiet)
+      "Suppress progress lines (errors still reported in JSON)"
+  ]
+  where
+    setFormat arg opts = pure opts {optFormat = map toLower arg}
+    setQuality arg opts = pure opts {optQuality = arg}
+    setOutDir arg opts = pure opts {optOutDir = arg}
+    setInput arg opts = pure opts {optInput = Just arg}
+    setJSON opts = pure opts {optJSON = True}
+    setQuiet opts = pure opts {optQuiet = True}
+
+-- | Simple whitespace trimming helper.
+trim :: String -> String
+trim = dropWhile isSpace . dropWhileEnd isSpace
+
+-- | Reads URLs from a file, ignoring blank lines and comments.
+readUrlFile :: FilePath -> IO [String]
+readUrlFile path = do
+  exists <- doesFileExist path
+  unless exists $ dieWith $ "URL file not found: " ++ path
+  contents <- readFile path
+  let urls =
+        [ trimmed
+        | raw <- lines contents
+        , let trimmed = trim raw
+        , not (null trimmed)
+        , not ("#" `isPrefixOf` trimmed)
+        ]
+  pure urls
+  where
+    isPrefixOf prefix str = prefix == take (length prefix) str
+
+-- | Identify the download backend (prefers yt-dlp, fallback to youtube-dl).
+detectBackend :: IO String
+detectBackend = do
+  yt <- findExecutable "yt-dlp"
+  case yt of
+    Just path -> pure path
+    Nothing -> do
+      ydl <- findExecutable "youtube-dl"
+      case ydl of
+        Just path -> pure path
+        Nothing -> dieWith "Neither 'yt-dlp' nor 'youtube-dl' is available in PATH."
+
+-- | Execute yt-dlp/youtube-dl for a single URL and capture success/error state.
+downloadOne :: String -> Options -> FilePath -> String -> IO ItemResult
+downloadOne backend opts outTemplate url = do
+  when (not (optQuiet opts)) $ putStrLn $ "Downloading: " ++ url
+  let baseArgs =
+        [ "-f", "bestaudio/best"
+        , "--extract-audio"
+        , "--audio-format", optFormat opts
+        , "--audio-quality", optQuality opts
+        , "--output", outTemplate
+        , "--no-playlist"
+        , "--no-check-certificate"
+        ]
+      quietArgs =
+        if optQuiet opts then ["--quiet", "--no-progress"] else []
+      args = baseArgs ++ quietArgs ++ [url]
+  result <- try $ readProcessWithExitCode backend args ""
+  case result of
+    Left (err :: SomeException) -> pure $ ItemResult url False (Just (show err))
+    Right (exitCode, _stdoutTxt, stderrTxt) ->
+      case exitCode of
+        ExitSuccess -> pure $ ItemResult url True Nothing
+        ExitFailure _ -> do
+          when (not (optQuiet opts) && not (null (trim stderrTxt))) $
+            hPutStrLn stderr $ "  Failed: " ++ trim stderrTxt
+          let errMsg = if null (trim stderrTxt) then Just "Download failed" else Just (trim stderrTxt)
+          pure $ ItemResult url False errMsg
+
+-- | Utility to abort with a message printed to stderr.
+dieWith :: String -> IO a
+dieWith msg = do
+  hPutStrLn stderr msg
+  exitFailure
+
+-- | Parse command line arguments and run downloads.
+main :: IO ()
+main = do
+  argv <- getArgs
+  progName <- getProgName
+  let (actions, urls, errs) = getOpt Permute optionDescriptors argv
+  unless (null errs) $ do
+    mapM_ (hPutStrLn stderr) errs
+    hPutStrLn stderr $ usageInfo ("Usage: " ++ progName ++ " [OPTIONS] URL [URL ...]") optionDescriptors
+    exitFailure
+  opts <- foldM (\acc action -> action acc) defaultOptions actions
+  let fmt = map toLower (optFormat opts)
+  unless (fmt `elem` validFormats) $
+    dieWith $ "Unsupported format (choose one of: " ++ unwords validFormats ++ ")"
+  let opts' = opts {optFormat = fmt}
+  extraUrls <- case optInput opts' of
+    Nothing -> pure []
+    Just path -> readUrlFile path
+  let allUrls = urls ++ extraUrls
+  when (null allUrls) $ dieWith "Provide at least one URL or --input file"
+  createDirectoryIfMissing True (optOutDir opts')
+  outDirAbs <- makeAbsolute (optOutDir opts')
+  backendPath <- detectBackend
+  let outTemplate = outDirAbs </> "%(title)s.%(ext)s"
+  items <- mapM (downloadOne backendPath opts' outTemplate) allUrls
+  let successCount = length (filter itemSuccess items)
+      totalCount = length items
+      summary =
+        Summary
+          { sumBackend = backendLabel backendPath
+          , sumFormat = optFormat opts'
+          , sumQuality = optQuality opts'
+          , sumOutDir = outDirAbs
+          , sumTotal = totalCount
+          , sumSuccess = successCount
+          , sumFailed = totalCount - successCount
+          , sumItems = items
+          }
+  if optJSON opts'
+    then BL8.putStrLn (Aeson.encode summary)
+    else putStrLn $ "Completed: " ++ show successCount ++ "/" ++ show totalCount ++ " succeeded (backend=" ++ backendLabel backendPath ++ ")"
+  if successCount == totalCount
+    then exitSuccess
+    else exitFailure
+  where
+    backendLabel path
+      | "yt-dlp" `isSuffixOf` path = "yt-dlp"
+      | "youtube-dl" `isSuffixOf` path = "youtube-dl"
+      | otherwise = path
+


### PR DESCRIPTION
## Summary
- add a Haskell-based yt-dlp wrapper that mirrors the Python CLI options and JSON reporting
- resolve absolute output directories while supporting format, bitrate, quiet mode, and URL file inputs
- document Haskell usage steps, dependencies, and JSON compatibility alongside the existing Python workflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6908be302dec8330aaeb0fb22faa7c72