### PR TITLE
Track drawn cell counts in Sierpinski triangle generator

### DIFF
--- a/challenges/Algorithmic/Sierpinski/test_triangle.py
+++ b/challenges/Algorithmic/Sierpinski/test_triangle.py
@@ -1,13 +1,18 @@
+import json
+
+import pytest
+
 from triangle import generate_sierpinski_lines, main as tri_main
 
 
 def test_basic_generation():
-    lines = generate_sierpinski_lines(4, "*")
+    lines, drawn = generate_sierpinski_lines(4, "*")
     assert len(lines) == 4
     # Top line should start with no leading spaces
     assert lines[0].startswith("")
     # Last line should contain exactly one symbol (apex row widens upward in our orientation)
     assert "*" in lines[0]
+    assert drawn == sum(line.count("*") for line in lines)
 
 
 def test_invalid_size():
@@ -16,11 +21,25 @@ def test_invalid_size():
     assert rc == 1
 
 
-def test_json_output():
+def test_json_output(capsys):
     rc = tri_main(["--size", "8", "--json"])
     assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["non_space_chars"] == pytest.approx(
+        payload["density"] * (8 * 8)
+    )
 
 
 def test_custom_char():
-    lines = generate_sierpinski_lines(4, "#")
+    lines, drawn = generate_sierpinski_lines(4, "#")
     assert any("#" in ln for ln in lines)
+    assert drawn == sum(line.count("#") for line in lines)
+
+
+def test_space_character_counts_drawn_cells(capsys):
+    rc = tri_main(["--size", "4", "--json", "--char", " "])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["non_space_chars"] == 5
+    assert payload["density"] == payload["non_space_chars"] / (4 * 4)

--- a/challenges/Algorithmic/Sierpinski/triangle.py
+++ b/challenges/Algorithmic/Sierpinski/triangle.py
@@ -27,7 +27,7 @@ import json
 import math
 import sys
 from dataclasses import dataclass
-from typing import Iterable, List, Optional, Sequence
+from typing import List, Optional, Sequence, Tuple
 
 
 @dataclass(slots=True)
@@ -50,13 +50,14 @@ class TriangleConfig:
         return (self.size & (self.size - 1)) == 0
 
 
-def generate_sierpinski_lines(size: int, char: str = "*") -> List[str]:
+def generate_sierpinski_lines(size: int, char: str = "*") -> Tuple[List[str], int]:
     """Generate lines for a Sierpinski triangle of given size.
 
-    Returns a list of strings (each line without trailing spaces) suitable
-    for printing or further processing.
+    Returns a tuple of the generated lines (without trailing spaces) and the
+    number of positions where the drawing character was placed.
     """
     lines: List[str] = []
+    drawn_count = 0
     for y in range(size):
         calc_y = size - 1 - y  # invert for upright orientation
         line_chars: List[str] = []
@@ -64,16 +65,18 @@ def generate_sierpinski_lines(size: int, char: str = "*") -> List[str]:
         line_chars.append(" " * y)
         for x in range(size - y):
             if (x & calc_y) == 0:
+                drawn_count += 1
                 line_chars.append(char)
                 line_chars.append(" ")  # spacing for visual proportion
             else:
                 line_chars.append("  ")
         lines.append("".join(line_chars).rstrip())
-    return lines
+    return lines, drawn_count
 
 
 def generate_sierpinski(size: int, char: str = "*") -> str:
-    return "\n".join(generate_sierpinski_lines(size, char))
+    lines, _ = generate_sierpinski_lines(size, char)
+    return "\n".join(lines)
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
@@ -104,11 +107,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    lines = generate_sierpinski_lines(cfg.size, cfg.char)
+    lines, drawn_count = generate_sierpinski_lines(cfg.size, cfg.char)
     output_text = "\n".join(lines)
 
     if cfg.json_output:
-        total_cells = sum(len(line.replace(" ", "")) for line in lines)
+        total_cells = drawn_count
         payload = {
             "size": cfg.size,
             "char": cfg.char,


### PR DESCRIPTION
## Summary
- count drawn positions while building Sierpinski triangle lines and return the tally
- use the drawn count when producing JSON metadata so density works even for space characters
- extend tests to validate drawn counts and cover a space-filled triangle

## Testing
- pytest challenges/Algorithmic/Sierpinski/test_triangle.py

------
https://chatgpt.com/codex/tasks/task_e_69099a0ed38c8330aca1dca7bc822a00