### PR TITLE
Handle invalid UTF-8 input in Rumkin cipher CLIs

### DIFF
--- a/challenges/Algorithmic/ROT 13/rot13.py
+++ b/challenges/Algorithmic/ROT 13/rot13.py
@@ -86,7 +86,7 @@ def resolve_input(cfg: CLIConfig) -> str:
         try:
             with open(cfg.file, "r", encoding="utf-8") as f:
                 return f.read()
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             raise ValueError(f"Failed to read file: {e}")
     if cfg.stdin:
         return sys.stdin.read()

--- a/challenges/Algorithmic/ROT 13/test_rot13.py
+++ b/challenges/Algorithmic/ROT 13/test_rot13.py
@@ -28,6 +28,17 @@ class TestROT13(unittest.TestCase):
             rot13.main(["--file", src])  # prints, but we only ensure no error
             self.assertEqual(rot13.rot13("abcXYZ"), "nopKLM")
 
+    def test_invalid_utf8_file(self):
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(b"\xff\xfe\xff")
+            tmp_path = tmp.name
+        try:
+            cfg = rot13.CLIConfig(file=tmp_path)
+            with self.assertRaises(ValueError):
+                rot13.resolve_input(cfg)
+        finally:
+            os.remove(tmp_path)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/challenges/Algorithmic/Rumkin Ciphers/affine.py
+++ b/challenges/Algorithmic/Rumkin Ciphers/affine.py
@@ -141,7 +141,7 @@ def resolve_input(cfg: CLIConfig) -> str:
         try:
             with open(cfg.file, "r", encoding="utf-8") as f:
                 return f.read()
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             raise ValueError(f"File read error: {e}")
     if cfg.stdin:
         return sys.stdin.read()

--- a/challenges/Algorithmic/Rumkin Ciphers/atbash.py
+++ b/challenges/Algorithmic/Rumkin Ciphers/atbash.py
@@ -78,7 +78,7 @@ def resolve_input(cfg: CLIConfig) -> str:
         try:
             with open(cfg.file, "r", encoding="utf-8") as f:
                 return f.read()
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             raise ValueError(f"Failed to read file: {e}")
     if cfg.stdin:
         return sys.stdin.read()


### PR DESCRIPTION
## Summary
- raise a ValueError when decoding text files fails in the ROT13, Atbash, and Affine CLIs
- add a regression test covering invalid UTF-8 input for the ROT13 helper

## Testing
- pytest "challenges/Algorithmic/ROT 13/test_rot13.py"


------
https://chatgpt.com/codex/tasks/task_e_69099a1277d483309398a3510dc6f30d