### PR TITLE
Ensure interactive encoding selection is applied

### DIFF
--- a/challenges/Algorithmic/basic text encoding/txtToHexAndBin.py
+++ b/challenges/Algorithmic/basic text encoding/txtToHexAndBin.py
@@ -264,6 +264,8 @@ def interactive_mode() -> None:
     print("=" * 60)
     print()
 
+    current_encoding = "utf-8"
+
     while True:
         try:
             print("Available operations:")
@@ -271,7 +273,7 @@ def interactive_mode() -> None:
             print("2. Text to Binary")
             print("3. Hexadecimal to Text")
             print("4. Binary to Text")
-            print("5. Change encoding (current: utf-8)")
+            print(f"5. Change encoding (current: {current_encoding})")
             print("6. Exit")
             print()
 
@@ -299,16 +301,16 @@ def interactive_mode() -> None:
 
                 try:
                     if choice == "1":
-                        result = text_to_hex(text_input)
+                        result = text_to_hex(text_input, encoding=current_encoding)
                         print(f"\nHexadecimal:\n{format_output(result)}")
                     elif choice == "2":
-                        result = text_to_bin(text_input)
+                        result = text_to_bin(text_input, encoding=current_encoding)
                         print(f"\nBinary:\n{format_output(result)}")
                     elif choice == "3":
-                        result = hex_to_text(text_input)
+                        result = hex_to_text(text_input, encoding=current_encoding)
                         print(f"\nDecoded text: {result}")
                     elif choice == "4":
-                        result = bin_to_text(text_input)
+                        result = bin_to_text(text_input, encoding=current_encoding)
                         print(f"\nDecoded text: {result}")
 
                 except (ValueError, TypeError, UnicodeError) as e:

--- a/tests/algorithmic/test_basic_text_encoding.py
+++ b/tests/algorithmic/test_basic_text_encoding.py
@@ -68,3 +68,18 @@ def test_invalid_hex_chunk_alignment():
 def test_text_to_base_requires_string():
     with pytest.raises(TypeError):
         module.text_to_hex(123)  # type: ignore[arg-type]
+
+
+def test_interactive_mode_updates_current_encoding(monkeypatch, capsys):
+    inputs = iter(["5", "ascii", "1", "é", "6"])
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+
+    module.interactive_mode()
+
+    captured = capsys.readouterr()
+
+    assert "Change encoding (current: utf-8)" in captured.out
+    assert "Encoding changed to: ascii" in captured.out
+    assert "Change encoding (current: ascii)" in captured.out
+    assert "'ascii' codec can't encode" in captured.out


### PR DESCRIPTION
## Summary
- track the interactive mode's current encoding and include it in prompts
- use the selected encoding for conversions during the interactive session
- add coverage to confirm the menu updates and the encoding is honoured

## Testing
- pytest tests/algorithmic/test_basic_text_encoding.py

------
https://chatgpt.com/codex/tasks/task_e_69099a102c4c8330bcb59a7e206e88a6