### PR TITLE
Add Haskell Vigenere CLI and document usage

### DIFF
--- a/challenges/Algorithmic/Vigniere Cipher/README.md
+++ b/challenges/Algorithmic/Vigniere Cipher/README.md
@@ -4,6 +4,7 @@
 Encrypt or decrypt alphabetic text using the classical Vigenère cipher, where each plaintext letter is shifted by the alphabetic position of a repeating key.
 
 ## Usage
+### Python CLI
 - Encrypt a message with key `LEMON`:
   ```bash
   python vig.py encrypt LEMON -t "Attack at dawn"
@@ -17,12 +18,28 @@ Encrypt or decrypt alphabetic text using the classical Vigenère cipher, where e
   echo "Hello World" | python vig.py encrypt key --upper
   ```
 
+### Haskell CLI
+- Run directly with `runghc` (or compile with `ghc` first) using the same arguments as the Python script:
+  ```bash
+  runghc Vigenere.hs encrypt LEMON -t "Attack at dawn"
+  ```
+- Toggle uppercase output or switch to JSON metadata just like the Python version:
+  ```bash
+  runghc Vigenere.hs encrypt key --upper --json
+  ```
+- Provide text via files or stdin:
+  ```bash
+  echo "HELLO" | runghc Vigenere.hs decrypt key --out plain.txt
+  ```
+  On systems without `runghc`, compile first with `ghc -O2 Vigenere.hs -o vigenere` and then execute `./vigenere` with the same flags.
+
 ### Visual exploration
 - Render key-specific substitution tables and bar charts with the shared helper:
   ```bash
   python ../Caesar\ Cipher/cipher_visualizer.py --cipher vigenere --key LEMON --text "Attack at dawn" --output-json vigenere.json --output-html vigenere.html
   ```
 - The JSON payload lists mappings for each key position, enabling automated inspections without loading Plotly.
+- The Haskell CLI mirrors the Python script's JSON schema, so either tool can feed directly into the visualizer or downstream automation without modifications.
 
 ## Debugging Tips
 - Sanitized keys must contain alphabetic characters only; keys like `abc123` will be reduced to `abc`.

--- a/challenges/Algorithmic/Vigniere Cipher/Vigenere.hs
+++ b/challenges/Algorithmic/Vigniere Cipher/Vigenere.hs
@@ -1,0 +1,253 @@
+module Main (main) where
+
+import Data.Char (chr, isAlpha, isLetter, isUpper, ord, toLower, toUpper)
+import Data.List (intercalate, isPrefixOf)
+import Data.Maybe (isJust)
+import System.Environment (getArgs, getProgName)
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (hPutStrLn, hSetEncoding, stderr, stdin, stdout, utf8)
+
+-- | Cipher mode (encrypt or decrypt).
+data Mode = ModeEncrypt | ModeDecrypt deriving (Eq, Show)
+
+data Config = Config
+  { cfgMode :: Mode
+  , cfgKey :: String
+  , cfgText :: Maybe String
+  , cfgInFile :: Maybe FilePath
+  , cfgOutFile :: Maybe FilePath
+  , cfgJson :: Bool
+  , cfgUpper :: Bool
+  }
+
+-- | Result of parsing CLI arguments.
+data ParseResult
+  = Parsed Config
+  | ShowHelp
+  | ParseError String
+
+main :: IO ()
+main = do
+  setUtf8
+  args <- getArgs
+  case parseArgs args of
+    ShowHelp -> do
+      prog <- getProgName
+      putStrLn (usage prog)
+      exitSuccess
+    ParseError err -> do
+      hPutStrLn stderr err
+      prog <- getProgName
+      hPutStrLn stderr (usage prog)
+      exitFailure
+    Parsed cfg -> runWith cfg
+
+setUtf8 :: IO ()
+setUtf8 = do
+  hSetEncoding stdout utf8
+  hSetEncoding stderr utf8
+  hSetEncoding stdin utf8
+
+runWith :: Config -> IO ()
+runWith cfg = do
+  case sanitizeKey (cfgKey cfg) of
+    "" -> die "key must contain at least one alphabetic character after sanitization"
+    _ -> pure ()
+  input <- loadInput cfg
+  let result = vigenereCipher (cfgMode cfg) (cfgKey cfg) (cfgUpper cfg) input
+  if cfgJson cfg
+    then emitJson cfg input result
+    else emitOutput cfg result
+
+emitOutput :: Config -> String -> IO ()
+emitOutput cfg result =
+  case cfgOutFile cfg of
+    Just path -> writeFile path result
+    Nothing -> putStrLn result
+
+emitJson :: Config -> String -> String -> IO ()
+emitJson cfg input result = do
+  let sanitized = sanitizeKey (cfgKey cfg)
+      payload =
+        [ jsonPair "mode" (jsonString (modeLabel (cfgMode cfg)))
+        , jsonPair "key_length" (jsonNumber (length sanitized))
+        , jsonPair "input_length" (jsonNumber (length input))
+        , jsonPair "output_length" (jsonNumber (length result))
+        , jsonPair "result" (jsonString result)
+        , jsonPair "upper" (jsonBool (cfgUpper cfg))
+        , jsonPair "source" (jsonString (inputSource cfg))
+        , jsonPair "outfile" (jsonBool (isJust (cfgOutFile cfg)))
+        ]
+      jsonText = buildJson payload
+  case cfgOutFile cfg of
+    Just path -> writeFile path jsonText
+    Nothing -> putStrLn jsonText
+
+inputSource :: Config -> String
+inputSource cfg =
+  case (cfgText cfg, cfgInFile cfg) of
+    (Just _, _) -> "text"
+    (Nothing, Just _) -> "file"
+    _ -> "stdin"
+
+loadInput :: Config -> IO String
+loadInput cfg =
+  case (cfgText cfg, cfgInFile cfg) of
+    (Just txt, Nothing) -> pure txt
+    (Nothing, Just path) -> readFile path
+    (Just _, Just _) -> die "Provide either --text or --in, not both"
+    (Nothing, Nothing) -> getContents
+
+die :: String -> IO a
+die msg = do
+  hPutStrLn stderr msg
+  exitFailure
+
+modeLabel :: Mode -> String
+modeLabel mode =
+  case mode of
+    ModeEncrypt -> "encrypt"
+    ModeDecrypt -> "decrypt"
+
+vigenereCipher :: Mode -> String -> Bool -> String -> String
+vigenereCipher mode key makeUpper text =
+  case sanitizeKey key of
+    "" -> error "sanitizeKey should ensure non-empty keys before cipher"
+    sanitized ->
+      let len = length sanitized
+       in go sanitized len 0 text
+  where
+    decryptMode = mode == ModeDecrypt
+    go _ _ _ [] = []
+    go sanitized len idx (c : cs)
+      | isLetter c =
+          let keyIdx = idx `mod` len
+              shift = ord (sanitized !! keyIdx) - ord 'a'
+              base = if isUpper c then ord 'A' else ord 'a'
+              raw = ord c - base
+              adj = if decryptMode then (raw - shift) else (raw + shift)
+              rotated = chrMod base adj
+              finalChar = if makeUpper then toUpper rotated else rotated
+           in finalChar : go sanitized len (idx + 1) cs
+      | otherwise = c : go sanitized len idx cs
+
+chrMod :: Int -> Int -> Char
+chrMod base value =
+  let m = value `mod` 26
+   in chr (base + m)
+
+sanitizeKey :: String -> String
+sanitizeKey = map toLower . filter isAlpha
+
+buildJson :: [String] -> String
+buildJson pairs =
+  let indent = "  "
+      inner = intercalate (",\n" ++ indent) pairs
+   in "{\n" ++ indent ++ inner ++ "\n}"
+
+jsonPair :: String -> String -> String
+jsonPair key value = jsonString key ++ ": " ++ value
+
+jsonString :: String -> String
+jsonString s = "\"" ++ concatMap escapeChar s ++ "\""
+  where
+    escapeChar '"' = "\\\""
+    escapeChar '\\' = "\\\\"
+    escapeChar '\b' = "\\b"
+    escapeChar '\f' = "\\f"
+    escapeChar '\n' = "\\n"
+    escapeChar '\r' = "\\r"
+    escapeChar '\t' = "\\t"
+    escapeChar c
+      | c < ' ' = unicodeEscape c
+      | otherwise = [c]
+    unicodeEscape c =
+      let code = fromEnum c
+          hex = padLeft 4 '0' (showHex code)
+       in "\\u" ++ hex
+
+jsonNumber :: Int -> String
+jsonNumber = show
+
+jsonBool :: Bool -> String
+jsonBool True = "true"
+jsonBool False = "false"
+
+padLeft :: Int -> Char -> String -> String
+padLeft len ch str = replicate (max 0 (len - length str)) ch ++ str
+
+showHex :: Int -> String
+showHex n
+  | n < 16 = [digits !! n]
+  | otherwise = showHex (n `div` 16) ++ [digits !! (n `mod` 16)]
+  where
+    digits = "0123456789abcdef"
+
+parseArgs :: [String] -> ParseResult
+parseArgs args
+  | "--help" `elem` args || "-h" `elem` args = ShowHelp
+  | otherwise =
+      case args of
+        (modeStr : keyStr : rest) ->
+          case toMode modeStr of
+            Nothing -> ParseError "mode must be 'encrypt' or 'decrypt'"
+            Just mode ->
+              case parseOptions rest defaultConfig {cfgMode = mode, cfgKey = keyStr} of
+                Left err -> ParseError err
+                Right cfg -> Parsed cfg
+        _ -> ParseError "Usage: vigenere MODE KEY [options]"
+
+parseOptions :: [String] -> Config -> Either String Config
+parseOptions [] cfg = validateConfig cfg
+parseOptions (flag : rest) cfg =
+  case flag of
+    "-t" -> grabValue rest $ \val xs -> parseOptions xs cfg {cfgText = Just val}
+    "--text" -> grabValue rest $ \val xs -> parseOptions xs cfg {cfgText = Just val}
+    "--in" -> grabValue rest $ \val xs -> parseOptions xs cfg {cfgInFile = Just val}
+    "--out" -> grabValue rest $ \val xs -> parseOptions xs cfg {cfgOutFile = Just val}
+    "--json" -> parseOptions rest cfg {cfgJson = True}
+    "--upper" -> parseOptions rest cfg {cfgUpper = True}
+    unknown | "-" `isPrefixOf` unknown -> Left ("Unrecognized option: " ++ unknown)
+    value -> Left ("Unexpected positional argument: " ++ value)
+  where
+    grabValue xs cont =
+      case xs of
+        (v : rest') -> cont v rest'
+        [] -> Left ("Missing value for option " ++ flag)
+
+validateConfig :: Config -> Either String Config
+validateConfig cfg
+  | cfgText cfg /= Nothing && cfgInFile cfg /= Nothing =
+      Left "Provide either --text or --in, not both"
+  | otherwise = Right cfg
+
+usage :: String -> String
+usage progName =
+  unlines
+    [ "Usage: " ++ progName ++ " MODE KEY [options]"
+    , "\nOptions:"
+    , "  -t, --text TEXT        Inline plaintext/ciphertext input"
+    , "      --in PATH          Read input from file"
+    , "      --out PATH         Write output to file"
+    , "      --json             Emit JSON metadata"
+    , "      --upper            Force alphabetic output to uppercase"
+    , "  -h, --help            Show this help message"
+    ]
+
+defaultConfig :: Config
+defaultConfig =
+  Config
+    { cfgMode = ModeEncrypt
+    , cfgKey = ""
+    , cfgText = Nothing
+    , cfgInFile = Nothing
+    , cfgOutFile = Nothing
+    , cfgJson = False
+    , cfgUpper = False
+    }
+
+toMode :: String -> Maybe Mode
+toMode str
+  | map toLower str == "encrypt" = Just ModeEncrypt
+  | map toLower str == "decrypt" = Just ModeDecrypt
+  | otherwise = Nothing


### PR DESCRIPTION
## Summary
- implement a standalone Haskell Vigenère cipher CLI mirroring the Python tool
- add JSON reporting, key normalization, and flexible input/output handling in Haskell
- document Haskell usage patterns and note interoperability with the cipher visualizer

## Testing
- ⚠️ `runghc challenges/Algorithmic/Vigniere Cipher/Vigenere.hs --help` *(fails: runghc not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6908be2d180883308295ab5d53be07e5