### PR TITLE
Improve IRC client fallback stdin handling

### DIFF
--- a/tests/practical/irc_client/test_fallback_shutdown.py
+++ b/tests/practical/irc_client/test_fallback_shutdown.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import logging
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+
+
+def load_module() -> ModuleType:
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "challenges"
+        / "Practical"
+        / "IRC Client"
+        / "irc_client.py"
+    )
+    spec = importlib.util.spec_from_file_location("irc_client_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class BlockingStdin:
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._value: str = ""
+
+    def readline(self) -> str:
+        self._event.wait()
+        return self._value
+
+    def release(self, value: str = "") -> None:
+        self._value = value
+        self._event.set()
+
+
+def test_fallback_loop_exits_promptly(monkeypatch):
+    module = load_module()
+    IRCConfig = module.IRCConfig
+    IRCClient = module.IRCClient
+
+    config = IRCConfig(
+        server="example.com",
+        port=6667,
+        nickname="tester",
+        username="tester",
+        realname="Tester",
+        password=None,
+        channels=[],
+    )
+    client = IRCClient(config, logging.getLogger("irc-test"))
+
+    blocking_stdin = BlockingStdin()
+
+    monkeypatch.setattr(module.sys, "stdin", blocking_stdin)
+
+    async def runner() -> None:
+        client._stdin_fallback = True
+        task = asyncio.create_task(client._fallback_input_loop())
+        await asyncio.sleep(0)
+        await client.quit("bye")
+        await asyncio.wait_for(task, timeout=0.5)
+
+    try:
+        asyncio.run(runner())
+    finally:
+        blocking_stdin.release()
+
+    assert client.stop_requested.is_set()


### PR DESCRIPTION
## Summary
- replace the IRC client's fallback stdin handling with a queue-driven background thread so the loop responds immediately to stop events
- guard the fallback loop to exit cleanly on EOF or when stop_requested is set and ensure the background reader shuts down safely
- add a regression test that exercises the fallback path and verifies quit() stops the client promptly

## Testing
- pytest tests/practical

------
https://chatgpt.com/codex/tasks/task_e_6908bdc27d1883308a049a59663610b1