### PR TITLE
Handle undefined neighbors in Dijkstra's relaxation

### DIFF
--- a/challenges/Algorithmic/Djikstra/dijkstra.py
+++ b/challenges/Algorithmic/Djikstra/dijkstra.py
@@ -277,6 +277,16 @@ def dijkstra(
 
         # Explore neighbors of the current node
         for neighbor, weight in graph[current_node].items():
+            # Skip neighbors that are not defined in the graph/distances
+            if neighbor not in graph or neighbor not in distances:
+                if config.enable_logging:
+                    logger.warning(
+                        "Skipping undefined neighbor '%s' referenced from '%s'",
+                        neighbor,
+                        current_node,
+                    )
+                continue
+
             # Skip already visited neighbors
             if neighbor in visited_nodes:
                 continue

--- a/challenges/Algorithmic/Djikstra/test_dijkstra.py
+++ b/challenges/Algorithmic/Djikstra/test_dijkstra.py
@@ -78,6 +78,21 @@ class TestDijkstraAlgorithm(unittest.TestCase):
 
         self.assertEqual(distances, expected)
 
+    def test_edges_to_undefined_nodes_are_skipped(self):
+        """Ensure edges referencing undefined nodes are ignored without crashing."""
+        graph = {
+            "A": {"B": 1, "Z": 5},
+            "B": {},
+        }
+
+        config = DijkstraConfiguration(enable_logging=False, validate_graph=False)
+
+        distances = dijkstra(graph, "A", config=config)
+
+        self.assertEqual(distances["A"], 0)
+        self.assertEqual(distances["B"], 1)
+        self.assertNotIn("Z", distances)
+
     def test_single_node_graph(self):
         """Test graph with single node."""
         single_graph = {"A": {}}


### PR DESCRIPTION
## Summary
- skip undefined neighbors before relaxing edges in Dijkstra's algorithm
- log a warning when an adjacency references an undefined node
- add a regression test covering an adjacency entry pointing to an undefined node

## Testing
- pytest challenges/Algorithmic/Djikstra/test_dijkstra.py

------
https://chatgpt.com/codex/tasks/task_e_69099a135f8c833084b3c40930cc4017