### PR TITLE
Ensure encoding visualizer saves to nested directories

### DIFF
--- a/challenges/Algorithmic/basic text encoding/encoding_visualizer.py
+++ b/challenges/Algorithmic/basic text encoding/encoding_visualizer.py
@@ -214,6 +214,8 @@ def create_visualizations(
     plt.tight_layout()
 
     if save_path is not None:
+        save_path = Path(save_path)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
         fig.savefig(save_path, dpi=300)
     if show:
         plt.show()

--- a/tests/algorithmic/test_encoding_visualizer.py
+++ b/tests/algorithmic/test_encoding_visualizer.py
@@ -63,3 +63,15 @@ def test_utf16_visualization_metadata():
 
     ascii_differences = data["comparisons"]["differences"]
     assert len(ascii_differences) == max(len(data["byte_values"]), 2)
+
+
+def test_create_visualizations_nested_save_path(tmp_path):
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg", force=True)
+
+    data = visualizer.generate_visualization_data("Hello", encoding="utf-8")
+    save_path = tmp_path / "nested" / "plots" / "encoding.png"
+
+    visualizer.create_visualizations(data, show=False, save_path=save_path)
+
+    assert save_path.exists()


### PR DESCRIPTION
## Summary
- create parent directories when the encoding visualizer saves figures
- add a regression test that saves to a nested output path when matplotlib is available

## Testing
- pytest tests/algorithmic/test_encoding_visualizer.py

------
https://chatgpt.com/codex/tasks/task_e_69099a0e0818833093d1b0a2a31c8edb