### PR TITLE
Improve CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: CI
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
 on:
   push:
     branches: [main, master]
@@ -20,12 +27,14 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: |
+            requirements-ci.txt
+            pyproject.toml
 
-      - name: Install dependencies
+      - name: Install lint dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-ci.txt
           python -m pip install -e .
 
       - name: Ruff lint
@@ -46,13 +55,15 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: |
+            requirements-ci.txt
+            pyproject.toml
 
-      - name: Install dependencies
+      - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-ci.txt
           python -m pip install -e .
 
       - name: Run pytest
-        run: pytest
+        run: pytest --durations=10

--- a/.github/workflows/requirements-sync.yml
+++ b/.github/workflows/requirements-sync.yml
@@ -1,5 +1,15 @@
 name: Ensure requirements.txt matches extras
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
 on:
   pull_request:
   push:
@@ -10,10 +20,16 @@ jobs:
   sync-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
       - name: Verify requirements sync
         run: python tools/sync_requirements.py --check


### PR DESCRIPTION
## Summary
- add concurrency controls and pip version check suppression to CI workflows
- switch CI jobs to the lightweight requirements-ci.txt set and reuse dependency caching
- extend pytest invocation with duration reporting and upgrade pip before syncing requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c5b749fc48330ae7b61843940e03a