### PR TITLE
Handle math domain errors in unary RPN operations

### DIFF
--- a/challenges/Algorithmic/RPN Calculator/postifx_evaluator.py
+++ b/challenges/Algorithmic/RPN Calculator/postifx_evaluator.py
@@ -123,12 +123,14 @@ def evaluate_rpn(
                     raise RPNError(f"Unary operator '{token}' requires one operand")
                 x = stack.pop()
                 func = unary_funcs[token]
-                if token in {"sin", "cos", "tan"}:
-                    x = apply_trig(x, lambda z: z)  # convert degrees if needed
-                    # after conversion apply original function
-                    stack.append(func(x))
-                else:
-                    stack.append(func(x))
+                try:
+                    if token in {"sin", "cos", "tan"}:
+                        result = apply_trig(x, func)
+                    else:
+                        result = func(x)
+                except (ValueError, OverflowError) as exc:
+                    raise RPNError(f"Error evaluating {token}: {exc}") from exc
+                stack.append(result)
             # binary op
             elif token in bin_ops:
                 if len(stack) < 2:

--- a/challenges/Algorithmic/RPN Calculator/test_rpn.py
+++ b/challenges/Algorithmic/RPN Calculator/test_rpn.py
@@ -39,6 +39,14 @@ class TestRPNEvaluator(unittest.TestCase):
         with self.assertRaises(rpn.RPNError):
             self.eval("3 0 /")
 
+    def test_error_sqrt_negative(self):
+        with self.assertRaises(rpn.RPNError):
+            self.eval("-1 sqrt")
+
+    def test_error_log_zero(self):
+        with self.assertRaises(rpn.RPNError):
+            self.eval("0 log")
+
     def test_malformed(self):
         with self.assertRaises(rpn.RPNError):
             self.eval("1 2 + 3")


### PR DESCRIPTION
## Summary
- wrap unary function execution in error handling that translates math domain and overflow issues into `RPNError`
- add regression tests covering `sqrt(-1)` and `log(0)` inputs

## Testing
- pytest "challenges/Algorithmic/RPN Calculator/test_rpn.py"


------
https://chatgpt.com/codex/tasks/task_e_69099a07a0fc83309696c9ad5c7c6dac