### PR TITLE
Fix fizzbuzz rule selection for empty sequences

### DIFF
--- a/challenges/Algorithmic/FizzBuzz/fizzbuzz.py
+++ b/challenges/Algorithmic/FizzBuzz/fizzbuzz.py
@@ -207,7 +207,10 @@ def run(
 
     This function is import-friendly and can be used in tests.
     """
-    chosen_rules = tuple(rules) if rules else DEFAULT_RULES
+    if rules is None:
+        chosen_rules = DEFAULT_RULES
+    else:
+        chosen_rules = tuple(rules)
     if fmt not in OUTPUT_FORMATTERS:
         raise ValueError(f"Unsupported format: {fmt}")
     stream = fizzbuzz_stream(limit, chosen_rules, include_numbers=include_numbers)

--- a/tests/test_fizzbuzz.py
+++ b/tests/test_fizzbuzz.py
@@ -1,0 +1,6 @@
+from challenges.Algorithmic.FizzBuzz.fizzbuzz import run
+
+
+def test_run_with_empty_rules():
+    result = run(5, rules=())
+    assert result == "1\n2\n3\n4\n5"


### PR DESCRIPTION
## Summary
- ensure `run` preserves explicitly provided empty rule sequences instead of defaulting to the classic rules
- add a regression test verifying `run(limit=5, rules=())` returns the plain number output

## Testing
- pytest tests/test_fizzbuzz.py

------
https://chatgpt.com/codex/tasks/task_e_690999ec37a0833083c7569bf393aec5