### PR TITLE
Preserve query strings in crawler URL normalization

### DIFF
--- a/challenges/Algorithmic/Web Page Crawler/wpc.py
+++ b/challenges/Algorithmic/Web Page Crawler/wpc.py
@@ -150,7 +150,7 @@ class WebCrawler:
                 continue
             absolute = urljoin(base_url, href_val)
             parsed = urlparse(absolute)
-            clean = parsed._replace(fragment="", params="", query="").geturl()
+            clean = parsed._replace(fragment="").geturl()
             if self._accept_link(clean):
                 yield clean
 

--- a/tests/algorithmic/test_web_page_crawler.py
+++ b/tests/algorithmic/test_web_page_crawler.py
@@ -1,0 +1,33 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_ = pytest.importorskip("bs4")
+from bs4 import BeautifulSoup  # type: ignore  # noqa: E402
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "challenges"
+    / "Algorithmic"
+    / "Web Page Crawler"
+    / "wpc.py"
+)
+
+spec = importlib.util.spec_from_file_location("web_page_crawler", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+def test_extract_links_preserves_query_and_params():
+    cfg = module.CrawlerConfig(start_url="https://example.com")
+    crawler = module.WebCrawler(cfg)
+    html = '<a href="/blog;param?page=2#comments">Read</a>'
+    soup = BeautifulSoup(html, "html.parser")
+
+    links = list(crawler.extract_links(soup, "https://example.com/articles"))
+
+    assert links == ["https://example.com/blog;param?page=2"]


### PR DESCRIPTION
## Summary
- retain query strings and parameters when normalizing links in the web page crawler
- add a regression test to ensure extracted links keep their query components

## Testing
- pytest tests/algorithmic/test_web_page_crawler.py

------
https://chatgpt.com/codex/tasks/task_e_69099a01f5a4833085f079c1c9322d9b