### PR TITLE
Ensure dummy MBR creation creates parent directories

### DIFF
--- a/challenges/Algorithmic/MBR/mbr.py
+++ b/challenges/Algorithmic/MBR/mbr.py
@@ -260,6 +260,10 @@ def create_dummy_mbr_file(filepath: str, *, overwrite: bool = False) -> None:
         raise FileExistsError(
             f"File '{filepath}' already exists. Pass --force to overwrite."
         )
+
+    directory = os.path.dirname(filepath)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
     mbr = bytearray(MBR_SIZE)
 
     # Helper to build a partition entry; CHS fields left zero for simplicity.

--- a/challenges/Algorithmic/MBR/test_mbr.py
+++ b/challenges/Algorithmic/MBR/test_mbr.py
@@ -46,6 +46,12 @@ class TestMBRParser(unittest.TestCase):
             self.assertEqual(2, len(data["partitions"]))
             self.assertEqual("0x0c", data["partitions"][0]["type_code"])
 
+    def test_creates_parent_directories(self):
+        with tempfile.TemporaryDirectory() as td:
+            nested_path = os.path.join(td, "nested", "dir", "dummy.bin")
+            mbr.create_dummy_mbr_file(nested_path, overwrite=True)
+            self.assertTrue(os.path.isfile(nested_path))
+
     def test_invalid_size_raises(self):
         with self.assertRaises(ValueError):
             mbr.parse_mbr(b"not512")


### PR DESCRIPTION
## Summary
- ensure `create_dummy_mbr_file` creates parent directories before writing the dummy image
- add a regression test that writes a dummy MBR to a nested path

## Testing
- pytest challenges/Algorithmic/MBR/test_mbr.py

------
https://chatgpt.com/codex/tasks/task_e_69099a09c1a88330a998c9ad9717caa7