### PR TITLE
Preserve decimal context during pi computation

### DIFF
--- a/challenges/Algorithmic/Digits of Pi/DigitPi.py
+++ b/challenges/Algorithmic/Digits of Pi/DigitPi.py
@@ -223,9 +223,14 @@ def compute_pi(
     else:
         final_precision = estimated_digits
 
-    # Apply final precision
-    decimal.getcontext().prec = final_precision
-    final_pi = +pi_result  # The + operator applies current context precision
+    # Apply final precision while preserving the caller's context precision
+    context = decimal.getcontext()
+    previous_precision = context.prec
+    context.prec = final_precision
+    try:
+        final_pi = +pi_result  # The + operator applies current context precision
+    finally:
+        context.prec = previous_precision
 
     logger.info(f"Pi computed to {final_precision} decimal places")
     return final_pi

--- a/tests/algorithmic/test_pi_visualizer.py
+++ b/tests/algorithmic/test_pi_visualizer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import decimal
 import importlib.util
 import json
 from pathlib import Path
@@ -71,6 +72,22 @@ def test_visualizer_summary_and_export(tmp_path: Path):
     assert payload["algorithm"] == "chudnovsky"
     assert payload["steps"]
     assert payload["steps"][0]["iteration"] == 0
+
+
+def test_compute_pi_restores_context_precision():
+    module = _load_module(
+        "digitpi_module_context", ROOT / "challenges/Algorithmic/Digits of Pi/DigitPi.py"
+    )
+
+    context = decimal.getcontext()
+    original_precision = context.prec
+    context.prec = original_precision + 5
+
+    try:
+        module.compute_pi(1)
+        assert context.prec == original_precision + 5
+    finally:
+        context.prec = original_precision
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- preserve the caller's decimal context precision when finalizing the computed value of π
- add a regression test to ensure compute_pi leaves the decimal precision unchanged

## Testing
- pytest tests/algorithmic/test_pi_visualizer.py

------
https://chatgpt.com/codex/tasks/task_e_690999fdbefc8330a3f2e1c6fd70cd2a