### PR TITLE
Handle invalid image data in image converters

### DIFF
--- a/challenges/Practical/Image Converter/tests/test_convert.py
+++ b/challenges/Practical/Image Converter/tests/test_convert.py
@@ -111,3 +111,15 @@ def test_batch_convert_file_like(tmp_path: Path) -> None:
     assert output_path.exists()
     with Image.open(output_path) as converted:
         assert converted.format == "JPEG"
+
+
+def test_convert_image_invalid_bytes(tmp_path: Path) -> None:
+    bad_source = io.BytesIO(b"not an image")
+    bad_source.name = "broken.png"
+
+    with pytest.raises(MODULE.ImageOpenError, match="Failed to open image 'broken.png'"):
+        MODULE.convert_image(
+            bad_source,
+            target_format="png",
+            output_path=tmp_path / "output.png",
+        )

--- a/tests/test_img_to_ascii_convert.py
+++ b/tests/test_img_to_ascii_convert.py
@@ -1,0 +1,25 @@
+"""Tests for the ImgToASCII converter CLI utilities."""
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "challenges/Practical/ImgToASCII/convert.py"
+MODULE_NAME = "img_to_ascii_convert"
+SPEC = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[MODULE_NAME] = MODULE
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)  # type: ignore[attr-defined]
+
+
+def test_convert_invalid_image_file_like(tmp_path: Path) -> None:
+    cfg = MODULE.Config(input_path=tmp_path / "placeholder.png", output_path=None)
+    bad_buffer = io.BytesIO(b"this is not an image")
+    bad_buffer.name = "bad.png"
+
+    with pytest.raises(MODULE.ImageOpenError, match="Failed to open image 'bad.png'"):
+        MODULE.convert(cfg, image_source=bad_buffer)


### PR DESCRIPTION
## Summary
- raise a dedicated ImageOpenError when ImgToASCII fails to open input images and surface the message in the CLI
- wrap Image Converter image loading with ImageOpenError to provide friendlier failures
- add regression tests that cover invalid in-memory image data for both converters

## Testing
- pytest tests/test_img_to_ascii_convert.py challenges/Practical/Image\ Converter/tests/test_convert.py

------
https://chatgpt.com/codex/tasks/task_e_69099a0c40f88330a421006d1442d911