### PR TITLE
Fix Gauss-Legendre convergence guard

### DIFF
--- a/challenges/Algorithmic/1000 Digits of Pi/pi.py
+++ b/challenges/Algorithmic/1000 Digits of Pi/pi.py
@@ -168,8 +168,6 @@ def generate_gauss_legendre_convergence(
 
         while True:
             iteration_count += 1
-            a_current = a
-
             a_next = (a + b) / 2
             b_next = (a * b).sqrt()
             t_next = t - p * (a - a_next) ** 2
@@ -189,7 +187,7 @@ def generate_gauss_legendre_convergence(
             if a == previous_a:
                 break
 
-            previous_a = a_current
+            previous_a = a
 
             if iteration_count > 50:
                 logging.warning(

--- a/tests/algorithmic/test_pi_visualizer.py
+++ b/tests/algorithmic/test_pi_visualizer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -91,3 +92,18 @@ def test_get_convergence_data_variants(algorithm: str, kwargs: dict[str, int]):
         assert isinstance(step.iteration, int)
         assert step.digits >= 0
         assert step.elapsed >= 0
+
+
+def test_gauss_legendre_converges_without_warning(caplog):
+    module = _load_module(
+        "gauss_legendre_module_test",
+        ROOT / "challenges/Algorithmic/1000 Digits of Pi/pi.py",
+    )
+
+    caplog.set_level(logging.WARNING)
+
+    steps = list(module.generate_gauss_legendre_convergence(5))
+    assert steps[-1].iteration < 50
+    assert not any(
+        "did not converge" in record.getMessage() for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- compare the Gauss-Legendre iteration against the immediately preceding `a` value to decide when to stop iterating
- add a regression test that ensures the generator converges well before the 50-iteration safeguard without emitting warnings

## Testing
- pytest tests/algorithmic/test_pi_visualizer.py

------
https://chatgpt.com/codex/tasks/task_e_690999f7741883308a21853a6ce514ef