### PR TITLE
Handle even-size Ulam spiral origin and add tests

### DIFF
--- a/challenges/Algorithmic/Ulam Spiral/README.md
+++ b/challenges/Algorithmic/Ulam Spiral/README.md
@@ -42,7 +42,7 @@ Plot prime numbers on an integer lattice arranged in a spiral, revealing diagona
   ```
 
 ## Debugging Tips
-- Odd sizes (101, 201, …) keep the center aligned; even sizes shift the origin—use small sizes like 7 or 9 to verify orientation by hand.
+- Odd sizes (101, 201, …) keep the center aligned; even sizes offset the start to `size//2 - 1` so the first steps remain inside the grid—use small sizes like 4 or 6 to verify orientation by hand.
 - Compare the prime sieve output against a trusted library (e.g., `sympy.isprime`) when adjusting algorithms.
 - If matplotlib is unavailable, the script will skip rendering; install `matplotlib` or pass `--no-show` to silence warnings.
 

--- a/challenges/Algorithmic/Ulam Spiral/ulam.py
+++ b/challenges/Algorithmic/Ulam Spiral/ulam.py
@@ -19,6 +19,9 @@ Notes:
     (spiral arms: step lengths repeating twice and incrementing: 1,1,2,2,3,3,...)
   * Primes trace striking diagonal and radial patterns, hinting at underlying
     structure in their distribution.
+  * For even ``size`` values the starting coordinate is nudged inward to
+    ``size//2 - 1`` so the spiral begins inside the central 2×2 block rather
+    than stepping out of bounds immediately.
 """
 
 from __future__ import annotations
@@ -73,8 +76,11 @@ def generate_ulam_spiral(size: int) -> np.ndarray:
 
     grid = np.zeros((size, size), dtype=np.uint8)
 
-    # Start at center (for even sizes this is the lower-left of the central 2x2)
-    x = y = size // 2
+    # Start at the center; even sizes offset into the central 2x2 block
+    center = size // 2
+    if size % 2 == 0:
+        center -= 1
+    x = y = center
     # Spiral parameters
     directions: List[Tuple[int, int]] = [(1, 0), (0, -1), (-1, 0), (0, 1)]  # R, U, L, D
     dir_index = 0

--- a/tests/algorithmic/test_ulam_spiral.py
+++ b/tests/algorithmic/test_ulam_spiral.py
@@ -1,0 +1,41 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "challenges"
+    / "Algorithmic"
+    / "Ulam Spiral"
+    / "ulam.py"
+)
+
+spec = importlib.util.spec_from_file_location("ulam", MODULE_PATH)
+ulam = importlib.util.module_from_spec(spec)
+sys.modules.setdefault(spec.name, ulam)
+spec.loader.exec_module(ulam)  # type: ignore[attr-defined]
+
+
+def test_even_size_two_marks_single_prime():
+    grid = ulam.generate_ulam_spiral(2)
+
+    expected = np.array([[0, 1], [0, 0]], dtype=np.uint8)
+    assert np.array_equal(grid, expected)
+
+
+def test_even_size_four_marks_primes_within_bounds():
+    grid = ulam.generate_ulam_spiral(4)
+
+    expected = np.array(
+        [
+            [1, 0, 1, 0],
+            [0, 0, 1, 1],
+            [1, 0, 0, 0],
+            [0, 0, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+    assert np.array_equal(grid, expected)


### PR DESCRIPTION
## Summary
- adjust the Ulam spiral origin for even sizes so the walk starts inside the grid
- document the even-size offset behaviour in the challenge README
- add regression tests covering size 2 and 4 spirals

## Testing
- pytest tests/algorithmic/test_ulam_spiral.py

------
https://chatgpt.com/codex/tasks/task_e_69099a09358483309aaea8053eb55172