### PR TITLE
Validate affine CLI key b range

### DIFF
--- a/challenges/Algorithmic/Rumkin Ciphers/affine.py
+++ b/challenges/Algorithmic/Rumkin Ciphers/affine.py
@@ -103,6 +103,8 @@ class CLIConfig:
             raise ValueError("-a and -b keys required unless --bruteforce used")
         if self.a not in VALID_A_VALUES:
             raise ValueError(f"Key a must be in {VALID_A_VALUES}")
+        if not (0 <= self.b < ALPHABET_SIZE):
+            raise ValueError(f"Key b must satisfy 0 <= b < {ALPHABET_SIZE}")
         if self.mode not in {"encrypt", "decrypt"}:
             raise ValueError("mode must be encrypt or decrypt")
 

--- a/tests/algorithmic/test_affine_cli.py
+++ b/tests/algorithmic/test_affine_cli.py
@@ -1,0 +1,39 @@
+"""Tests for the Rumkin affine cipher CLI helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+AFFINE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "challenges"
+    / "Algorithmic"
+    / "Rumkin Ciphers"
+)
+if str(AFFINE_DIR) not in sys.path:
+    sys.path.insert(0, str(AFFINE_DIR))
+
+import affine  # type: ignore  # noqa: E402
+
+
+@pytest.mark.parametrize("bad_b", [-1, 26, 99])
+def test_cli_rejects_out_of_range_key_b(bad_b: int, capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = affine.main(
+        [
+            "--mode",
+            "encrypt",
+            "-a",
+            "5",
+            "-b",
+            str(bad_b),
+            "--text",
+            "abc",
+        ]
+    )
+    err = capsys.readouterr().err
+    assert exit_code == 1
+    assert "Key b must satisfy 0 <= b < 26" in err


### PR DESCRIPTION
## Summary
- enforce the affine CLI's b parameter to stay within the alphabet range during validation
- add regression tests covering CLI rejection of out-of-range b values

## Testing
- pytest tests/algorithmic/test_affine_cli.py


------
https://chatgpt.com/codex/tasks/task_e_69099a14199083308d165ba80c1d08a1